### PR TITLE
test(getAutocompleteSource): Add tests for source

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -44,19 +44,17 @@ class DocSearch {
     this.algoliaOptions = algoliaOptions;
     this.autocompleteOptions = autocompleteOptions;
 
-    this.apiKey = apiKey;
-    this.indexName = indexName;
-    this.input = this.getInputFromSelector(inputSelector);
-    this.algoliaOptions = algoliaOptions;
-    this.autocompleteOptions = autocompleteOptions;
-
     this.client = algoliasearch('BH4D9OD16A', this.apiKey);
     this.client.addAlgoliaAgent('docsearch.js ' + version);
     this.autocomplete = autocomplete(this.input, autocompleteOptions, [{
       source: this.getAutocompleteSource(),
       templates: {
         suggestion: this.getSuggestionTemplate(),
-        footer: '<div class="ads-footer">Search by <a class="ads-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a></div>'
+        footer: `
+          <div class="ads-footer">
+            Search by <a class="ads-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a>
+          </div>
+        `
       }
     }]);
     this.autocomplete.on('autocomplete:selected', this.handleSelected);
@@ -74,6 +72,8 @@ class DocSearch {
     }
 
     if (!DocSearch.getInputFromSelector(args.inputSelector)) {
+      throw new Error(`Error: No input element in the page matches ${args.inputSelector}`);
+    }
   }
 
   /**

--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -44,6 +44,12 @@ class DocSearch {
     this.algoliaOptions = algoliaOptions;
     this.autocompleteOptions = autocompleteOptions;
 
+    this.apiKey = apiKey;
+    this.indexName = indexName;
+    this.input = this.getInputFromSelector(inputSelector);
+    this.algoliaOptions = algoliaOptions;
+    this.autocompleteOptions = autocompleteOptions;
+
     this.client = algoliasearch('BH4D9OD16A', this.apiKey);
     this.client.addAlgoliaAgent('docsearch.js ' + version);
     this.autocomplete = autocomplete(this.input, autocompleteOptions, [{
@@ -68,8 +74,6 @@ class DocSearch {
     }
 
     if (!DocSearch.getInputFromSelector(args.inputSelector)) {
-      throw new Error(`Error: No input element in the page matches ${args.inputSelector}`);
-    }
   }
 
   /**

--- a/test/DocSearch-test.js
+++ b/test/DocSearch-test.js
@@ -227,6 +227,17 @@ describe('DocSearch', () => {
       // Given
       let selector = '.i-do-not-exist > at #all';
 
+      DocSearch.prototype.checkArguments = checkArguments;
+      DocSearch.prototype.getInputFromSelector = getInputFromSelector;
+
+      DocSearch.__Rewire__('algoliasearch', AlgoliaSearch);
+      DocSearch.__Rewire__('autocomplete', AutoComplete);
+    });
+
+    it('should call checkArguments', () => {
+      // Given
+      let options = defaultOptions;
+
       // When
       let actual = getInputFromSelector(selector);
 


### PR DESCRIPTION
I had to change some methods to static to be able to tests them
without instantiating a new DocSearch. I also used better `restore`
methods of sinon.js.

I did not manage to correctly test the promise returned by the method
returned by getAutocompleteSource. I would have like to test that when
resolved it correctly call reformatHits on the data as well as call
the callback on the reformated hits but got confused in
spying/stubbing/mocking the promise.