### PR TITLE
test(formatHits): Add tests for formatHits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules/
 dist/
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "mocha-jsdom": "^1.0.0",
     "mversion": "^1.10.1",
     "nd": "^1.2.0",
-    "node-fixtures": "0.0.1",
     "node-sass": "^3.4.2",
     "npm-shrinkwrap": "^200.4.0",
     "onchange": "^2.0.0",

--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -102,16 +102,19 @@ class DocSearch {
         query: query,
         params: this.algoliaOptions
       }]).then((data) => {
-        callback(this.formatHits(data.results[0].hits));
+        callback(DocSearch.formatHits(data.results[0].hits));
       });
     };
   }
 
   // Given a list of hits returned by the API, will reformat them to be used in
   // a Hogan template
-  formatHits(receivedHits) {
-    let hits = receivedHits.map((hit) => {
-      hit._highlightResult = utils.mergeKeyWithParent(hit._highlightResult, 'hierarchy');
+  static formatHits(receivedHits) {
+    let clonedHits = utils.deepClone(receivedHits);
+    let hits = clonedHits.map((hit) => {
+      if (hit._highlightResult) {
+        hit._highlightResult = utils.mergeKeyWithParent(hit._highlightResult, 'hierarchy');
+      }
       return utils.mergeKeyWithParent(hit, 'hierarchy');
     });
 
@@ -140,7 +143,7 @@ class DocSearch {
 
       return {
         isCategoryHeader: hit.isCategoryHeader,
-        isSubcategoryHeader: hit.isSubcategoryHeader,
+        isSubCategoryHeader: hit.isSubCategoryHeader,
         category: category,
         subcategory: subcategory,
         title: displayTitle,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -24,10 +24,10 @@ let utils = {
   */
   mergeKeyWithParent(object, property) {
     if (object[property] === undefined) {
-      throw new Error(`[mergeKeyWithParent]: Object has no key ${property}`);
+      return object;
     }
     if (typeof object[property] !== 'object') {
-      throw new Error(`[mergeKeyWithParent]: Key ${property} is not an object`);
+      return object;
     }
     let newObject = $.extend({}, object, object[property]);
     delete newObject[property];
@@ -144,9 +144,11 @@ let utils = {
   * @return {array}
   */
   flattenAndFlagFirst(object, flag) {
-    let values = this.values(object).map(value => {
-      value[0][flag] = true;
-      return value;
+    let values = this.values(object).map(collection => {
+      return collection.map((item, index) => {
+        item[flag] = (index === 0);
+        return item;
+      });
     });
     return this.flatten(values);
   },
@@ -230,9 +232,16 @@ let utils = {
       snippet = `${snippet}…`;
     }
     return snippet;
+  },
+ /*
+  * Deep clone an object.
+  * Note: This will not clone functions and dates
+  * @param {object} object Object to clone
+  * @return {object}
+  */
+  deepClone(object) {
+    return JSON.parse(JSON.stringify(object));
   }
-
-
 };
 
 export default utils;

--- a/test/fixtures/formatHits.json
+++ b/test/fixtures/formatHits.json
@@ -23,7 +23,7 @@
           "value": "API"
         },
         "lvl2": {
-          "value": "<mark>Search</mark>"
+          "value": "Search"
         },
         "lvl3": null,
         "lvl4": null,

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -65,16 +65,17 @@ describe('utils', () => {
       expect(actual.lvl0).toNotEqual(42);
       expect(actual.lvl0).toEqual('bar');
     });
-    it('should throw an error if no such key', () => {
+    it('should do nothing if no such key', () => {
       // Given
       let input = {
         name: 'foo'
       };
 
       // When
-      expect(() => {
-        utils.mergeKeyWithParent(input, 'hierarchy');
-      }).toThrow(Error);
+      let actual = utils.mergeKeyWithParent(input, 'hierarchy');
+
+      // Then
+      expect(actual).toBe(input);
     });
     it('should throw an error if key is no an object', () => {
       // Given
@@ -84,9 +85,10 @@ describe('utils', () => {
       };
 
       // When
-      expect(() => {
-        utils.mergeKeyWithParent(input, 'hierarchy');
-      }).toThrow(Error);
+      let actual = utils.mergeKeyWithParent(input, 'hierarchy');
+
+      // Then
+      expect(actual).toBe(input);
     });
   });
 
@@ -193,11 +195,11 @@ describe('utils', () => {
       // Then
       expect(actual).toEqual([
         {name: 'Tim', category: 'dev', isTop: true},
-        {name: 'Vincent', category: 'dev'},
-        {name: 'AlexS', category: 'dev'},
+        {name: 'Vincent', category: 'dev', isTop: false},
+        {name: 'AlexS', category: 'dev', isTop: false},
         {name: 'Ben', category: 'sales', isTop: true},
-        {name: 'Jeremy', category: 'sales'},
-        {name: 'AlexK', category: 'sales'}
+        {name: 'Jeremy', category: 'sales', isTop: false},
+        {name: 'AlexK', category: 'sales', isTop: false}
       ]);
     });
   });
@@ -326,6 +328,40 @@ describe('utils', () => {
 
       // Then
       expect(actual).toEqual('This is an <mark>finished</mark> sentence…');
+    });
+  });
+
+  describe('deepClone', () => {
+    it('should create an object with the exact same value', () => {
+      // Given
+      let input = {
+        foo: {
+          bar: 'baz'
+        }
+      };
+
+      // When
+      let actual = utils.deepClone(input);
+
+      // Then
+      expect(actual.foo.bar).toEqual('baz');
+    });
+    it('should not change the initial object', () => {
+      // Given
+      let input = {
+        foo: {
+          bar: 'baz'
+        }
+      };
+
+      // When
+      let actual = utils.deepClone(input);
+      input.foo.bar = 42;
+
+      // Then
+      expect(input.foo.bar).toEqual(42);
+      expect(actual.foo.bar).toNotEqual(42);
+      expect(actual.foo.bar).toEqual('baz');
     });
   });
 });


### PR DESCRIPTION
The main logic of the library: splitting a set of 5 results into
a neatly ordered array, to be able to display it as two columns in
Hogan.