### PR TITLE
docs(documentation.md): Fix not working links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check out our [website][1] to add an outstanding search to your documentation.
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-<!-- START documentation.md -->
+<!-- START documentation -->
 
 ## Introduction
 
@@ -194,7 +194,7 @@ docsearch({
 
 You will find all Algolia API options in its [own documentation][23]
 
-<!-- END documentation.md -->
+<!-- END documentation -->
 
 ## Development workflow
 
@@ -248,6 +248,7 @@ configure the build path of eventmachine with
 bundle config build.eventmachine --with-cppflags=-I$(brew --prefix openssl)/include
 ```
 
+<!-- START links -->
 
 [1]: https://community.algolia.com/docsearch/
 [2]: https://img.shields.io/npm/v/docsearch.js.svg?style=flat-square
@@ -276,3 +277,5 @@ bundle config build.eventmachine --with-cppflags=-I$(brew --prefix openssl)/incl
 [25]: https://jekyllrb.com/
 [26]: https://www.ruby-lang.org/en/
 [27]: http://bundler.io/
+
+<!-- END links -->

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -5,15 +5,19 @@ set -o errexit
 
 readonly SOURCE=README.md
 readonly OUTPUT=docs/documentation.md
-readonly START_TAG="<!-- START documentation.md -->"
-readonly END_TAG="<!-- END documentation.md -->"
+
+readonly START_DOC_TAG="<!-- START documentation -->"
+readonly END_DOC_TAG="<!-- END documentation -->"
+
+readonly START_LINKS_TAG="<!-- START links -->"
+readonly END_LINKS_TAG="<!-- END links -->"
 
 function escape_regex {
-  echo "$@" | sed -e 's/[]\/\!$*.^|[]/\\&/g'
+  echo "$1" | sed -e 's/[]\/\!$*.^|[]/\\&/g'
 }
 
 function extract {
-  sed -n "/^\s*$(escape_regex $START_TAG)\s*$/,/^\s*$(escape_regex $END_TAG)\s*$/p" \
+  sed -n "/^\s*$(escape_regex "$1")\s*$/,/^\s*$(escape_regex "$2")\s*$/p" \
     | sed '$d' \
     | sed -n '2,$p'
 }
@@ -27,7 +31,8 @@ function main {
   echo "permalink: /documentation/" >> $OUTPUT
   echo "---" >> $OUTPUT
 
-  cat $SOURCE | extract >> $OUTPUT
+  cat $SOURCE | extract "$START_DOC_TAG" "$END_DOC_TAG" >> $OUTPUT
+  cat $SOURCE | extract "$START_LINKS_TAG" "$END_LINKS_TAG" >> $OUTPUT
 }
 
 main


### PR DESCRIPTION
Fix by importing all the links of the README inside the `documentation.md` file.
Fixes #65 