### PR TITLE
fix(dropdown): Visually group suggestions together

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -21,8 +21,12 @@
   color: #333;
   cursor: pointer;
   overflow: hidden;
-  border-bottom: 1px solid $color-border;
 }
+
+  // Each sub-suggestion
+ .algolia-docsearch-suggestion__secondary {
+    border-top: 1px solid $color-border;
+  }
 
 // Main category headers
 .algolia-docsearch-suggestion--category-header {
@@ -62,6 +66,7 @@
 // The secondary column is hidden on small screens
 .algolia-docsearch-suggestion--subcategory-column {
   display: none;
+  cursor: default;
 }
 // The text snippet is hidden on small screens
 .algolia-docsearch-suggestion--text {
@@ -70,7 +75,14 @@
 
 .algolia-docsearch-suggestion--content {
   padding: 3px 5px;
+  width: 100%;
+  border-top: 1px solid lighten($color-border, 60%);
 }
+  
+  .algolia-docsearch-suggestion__main .algolia-docsearch-suggestion--content,
+  .algolia-docsearch-suggestion__secondary .algolia-docsearch-suggestion--content {
+    border-top: 0;
+  }
 
 .algolia-docsearch-suggestion--subcategory-inline {
   display: inline-block;
@@ -128,8 +140,12 @@
   .algolia-docsearch-suggestion {
     display: table;
     width: 100%;
-    border-bottom: 1px solid $color-border-light;
   }
+
+  .algolia-docsearch-suggestion__secondary {
+    border-top: 1px solid $color-border-light;
+  }
+
   .algolia-docsearch-suggestion--subcategory-column {
     border-right: 1px solid $color-border-light;
     background: $color-left-column-bg;


### PR DESCRIPTION
In the current version, each row in the left column (display sub categories) are separated with a line, even when two suggestions belong to the same sub-category. 

<img width="618" alt="screenshot 2016-01-29 16 16 21" src="https://cloud.githubusercontent.com/assets/1101220/12679527/03ac30e0-c6a5-11e5-8430-73b69d0d8cd6.png">

Removing those, and making the interlines lighter in the right column, improves readability.
Makes it easier for the brain to understand that some items belong to a same sub-category.

<img width="620" alt="screenshot 2016-01-29 16 15 40" src="https://cloud.githubusercontent.com/assets/1101220/12679534/0682c2c0-c6a5-11e5-8d2c-bd378ead951c.png">

Also disabled the mouse hover look'n'feel when hovering the left column.