### PR TITLE
Fixed markdown links inside code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ sets white and purples colors.
 If you want to do heavily change the way results are displayed, you might find
 it easier to directly edit the `scss` files in this repository.
 
-`[_variables.scss][18]`
+[`_variables.scss`][18]
 contains all the color, breakpoints and size definitions while 
-`[_main.scss][19]`
+[`_main.scss`][19]
 holds the structure of the display.
 
 You can regenerate the whole final `css` file from those `scss` files by running


### PR DESCRIPTION
Ensure the links are correctly interpreted by the documentation website.

<img width="816" alt="screen shot 2016-02-08 at 01 41 08" src="https://cloud.githubusercontent.com/assets/29529/12876671/0c11c6fc-ce05-11e5-9d00-be84339e5f9b.png">
