### PR TITLE
fix(autocomplete): auto select top result

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -39,7 +39,8 @@ class DocSearch {
     },
     autocompleteOptions = {
       debug: false,
-      hint: false
+      hint: false,
+      autoselect: true
     }
   }) {
     DocSearch.checkArguments({apiKey, indexName, inputSelector, algoliaOptions, autocompleteOptions});


### PR DESCRIPTION
Use autocomplete.js's autoselect=true option to select the top
suggestion on <ENTER> even if you don't move the cursor.

Fix #81