### PR TITLE
feat(serve): Watch and serve all needed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ npm run dev
 - `npm run build:docs` will create the `./docs/documentation.md` file from the
   `README.md` file, to be displayed on the website.
 - `npm run build` will run all three previous commands
+- `npm run serve` will serve and watch the JavaScript and CSS files on
+  [http://localhost:8080/](http://localhost:8080/). If port `8080` is already
+  taken, it will choose an available port. Source files will also be available
+  and watched in `./dist/`.
 
 ### Documentation website
 

--- a/scripts/serve
+++ b/scripts/serve
@@ -1,17 +1,24 @@
 #!/usr/bin/env bash
-# Will expose the build version on:
-# - http://0.0.0.0:8080/docsearch.css
-# - http://0.0.0.0:8080/docsearch.js
+# Serves the current build version on a local server available (by default) on 
+# http://127.0.0.1:8080/docsearch.js and http://127.0.0.1/docsearch.css
+#
+# This is useful when you want to test the latest docsearch.js version
+# (including your own branches) on a specific local project. Just run `npm run
+# serve` in the docsearch repository, and link the file in your project.
+#
+# This works by running webpack in watch mode as well as simply serving the dist
+# folder through a local web server.
 
 npm run build:css
 
-# /bundle.js in memory
-webpack-dev-server \
+# Watch changes and rebuild file if needed
+NODE_ENV=production \
+  webpack \
   --config webpack.serve.config.babel.js \
-  --hot \
-  --inline \
-  --no-info & \
-# rebuild docsearch.css and docsearch.min.css
+  -w &
+# Serve files
+cd dist/cdn && http-server &
+# Rebuild css
 onchange './src/styles/*.scss' -- npm run build:css & \
 
 wait


### PR DESCRIPTION
Running `npm run serve` will watch for changes in the source files and
rebuild all `css` and `js` files accordingly in the `dist` folder. It
will also expose the same files on `http://localhost:8080/` (by
default, if port `8080` is already taken it will move to an available
one).

This will let developers use a specific branch/version of docsearch in
their projects. Just open a new tab and run `npm run serve` in the
docsearch repo, and you'll be able to include the scripts from the
running server in your HTML.

As files are automatically regenerated on disk whenever a change is
detected, you can also `require` files by targeting the `dist` folder.