### PR TITLE
feat(a11y): Hide separators to screen readers

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -203,7 +203,7 @@ class DocSearch {
         utils.getHighlightedValue(hit, 'lvl4'),
         utils.getHighlightedValue(hit, 'lvl5'),
         utils.getHighlightedValue(hit, 'lvl6')
-      ]).join('<span class="aa-suggestion-title-separator"> › </span>');
+      ]).join('<span class="aa-suggestion-title-separator" aria-hidden="true"> › </span>');
       const text = utils.getSnippetedValue(hit, 'content');
       const isTextOrSubcatoryNonEmpty = (subcategory && subcategory !== '') ||
         (displayTitle && displayTitle !== '');

--- a/test/DocSearch-test.js
+++ b/test/DocSearch-test.js
@@ -736,7 +736,7 @@ describe('DocSearch', () => {
       // When
       let actual = DocSearch.formatHits(input);
 
-      let separator = '<span class="aa-suggestion-title-separator"> › </span>';
+      let separator = '<span class="aa-suggestion-title-separator" aria-hidden="true"> › </span>';
       // Then
       expect(actual[0].title).toEqual('Geo-search' + separator + 'Foo' + separator + 'Bar' + separator + 'Baz');
     });
@@ -778,7 +778,7 @@ describe('DocSearch', () => {
       // When
       let actual = DocSearch.formatHits(input);
 
-      let separator = '<span class="aa-suggestion-title-separator"> › </span>';
+      let separator = '<span class="aa-suggestion-title-separator" aria-hidden="true"> › </span>';
       // Then
       let expected = '<mark>Geo-search</mark>' + separator + '<mark>Foo</mark>' + separator +
           '<mark>Bar</mark>' + separator + '<mark>Baz</mark>';


### PR DESCRIPTION
This PR makes DocSearch more accessible to screen readers.