### PR TITLE
chore(build): Use include instead of exclude in webpack dev build

### DIFF
--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -1,4 +1,4 @@
-import {join} from 'path';
+import path from 'path';
 
 export default {
   entry: './dev/app.js',
@@ -9,7 +9,12 @@ export default {
   },
   module: {
     loaders: [{
-      test: /\.js$/, exclude: /node_modules/, loader: 'babel'
+      test: /\.js$/,
+      include: [
+        path.resolve(__dirname, 'src'),
+        path.resolve(__dirname, 'dev'),
+        path.resolve(__dirname, 'scripts')
+      ], loader: 'babel'
     }]
   },
   devServer: {
@@ -21,10 +26,10 @@ export default {
   // helps fixing the npm link not working with webpack
   // http://stackoverflow.com/a/33722844/147079
   resolve: {
-    fallback: [join(__dirname, '..', 'node_modules')]
+    fallback: [path.join(__dirname, '..', 'node_modules')]
   },
   // same issue, for loaders like babel
   resolveLoader: {
-    fallback: [join(__dirname, '..', 'node_modules')]
+    fallback: [path.join(__dirname, '..', 'node_modules')]
   }
 };


### PR DESCRIPTION
This makes local development easier with local builds of autocomplete.js.

### Before

`npm link autocomplete.js` throws an error because of a babel related thing

### After

`npm link autocomplete.js` works