### PR TITLE
docs(readme): add installation instructions on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ docsearch({
 </script>
 ```
 
+You can also install docsearch via `npm`:
+
+```sh
+npm install --save docsearch.js
+```
+
 ## Customization
 
 The default colorscheme is white and gray:


### PR DESCRIPTION
docsearch is published on npm too, but it's a bit confusing that it's actually published as `docsearch.js`, so this should definitely be put somewhere in the README