### PR TITLE
docs(global): Add section on "powered by Algolia" attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npm install --save docsearch.js
 We're happy to provide DocSearch free of charge for your site, and you're
 welcome to customise that experience in a way that works for you; all we ask is
 that Algolia be attributed within the search context. For example, in the
-default implementation, we place a small "powered by Algolia" logo in the
+default implementation, we place a small "Search by Algolia" logo in the
 corner. If you prefer to roll your own UX, you'll need to make sure that this
 logo is included in your implementation as well.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ npm install --save docsearch.js
 
 ## Customization
 
+### Attribution
+
+We're happy to provide DocSearch free of charge for your site, and you're
+welcome to customise that experience in a way that works for you; all we ask is
+that Algolia be attributed within the search context. For example, in the
+default implementation, we place a small "powered by Algolia" logo in the
+corner. If you prefer to roll your own UX, you'll need to make sure that this
+logo is included in your implementation as well.
+
+### Default styling
+
 The default colorscheme is white and gray:
 
 ![Default colorscheme][17]


### PR DESCRIPTION
**Summary**
This is a tacit agreement, but imho it should really be stated somewhere explicitly.

**Result**
Now it's explicit. 

cc @pixelastic @ElPicador @s-pace 