### PR TITLE
docs(showcase): update React and React Native links

### DIFF
--- a/docs/_data/showcase.yml
+++ b/docs/_data/showcase.yml
@@ -14,12 +14,12 @@
   logo: "./img/showcase/logo-vuejs.png"
 
 - name: React
-  url: "https://facebook.github.io/react/"
+  url: "https://reactjs.org"
   gif: "./img/showcase/example-react.gif"
   logo: "./img/showcase/logo-react.png"
 
 - name: React Native
-  url: "https://facebook.github.io/react/"
+  url: "https://facebook.github.io/react-native/"
   gif: "./img/showcase/example-reactnative.gif"
   logo: "./img/showcase/logo-react.png"
 


### PR DESCRIPTION
react -> standalone website
react native -> link to its site instead of react's site
