### PR TITLE
fix(autocompleteOptions): allow cssClasses options

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -73,9 +73,10 @@ class DocSearch {
     // eslint-disable-next-line no-param-reassign
     autocompleteOptions.debug = debug || autocompleteOptionsDebug;
     this.autocompleteOptions = autocompleteOptions;
-    this.autocompleteOptions.cssClasses = {
-      prefix: 'ds',
-    };
+    this.autocompleteOptions.cssClasses =
+      this.autocompleteOptions.cssClasses || {};
+    this.autocompleteOptions.cssClasses.prefix =
+      this.autocompleteOptions.cssClasses.prefix || 'ds';
 
     // eslint-disable-next-line no-param-reassign
     handleSelected = handleSelected || this.handleSelected;


### PR DESCRIPTION
Let through options passed in `autocompleteOptions.cssClasses` and use `prefix: 'ds'` as default.

Right now, options being are overwritten [on these lines](https://github.com/algolia/docsearch/blob/master/src/lib/DocSearch.js#L76-L78).

Have a good weekend! ☀️