### PR TITLE
doc(site): Fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ set white and purple colors.
 .algolia-docsearch-suggestion--highlight {
   color: #3A33D1;
 }
-/* Highligted search terms in the main category headers */
+/* Highlighted search terms in the main category headers */
 .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight  {
   background-color: #4D47D5;
 }

--- a/docs/source/assets/stylesheets/_searchbar.scss
+++ b/docs/source/assets/stylesheets/_searchbar.scss
@@ -115,7 +115,7 @@ $custom:(
     text-align: center;
     user-select: none;
 
-    // Helper for vertical alignement of the icon
+    // Helper for vertical alignment of the icon
     &::before {
       display: inline-block;
       margin-right: -4px;

--- a/docs/source/documentation/2-docsearch-scraper/2-config-options.html.md.erb
+++ b/docs/source/documentation/2-docsearch-scraper/2-config-options.html.md.erb
@@ -63,7 +63,7 @@ Name of the Algolia index where all the data will be pushed.
 
 **On our own infrastructure, this name must be equal to the configuration file name**
 
-We mostly attribute it on our own regarding plenty of underlying factors. The `apiKey` that we provide is generated with a restriction on the `index_name`. Changing the `index_name` would require to ask for a new key. Thus if you want to **change the name**, please **submit a new configration**, we will generate a new key accordingly.
+We mostly attribute it on our own regarding plenty of underlying factors. The `apiKey` that we provide is generated with a restriction on the `index_name`. Changing the `index_name` would require to ask for a new key. Thus if you want to **change the name**, please **submit a new configuration**, we will generate a new key accordingly.
 
 ### `start_urls` _Mandatory_
 You can pass either a string or an array of urls. The crawler will go to each
@@ -115,7 +115,7 @@ You can also define some `tags` that will also behave as [`attributesForFaceting
 
 In order to promote some pages, you can set the `page_rank` attribute (default: `0`, can be a positive or negative integer).
 
-Finally, If your website contains differents parts and layouts, you can define specific `selectors` for each part and apply them using `selectors_key`:
+Finally, If your website contains different parts and layouts, you can define specific `selectors` for each part and apply them using `selectors_key`:
 
 Example:
 ```json
@@ -343,7 +343,7 @@ settings. You will [look under the hood of algolia](https://www.algolia.com/doc/
 
 The number of maximum records allowed for the whole indexing. If the scrapping is bigger, it will fail.
 
-This value is not meant to be set from anyone except DocSearch maintaner.
+This value is not meant to be set from anyone except DocSearch maintainer.
 
 Default is `600 000` (arbitrary, might change)
 

--- a/docs/source/documentation/3-docsearch-autocomplete/1-customize-autocomplete-styles.html.md.erb
+++ b/docs/source/documentation/3-docsearch-autocomplete/1-customize-autocomplete-styles.html.md.erb
@@ -34,7 +34,7 @@ set white and purple colors.
 .algolia-docsearch-suggestion--highlight {
   color: #3A33D1;
 }
-/* Highligted search terms in the main category headers */
+/* Highlighted search terms in the main category headers */
 .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight  {
   background-color: #4D47D5;
 }

--- a/scripts/test-coverage
+++ b/scripts/test-coverage
@@ -3,7 +3,7 @@
 # This file will then be read by Travis to push it to Coveralls
 #
 # The command is long and was quite hard to write correctly.
-# We need babel-istanbul and not instanbul
+# We need babel-istanbul and not istanbul
 # We need the _mocha and not mocha
 # We need to use full path for each binaries
 # We need to run everything through babel-node

--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -249,7 +249,7 @@ class DocSearch {
           '<span class="aa-suggestion-title-separator" aria-hidden="true"> › </span>'
         );
       const text = utils.getSnippetedValue(hit, 'content');
-      const isTextOrSubcatoryNonEmpty =
+      const isTextOrSubcategoryNonEmpty =
         (subcategory && subcategory !== '') ||
         (displayTitle && displayTitle !== '');
       const isLvl1EmptyOrDuplicate =
@@ -268,7 +268,7 @@ class DocSearch {
         isLvl1EmptyOrDuplicate,
         isCategoryHeader: hit.isCategoryHeader,
         isSubCategoryHeader: hit.isSubCategoryHeader,
-        isTextOrSubcatoryNonEmpty,
+        isTextOrSubcategoryNonEmpty,
         category,
         subcategory,
         title: displayTitle,

--- a/src/lib/__tests__/DocSearch-test.js
+++ b/src/lib/__tests__/DocSearch-test.js
@@ -349,7 +349,7 @@ describe('DocSearch', () => {
     });
 
     describe('the returned function', () => {
-      it('calls the Agolia client with the correct parameters', () => {
+      it('calls the Algolia client with the correct parameters', () => {
         // Given
         const actual = docsearch.getAutocompleteSource();
 
@@ -369,7 +369,7 @@ describe('DocSearch', () => {
     });
 
     describe('when queryHook is used', () => {
-      it('calls the Agolia client with the correct parameters', () => {
+      it('calls the Algolia client with the correct parameters', () => {
         // Given
         const actual = docsearch.getAutocompleteSource(
           false,

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -17,13 +17,13 @@ const templates = {
       <div class="${suggestionPrefix}--subcategory-column">
         <span class="${suggestionPrefix}--subcategory-column-text">{{{subcategory}}}</span>
       </div>
-      {{#isTextOrSubcatoryNonEmpty}}
+      {{#isTextOrSubcategoryNonEmpty}}
       <div class="${suggestionPrefix}--content">
         <div class="${suggestionPrefix}--subcategory-inline">{{{subcategory}}}</div>
         <div class="${suggestionPrefix}--title">{{{title}}}</div>
         {{#text}}<div class="${suggestionPrefix}--text">{{{text}}}</div>{{/text}}
       </div>
-      {{/isTextOrSubcatoryNonEmpty}}
+      {{/isTextOrSubcategoryNonEmpty}}
     </div>
   </div>
   `,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -233,7 +233,7 @@ const utils = {
    *    text: 'This is an unfinished sentence'
    * }, 'text');
    * =>
-   * '<mark>This is an unefinished sentenced</mark>…'
+   * '<mark>This is an unfinished sentence</mark>…'
    * @param {object} object Hit object returned by the Algolia API
    * @param {string} property Object key to look for
    * @return {string}

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -50,7 +50,7 @@
   }
 }
 
-// Alignement type
+// Alignment type
 @mixin alignment-type($type) {
   @if $type == 'left' {
     left: 0 !important;

--- a/src/styles/_searchbox.scss
+++ b/src/styles/_searchbox.scss
@@ -127,7 +127,7 @@
         left: 0;
       }
 
-      // Helper for vertical alignement of the icon
+      // Helper for vertical alignment of the icon
       &::before {
         display: inline-block;
         margin-right: -4px;


### PR DESCRIPTION
**Summary**

Fixed few typos

**Result**

Less typos

**Care**

Maybe the typo fix of `isTextOrSubcatoryNonEmpty` can provoke a regression somewhere/somehow ?
