### PR TITLE
chore(lint): Remove .js extension from imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 /* eslint-disable import/no-commonjs */
 
-import docsearch from './src/lib/main.js';
+import docsearch from './src/lib/main';
 module.exports = docsearch;

--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -1,10 +1,10 @@
 import Hogan from 'hogan.js';
 import algoliasearch from 'algoliasearch/lite';
 import autocomplete from 'autocomplete.js';
-import templates from './templates.js';
-import utils from './utils.js';
-import version from './version.js';
-import $ from './zepto.js';
+import templates from './templates';
+import utils from './utils';
+import version from './version';
+import $ from './zepto';
 
 /**
  * Adds an autocomplete dropdown to an input field

--- a/src/lib/__tests__/DocSearch-test.js
+++ b/src/lib/__tests__/DocSearch-test.js
@@ -1,8 +1,8 @@
 /* eslint no-new:0 */
 /* eslint-disable max-len */
 import sinon from 'sinon';
-import $ from '../zepto.js';
-import DocSearch from '../DocSearch.js';
+import $ from '../zepto';
+import DocSearch from '../DocSearch';
 
 describe('DocSearch', () => {
   beforeEach(() => {

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -1,4 +1,4 @@
-import utils from '../utils.js';
+import utils from '../utils';
 
 describe('utils', () => {
   describe('mergeKeyWithParent', () => {

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -1,6 +1,6 @@
 import toFactory from 'to-factory';
 import DocSearch from './DocSearch';
-import version from './version.js';
+import version from './version';
 
 const docsearch = toFactory(DocSearch);
 docsearch.version = version;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,4 @@
-import $ from './zepto.js';
+import $ from './zepto';
 
 const utils = {
   /*

--- a/src/lib/zepto.js
+++ b/src/lib/zepto.js
@@ -1,2 +1,2 @@
-import zepto from 'autocomplete.js/zepto.js';
+import zepto from 'autocomplete.js/zepto';
 export default zepto;


### PR DESCRIPTION
 ESLint was complaining about having trailing .js extensions in imports and suggesting removing them as they are the default.