### PR TITLE
Skip linting the docs when making a change to the root

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "lint:css": "./scripts/lint-css",
     "lint:md": "./scripts/lint-md",
     "lint:md:fix": "./scripts/lint-md-fix",
-    "prepush": "yarn lint",
+    "prepush": "./scripts/prepush",
     "serve": "babel-node ./scripts/serve.js"
   },
   "devDependencies": {

--- a/docs/scripts/prepush
+++ b/docs/scripts/prepush
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+git diff --name-status master | grep 'docs/' 1>/dev/null
+DOCS_FOLDER_HAS_CHANGED=$?
+
+# We don't run the docs linting if no changes were made in the docs
+if [ "$DOCS_FOLDER_HAS_CHANGED" = "1" ]; then
+  exit 0
+fi
+
+yarn run lint:js && \
+yarn run lint:css && \
+yarn run lint:md


### PR DESCRIPTION
The `./docs` subfolder contains a git hook (automatically added through husky) that checks for lint before any push, preventing to push content that doesn't comply with our linting rules.

While this is a good thing, it had the side effect of also trigger on unrelated pushes (when editing the main DocSearch code for example). This happened because we have two nested node projects (DocSearch at the root and the docs in `./docs`), each with their own dependencies. But has husky adds git hooks, even if it is defined in the subfolder, it adds them to the whole repo.

This PR now makes sure the prepush hook call a custom script that double check that changes were actually made in the `./docs` subfolder before running the doc linting.

This will allow us to push updates to DocSearch faster, without having to wait for the lint of the documentation we didn't change.