### PR TITLE
Add precommit and prepush hooks that don't conflict

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  hooks: {
+    'pre-commit': './scripts/precommit-dispatcher',
+    'pre-push': './scripts/prepush-dispatcher',
+  },
+};

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,8 +9,6 @@
     "lint:css": "./scripts/lint-css",
     "lint:md": "./scripts/lint-md",
     "lint:md:fix": "./scripts/lint-md-fix",
-    "precommit": "./scripts/precommit",
-    "prepush": "yarn lint",
     "serve": "babel-node ./scripts/serve.js"
   },
   "devDependencies": {
@@ -37,7 +35,6 @@
     "fs-extra": "7.0.0",
     "gh-pages": "1.2.0",
     "glob": "7.1.3",
-    "husky": "0.14.3",
     "inquirer": "6.2.0",
     "live-server": "1.2.0",
     "lodash": "4.17.11",

--- a/docs/scripts/lint-md-fix
+++ b/docs/scripts/lint-md-fix
@@ -1,15 +1,21 @@
-#!/usr/bin/env sh
-set -e
+#!/usr/bin/env bash
 # This will attempt to automatically fix most of the Markdown linting issues
 # detected.
+set -e
+
+# Lint only file specified through FILES_TO_LINT (done in the pre-commit hook)
+# or fallback to all markdown files
+FILES_TO_LINT=($FILES_TO_LINT)
+if [ "${#FILES_TO_LINT[@]}" = "0" ]; then
+  FILES_TO_LINT=(./*.md ./src/*.md)
+fi
 
 # We will first transform the file according to remark config. This will mostly
 # convert inline links to references at the bottom of the file.
 REMARK_MODE=fix \
   remark \
     --quiet \
-    ./*.md \
-    ./src/*.md \
+    "${FILES_TO_LINT[@]}" \
     --output
 
 # We then check the actual natural language content of the file, to fix
@@ -17,8 +23,7 @@ REMARK_MODE=fix \
 TEXTLINT_MODE=fix textlint \
   --fix \
   --cache \
-  ./*.md \
-  ./src/*.md \
+  "${FILES_TO_LINT[@]}" \
   1>/dev/null
 
 # Finally, we'll run everything through prettier to make sure all files are
@@ -27,5 +32,4 @@ TEXTLINT_MODE=fix textlint \
 prettier \
   --loglevel error \
   --write \
-  ./*.md \
-  ./src/*.md
+  "${FILES_TO_LINT[@]}"

--- a/docs/scripts/precommit
+++ b/docs/scripts/precommit
@@ -1,23 +1,24 @@
-#!/usr/bin/env sh
-
-# This script is run before each commit on the repo and will try to fix linting
-# issues of the documentation.
-
-# This is run from ./docs folder, we need to go back to the git root to run the
-# git methods
-cd ../ || exit 1
-
-# We only run the auto-fix when changes are actually made to markdown files
-git diff --name-status master | grep '^\(.*\)docs/\(.*\).md$' 1>/dev/null
-DOCS_FOLDER_HAS_CHANGED=$?
-if [ "$DOCS_FOLDER_HAS_CHANGED" = "1" ]; then
+#!/usr/bin/env bash
+# We first check if, among the files ready to be committed, we have some
+# documentation markdown files.
+CHANGED_MARKDOWN_FILES="$(git diff --cached --name-only HEAD | grep '^docs/\(.*\).md$')"
+if [ "$CHANGED_MARKDOWN_FILES" = "" ]; then
+  echo "No markdown file changed"
   exit 0
 fi
 
-echo "Markdown documentation updated."
-echo "Running auto-lint..."
+# We now run the auto-fix linting on only those files
 cd ./docs || exit 1
-yarn run lint:md:fix
+echo "Running auto-lint..."
+# Converting the list into a list relative to the ./docs folder, all on one line
+RELATIVE_CHANGED_MARKDOWN_FILES="$(
+  echo "$CHANGED_MARKDOWN_FILES" \
+    | sed 's/^docs/./g' \
+    | tr '\n' ' '
+)"
+FILES_TO_LINT="$RELATIVE_CHANGED_MARKDOWN_FILES" yarn run lint:md:fix
 
-cd ../ || exit 1
-git add ./docs/**/*.md
+# We re-add those changed files to the index so they show up in the commit
+cd ..
+FILES_TO_ADD=($CHANGED_MARKDOWN_FILES)
+git add "${FILES_TO_ADD[@]}"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2883,14 +2883,6 @@ humannames@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/humannames/-/humannames-1.0.5.tgz#a4d60d4168df8737f4b262efd23f2ee32974f1c5"
 
-husky@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
-  dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
-
 iconv-lite@^0.4.17, iconv-lite@^0.4.22, iconv-lite@^0.4.4:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
@@ -4021,10 +4013,6 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
-
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "21.24.1",
     "eslint-plugin-prettier": "2.7.0",
+    "husky": "1.1.1",
     "jest": "23.6.0",
     "jsdom": "11.12.0",
     "json": "9.0.6",

--- a/scripts/precommit-dispatcher
+++ b/scripts/precommit-dispatcher
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# This will be called on every commit to the repo and will trigger the
+# appropriate ./precommit script for the root project and the ./docs subfolder
+# based on which file were changed
+HAS_CHANGES_IN_ROOT="0"
+HAS_CHANGES_IN_DOCS="0"
+HAS_SCRIPT_IN_ROOT="0"
+HAS_SCRIPT_IN_DOCS="0"
+
+# Did we change files in root or docs?
+CHANGED_FILES="$(git diff --cached --name-only HEAD)"
+if echo "$CHANGED_FILES" | grep -qv '^docs/'; then
+  HAS_CHANGES_IN_ROOT="1"
+fi
+if echo "$CHANGED_FILES" | grep -q '^docs/'; then
+  HAS_CHANGES_IN_DOCS="1"
+fi
+
+# Do we have a precommit script in root or docs?
+if [ -x ./scripts/precommit ]; then
+  HAS_SCRIPT_IN_ROOT="1"
+fi
+if [ -x ./docs/scripts/precommit ]; then
+  HAS_SCRIPT_IN_DOCS="1"
+fi
+
+# Execute the needed scripts
+if [ $HAS_CHANGES_IN_ROOT = "1" ] && [ $HAS_SCRIPT_IN_ROOT = "1" ]; then
+  echo "Running precommit in ./"
+  ./scripts/precommit || exit 1
+fi
+if [ $HAS_CHANGES_IN_DOCS = "1" ] && [ $HAS_SCRIPT_IN_DOCS = "1" ]; then
+  echo "Running precommit in ./docs"
+  ./docs/scripts/precommit || exit 1
+fi
+
+

--- a/scripts/prepush
+++ b/scripts/prepush
@@ -1,2 +1,5 @@
 #!/usr/bin/env sh
+set -e
+
 yarn run lint
+yarn run test

--- a/scripts/prepush-dispatcher
+++ b/scripts/prepush-dispatcher
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# This will be called on every push to the repo and will trigger the appropriate
+# ./prepush script for the root project and the ./docs subfolder based on which
+# file were changed
+HAS_CHANGES_IN_ROOT="0"
+HAS_CHANGES_IN_DOCS="0"
+HAS_SCRIPT_IN_ROOT="0"
+HAS_SCRIPT_IN_DOCS="0"
+
+# Did we change files in root or docs?
+CHANGED_FILES="$(git diff --name-only master)"
+if echo "$CHANGED_FILES" | grep -qv '^docs/'; then
+  HAS_CHANGES_IN_ROOT="1"
+fi
+if echo "$CHANGED_FILES" | grep -q '^docs/'; then
+  HAS_CHANGES_IN_DOCS="1"
+fi
+
+# Do we have a prepush script in root or docs?
+if [ -x ./scripts/prepush ]; then
+  HAS_SCRIPT_IN_ROOT="1"
+fi
+if [ -x ./docs/scripts/prepush ]; then
+  HAS_SCRIPT_IN_DOCS="1"
+fi
+
+# Execute the needed scripts
+if [ $HAS_CHANGES_IN_ROOT = "1" ] && [ $HAS_SCRIPT_IN_ROOT = "1" ]; then
+  echo "Running prepush in ./"
+  ./scripts/prepush || exit 1
+fi
+if [ $HAS_CHANGES_IN_DOCS = "1" ] && [ $HAS_SCRIPT_IN_DOCS = "1" ]; then
+  echo "Running prepush in ./docs"
+  ./docs/scripts/prepush || exit 1
+fi
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,6 +1474,11 @@ ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
 
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -1877,6 +1882,15 @@ cosmiconfig@^4.0.0:
 cosmiconfig@^5.0.0:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
+cosmiconfig@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
+  integrity sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
@@ -2783,6 +2797,19 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
+  integrity sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -3525,6 +3552,22 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+husky@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.1.tgz#7179043184f68a4d1ffc975cbd1c6132ef1fd7b3"
+  integrity sha512-D8ly8eIZdWzWVG4mh4apaX1PP47uLSaN8CS0RyuuLtHJ20Gt6Ccky5pSecaPsqxNzQj0zon3x6QX/0kCc5/TOQ==
+  dependencies:
+    cosmiconfig "^5.0.6"
+    execa "^0.9.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^1.2.1"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -3724,6 +3767,13 @@ is-ci@^1.0.10:
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
   dependencies:
     ci-info "^1.0.0"
+
+is-ci@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
+  dependencies:
+    ci-info "^1.5.0"
 
 is-color-stop@^1.0.0:
   version "1.1.0"
@@ -5744,6 +5794,13 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
+please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
+
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
@@ -6278,6 +6335,15 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+
 readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -6583,6 +6649,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
 rxjs@^5.5.2:
   version "5.5.11"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
@@ -6641,6 +6712,11 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -6776,6 +6852,11 @@ sisteransi@^0.1.1:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I improved the way our git hooks were working to avoid conflict between the root repo and the ./docs folder.

Husky has been installed at the root and is configured through a `.huskyrc.js` file. It has a precommit and prepush hook defined. They will both check if there are changes made in the root or in the docs, and call the appropriate hook based on this. 

For example, when committing a change to `./docs/src/whatever.md`, it will run the `./docs/scripts/precommit` hook. When pushing changes that only affect the root directory, it will run `./scripts/prepush`, but when also pushing changes in `./docs`, it will also run `./docs/scripts/prepush`.

The current hooks are:
- Before pushing changes in the root, we run the tests and lint
- Before pushing changes in docs, we run the documentation linting
- Before committing in the docs, we try to auto-fix the linting issues of the modified files