### PR TITLE
docs(website): fix typo

### DIFF
--- a/docs/src/recomended-configuration.md
+++ b/docs/src/recomended-configuration.md
@@ -60,7 +60,7 @@ The biggest blue element will be you `docSearch-content` container. Every
 selectors outside this element will be `global`. Every selectors appear in the
 same order than their `lvl` along the HTML flow.
 
-### The genreic configuration example
+### The generic configuration example
 
 ```json
 {


### PR DESCRIPTION
I know it's rude to overwrite the PR template but I don't think it applies in this case. Let me know if I need to change anything.