### PR TITLE
Add test that normal click is disable with custom handleSelected

### DIFF
--- a/scripts/playground.html
+++ b/scripts/playground.html
@@ -26,11 +26,11 @@
         apiKey: '25626fae796133dc1e734c6bcaaeac3c',
         indexName: 'docsearch',
         inputSelector: '#q',
-        handleSelected(input, event, suggestion) {
-          console.info(input);
-          console.info(event);
-          console.info(suggestion);
-        },
+        // handleSelected(input, event, suggestion) {
+        //   console.info(input);
+        //   console.info(event);
+        //   console.info(suggestion);
+        // },
         debug: true // Set debug to true if you want to inspect the dropdown
       });
     </script>

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -1,1 +1,1 @@
-export default '3.0.0';
+export default '2.5.2';


### PR DESCRIPTION
I added the missing tests for the ctrl-click and handleSelected.

This keeps backward compatibility for `handleSelected`: people that defined it will still have it honored. The way to do it was to intercept all clicks on the dropdown suggestion when a `handleSelected` with defined, and cancel them through `event.preventDefault()`, in order to allow the custom `handleSelected` to be triggered.

I also downgraded the version (that was bumped by mistake to 3.0) in another PR. The version will be automatically bumped in the release script, so no need to update it here. Especially because we don't want to bump to v3 yet.

Finally, I discovered an issue with the tests. Whenever we called `new DocSearch()` it would create slightly different markup of the dropdown (class names include a suffix of how many calls where made). This was no big deal in most cases, but when trying to access specific parts of the dropdown in a test, it resulted in tests failing randomly based on the order you run them. I added a note in the test file to warn future developers about this.