### PR TITLE
Remove `release:beta` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "format:scss": "prettier --write ./src/**/*.scss",
     "format:md": "prettier --write '**/*.md'",
     "release": "./scripts/release",
-    "release:beta": "./scripts/release-beta",
     "serve": "./scripts/serve",
     "test": "./scripts/test",
     "test:watch": "./scripts/test-watch",


### PR DESCRIPTION
Script was removed in 3c98ea588280f02bae581af2f52b69b3f0b044d0, but
the entry stayed.