### PR TITLE
Omit redundant `type="text/javascript"`

### DIFF
--- a/scripts/playground.html
+++ b/scripts/playground.html
@@ -20,8 +20,8 @@
       </div>
     </div>
     <!-- at the end of the BODY -->
-    <script type="text/javascript" src="http://127.0.0.1:8080/docsearch.js"></script>
-    <script type="text/javascript">
+    <script src="http://127.0.0.1:8080/docsearch.js"></script>
+    <script>
       docsearch({
         apiKey: '25626fae796133dc1e734c6bcaaeac3c',
         indexName: 'docsearch',


### PR DESCRIPTION
**Summary**

This removes some redundant code from the recommended HTML snippet. See <https://mathiasbynens.be/notes/html5-levels#type-attributes>.

**Result**

This is valid HTML. `text/javascript` is the default `type` for `<script>` elements per spec, and this is implemented by all browsers.