### PR TITLE
ci: use vm-based travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 script: "./scripts/test"
-sudo: false
 branches:
   only:
   - master


### PR DESCRIPTION
Let's see if this breaks anything, since it will become required soon: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
