### PR TITLE
implement query data callback method into src

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -36,6 +36,7 @@ class DocSearch {
     appId = 'BH4D9OD16A',
     debug = false,
     algoliaOptions = {},
+    queryDataCallback = null,
     autocompleteOptions = {
       debug: false,
       hint: false,
@@ -53,6 +54,7 @@ class DocSearch {
       inputSelector,
       debug,
       algoliaOptions,
+      queryDataCallback,
       autocompleteOptions,
       transformData,
       queryHook,
@@ -66,6 +68,7 @@ class DocSearch {
     this.indexName = indexName;
     this.input = DocSearch.getInputFromSelector(inputSelector);
     this.algoliaOptions = { hitsPerPage: 5, ...algoliaOptions };
+    this.queryDataCallback = queryDataCallback || null;
     const autocompleteOptionsDebug =
       autocompleteOptions && autocompleteOptions.debug
         ? autocompleteOptions.debug
@@ -214,6 +217,9 @@ class DocSearch {
           },
         ])
         .then(data => {
+          if (this.queryDataCallback && typeof this.queryDataCallback == "function") {
+            this.queryDataCallback(data)
+          }
           let hits = data.results[0].hits;
           if (transformData) {
             hits = transformData(hits) || hits;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
https://github.com/algolia/docsearch/issues/555
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

``` js
// Usage of new method
docsearch({
    ...config,
    inputSelector: "#docsearch-input",
    dataCallback: data => formatData(data)
    ...
});
---

const clickObject = {
    objectID,
    position,
    queryID //queryID of inner query, can now retrieve from within DocSearch instance
};
        
// Algolia Analytics library
aa("click", clickObject); //send the click data to algolia
```
