### PR TITLE
Fix a set of minor typos in "Inside the Engine -> Ranking Records"

### DIFF
--- a/docs/src/inside-the-engine.md
+++ b/docs/src/inside-the-engine.md
@@ -44,16 +44,16 @@ then fallback to partial matches. Those results will then be ordered based, once
 again, on the page hierarchy, as extracted from the `selectors`.
 
 The default strategy is to promote records having matching words in the highest
-level fist. Thus if two results have the same matching words, the one having
-them in the highest level (lvl0) will be reanked higher. We also use the
+level first. Thus if two results have the same matching words, the one having
+them in the highest level (lvl0) will be ranked higher. We also use the
 position of the matching words. The sooner they appear within the HTML flow, the
 higher the record will be ranked.
 
 The relevancy is based on several factors and can be customized according to the
 Algolia tie-breaking method.
 
-You can boost pages depending ont their URLs. This is done from the `start_urls`
-and its `page_rank` attributes. It is a numeric value, default to 0. The higher
+You can boost pages depending on their URLs. This is done from the `start_urls`
+and its `page_rank` attributes. It is a numeric value (defaults to 0). The higher
 it is, the higher results from the matching pages will be ranked. For example
 all pages with a `page_rank` of 5 will be returned before pages with a
 `page_rank` of 1.


### PR DESCRIPTION
This commit just fixes a set of minor typos in the text, that I found while reading through it. It also makes a small grammar adjustment as well, for greater reading clarity.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
