### PR TITLE
Fix dead VuePress link

### DIFF
--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -23,7 +23,7 @@ to the list, get [in touch with us][10]. We'd be happy to help.
 [1]: https://docusaurus.io/
 [2]: https://docusaurus.io/docs/en/search#docsNav
 [3]: https://vuepress.vuejs.org/
-[4]: https://vuepress.vuejs.org/default-theme-config/#algolia-search
+[4]: https://v0.vuepress.vuejs.org/default-theme-config/#algolia-search
 [5]: https://docs.gitbook.com/
 [6]: http://pkgdown.r-lib.org/index.html
 [7]: http://pkgdown.r-lib.org/articles/pkgdown.html#search


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The link to Algolia Search documentation on the VuePress site was dead, because VuePress has migrated its docs to v1.0-alpha and changed where the default theme docs are located. Because fragments seem to not work on v1.0-alpha yet, I fixed the link to still reference the v0 docs.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Before:

![screenshot 2018-12-29 at 10 10 55](https://user-images.githubusercontent.com/15911462/50536207-33746280-0b52-11e9-8811-bb415d6a1868.png)

After:

![screenshot 2018-12-29 at 10 11 09](https://user-images.githubusercontent.com/15911462/50536209-353e2600-0b52-11e9-92c1-68e7a862a2c4.png)
