### PR TITLE
Fixed VuePress Algolia link

### DIFF
--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -23,7 +23,7 @@ to the list, get [in touch with us][10]. We'd be happy to help.
 [1]: https://docusaurus.io/
 [2]: https://docusaurus.io/docs/en/search#docsNav
 [3]: https://vuepress.vuejs.org/
-[4]: https://vuepress.vuejs.org/theme/default-theme-config.html#search-box
+[4]: https://vuepress.vuejs.org/default-theme-config/#search-box
 [5]: https://docs.gitbook.com/
 [6]: http://pkgdown.r-lib.org/index.html
 [7]: http://pkgdown.r-lib.org/articles/pkgdown.html#search


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

The current VuePress Algolia link currently goes to a 404 page. This simple PR just fixes the link.