### PR TITLE
hashRouter anchor

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -305,7 +305,7 @@ class DocSearch {
   static formatURL(hit) {
     const { url, anchor } = hit;
     if (url) {
-      const containsAnchor = url.indexOf('#') !== -1;
+      const containsAnchor = !!url.match(/#[^\/]/);
       if (containsAnchor) return url;
       else if (anchor) return `${hit.url}#${hit.anchor}`;
       return url;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

if a website handle route by HashRouter.  such as: [react-router](https://github.com/ReactTraining/react-router).  then the url will has char '#', but it isn`t mean an anchor link. so in search result, the anchor will not append in url

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
exclude the string like '#/*'.  if url has '#/', it will be recognized as a route, not an anchor.


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
