### PR TITLE
fix: search input a11y issue

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -80,6 +80,7 @@ class DocSearch {
       this.autocompleteOptions.cssClasses || {};
     this.autocompleteOptions.cssClasses.prefix =
       this.autocompleteOptions.cssClasses.prefix || 'ds';
+   this.autocompleteOptions.ariaLabel = this.autocompleteOptions.ariaLabel || $(this.input)[0].getAttribute('aria-label') || 'search input';
 
 
     this.isSimpleLayout = layout === 'simple';


### PR DESCRIPTION
**Summary**

#418 

The search input does not have `aria-label`. I have found the underlying cause, it is because we are not passing `ariaLabel` options to autocomplete.js
See https://github.com/algolia/autocomplete.js/#global-options

> `ariaLabel` - An optional string that will populate the aria-label attribute.

My implementation is
- Check autoCompleteOptions for `ariaLabel`
- Otherwise, check original input selector `aria-label`
- Otherwise, use `search input` as aria-label

**Test Plan**

Here is my input

```html
<input
  id="search_input_react"
  type="search"
  placeholder="Search"
  aria-label="This is my aria-label from endiliey"
/>
```

**Before**
No aria-label
![image](https://user-images.githubusercontent.com/17883920/57546387-3b110700-738f-11e9-9a91-096590ab6c25.png)

**After**
aria-label exist
<img width="932" alt="aria-label working" src="https://user-images.githubusercontent.com/17883920/57546406-406e5180-738f-11e9-89ba-6fb5f0b5ff87.PNG">


