### PR TITLE
fix: docsearch input should have aria-label (a11y)

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -80,8 +80,8 @@ class DocSearch {
       this.autocompleteOptions.cssClasses || {};
     this.autocompleteOptions.cssClasses.prefix =
       this.autocompleteOptions.cssClasses.prefix || 'ds';
-   this.autocompleteOptions.ariaLabel = this.autocompleteOptions.ariaLabel || $(this.input)[0].getAttribute('aria-label') || 'search input';
-
+    this.autocompleteOptions.ariaLabel = 
+      this.autocompleteOptions.ariaLabel || (this.input && this.input.attr("aria-label")) || "search input";
 
     this.isSimpleLayout = layout === 'simple';
 

--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -80,8 +80,9 @@ class DocSearch {
       this.autocompleteOptions.cssClasses || {};
     this.autocompleteOptions.cssClasses.prefix =
       this.autocompleteOptions.cssClasses.prefix || 'ds';
+    const inputAriaLabel = this.input && typeof this.input.attr === 'function' && this.input.attr('aria-label');
     this.autocompleteOptions.ariaLabel = 
-      this.autocompleteOptions.ariaLabel || (this.input && this.input.attr("aria-label")) || "search input";
+      this.autocompleteOptions.ariaLabel || inputAriaLabel || "search input";
 
     this.isSimpleLayout = layout === 'simple';
 

--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -80,6 +80,7 @@ class DocSearch {
       this.autocompleteOptions.cssClasses || {};
     this.autocompleteOptions.cssClasses.prefix =
       this.autocompleteOptions.cssClasses.prefix || 'ds';
+   this.autocompleteOptions.ariaLabel = this.autocompleteOptions.ariaLabel || $(this.input)[0].getAttribute('aria-label') || 'search input';
 
 
     this.isSimpleLayout = layout === 'simple';

--- a/src/lib/__tests__/DocSearch-test.js
+++ b/src/lib/__tests__/DocSearch-test.js
@@ -175,6 +175,7 @@ describe('DocSearch', () => {
         debug: false,
         cssClasses: { prefix: 'ds' },
         anOption: 44,
+        ariaLabel: 'search input',
       });
     });
     it('should instantiate algoliasearch with the correct values', () => {
@@ -217,6 +218,7 @@ describe('DocSearch', () => {
           anOption: '44',
           cssClasses: { prefix: 'ds' },
           debug: false,
+          ariaLabel: 'search input'
         })
       ).toBe(true);
     });


### PR DESCRIPTION
**Summary**

Attempt to continue work on https://github.com/algolia/docsearch/pull/679
Previously it was reverted because there is no safe getter 😭 

**Result**

aria-label exist
<img width="932" alt="aria-label working" src="https://user-images.githubusercontent.com/17883920/57546406-406e5180-738f-11e9-89ba-6fb5f0b5ff87.PNG">
