### PR TITLE
fix(templating): replace Hogan.js with ES6 literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   "dependencies": {
     "algoliasearch": "^3.24.5",
     "autocomplete.js": "0.36.0",
-    "hogan.js": "^3.0.2",
     "request": "^2.87.0",
     "stack-utils": "^1.0.1",
     "to-factory": "^1.0.0",

--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -1,4 +1,3 @@
-import Hogan from 'hogan.js';
 import algoliasearch from 'algoliasearch/lite';
 import autocomplete from 'autocomplete.js';
 import templates from './templates';
@@ -236,7 +235,7 @@ class DocSearch {
   }
 
   // Given a list of hits returned by the API, will reformat them to be used in
-  // a Hogan template
+  // a template
   static formatHits(receivedHits) {
     const clonedHits = utils.deepClone(receivedHits);
     const hits = clonedHits.map(hit => {
@@ -323,15 +322,11 @@ class DocSearch {
   }
 
   static getEmptyTemplate() {
-    return args => Hogan.compile(templates.empty).render(args);
+    return templates.empty;
   }
 
   static getSuggestionTemplate(isSimpleLayout) {
-    const stringTemplate = isSimpleLayout
-      ? templates.suggestionSimple
-      : templates.suggestion;
-    const template = Hogan.compile(stringTemplate);
-    return suggestion => template.render(suggestion);
+    return isSimpleLayout ? templates.suggestionSimple : templates.suggestion;
   }
 
   handleSelected(input, event, suggestion, datasetNumber, context = {}) {

--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -80,9 +80,12 @@ class DocSearch {
       this.autocompleteOptions.cssClasses || {};
     this.autocompleteOptions.cssClasses.prefix =
       this.autocompleteOptions.cssClasses.prefix || 'ds';
-    const inputAriaLabel = this.input && typeof this.input.attr === 'function' && this.input.attr('aria-label');
-    this.autocompleteOptions.ariaLabel = 
-      this.autocompleteOptions.ariaLabel || inputAriaLabel || "search input";
+    const inputAriaLabel =
+      this.input &&
+      typeof this.input.attr === 'function' &&
+      this.input.attr('aria-label');
+    this.autocompleteOptions.ariaLabel =
+      this.autocompleteOptions.ariaLabel || inputAriaLabel || 'search input';
 
     this.isSimpleLayout = layout === 'simple';
 
@@ -142,9 +145,7 @@ class DocSearch {
 
     if (typeof args.inputSelector !== 'string') {
       throw new Error(
-        `Error: inputSelector:${
-          args.inputSelector
-        }  must be a string. Each selector must match only one element and separated by ','`
+        `Error: inputSelector:${args.inputSelector}  must be a string. Each selector must match only one element and separated by ','`
       );
     }
 
@@ -219,8 +220,11 @@ class DocSearch {
           },
         ])
         .then(data => {
-          if (this.queryDataCallback && typeof this.queryDataCallback == "function") {
-            this.queryDataCallback(data)
+          if (
+            this.queryDataCallback &&
+            typeof this.queryDataCallback === 'function'
+          ) {
+            this.queryDataCallback(data);
           }
           let hits = data.results[0].hits;
           if (transformData) {

--- a/src/lib/__tests__/DocSearch-test.js
+++ b/src/lib/__tests__/DocSearch-test.js
@@ -218,7 +218,7 @@ describe('DocSearch', () => {
           anOption: '44',
           cssClasses: { prefix: 'ds' },
           debug: false,
-          ariaLabel: 'search input'
+          ariaLabel: 'search input',
         })
       ).toBe(true);
     });

--- a/src/lib/__tests__/DocSearch-test.js
+++ b/src/lib/__tests__/DocSearch-test.js
@@ -1176,15 +1176,6 @@ describe('DocSearch', () => {
   });
 
   describe('getSuggestionTemplate', () => {
-    beforeEach(() => {
-      const templates = {
-        suggestion: '<div></div>',
-      };
-      DocSearch.__Rewire__('templates', templates);
-    });
-    afterEach(() => {
-      DocSearch.__ResetDependency__('templates');
-    });
     it('should return a function', () => {
       // Given
 
@@ -1193,38 +1184,6 @@ describe('DocSearch', () => {
 
       // Then
       expect(actual).toBeInstanceOf(Function);
-    });
-    describe('returned function', () => {
-      let Hogan;
-      let render;
-      beforeEach(() => {
-        render = sinon.spy();
-        Hogan = {
-          compile: sinon.stub().returns({ render }),
-        };
-        DocSearch.__Rewire__('Hogan', Hogan);
-      });
-      it('should compile the suggestion template', () => {
-        // Given
-
-        // When
-        DocSearch.getSuggestionTemplate();
-
-        // Then
-        expect(Hogan.compile.calledOnce).toBe(true);
-        expect(Hogan.compile.calledWith('<div></div>')).toBe(true);
-      });
-      it('should call render on a Hogan template', () => {
-        // Given
-        const actual = DocSearch.getSuggestionTemplate();
-
-        // When
-        actual({ foo: 'bar' });
-
-        // Then
-        expect(render.calledOnce).toBe(true);
-        expect(render.args[0][0]).toEqual({ foo: 'bar' });
-      });
     });
   });
 });

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -5,87 +5,109 @@ const footerPrefix = `${prefix}-footer`;
 /* eslint-disable max-len */
 
 const templates = {
-  suggestion: `
+  suggestion(s) {
+    return `
   <a class="${suggestionPrefix}
-    {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}
-    {{#isSubCategoryHeader}}${suggestionPrefix}__secondary{{/isSubCategoryHeader}}
+    ${s.isCategoryHeader ? `${suggestionPrefix}__main` : ''}
+    ${s.isSubCategoryHeader ? `${suggestionPrefix}__secondary` : ''}
     "
     aria-label="Link to the result"
-    href="{{{url}}}"
+    href="${s.url}"
     >
     <div class="${suggestionPrefix}--category-header">
-        <span class="${suggestionPrefix}--category-header-lvl0">{{{category}}}</span>
+        <span class="${suggestionPrefix}--category-header-lvl0">
+          ${s.category}
+        </span>
     </div>
     <div class="${suggestionPrefix}--wrapper">
       <div class="${suggestionPrefix}--subcategory-column">
-        <span class="${suggestionPrefix}--subcategory-column-text">{{{subcategory}}}</span>
+        <span class="${suggestionPrefix}--subcategory-column-text">
+          ${s.subcategory}
+        </span>
       </div>
-      {{#isTextOrSubcategoryNonEmpty}}
-      <div class="${suggestionPrefix}--content">
-        <div class="${suggestionPrefix}--subcategory-inline">{{{subcategory}}}</div>
-        <div class="${suggestionPrefix}--title">{{{title}}}</div>
-        {{#text}}<div class="${suggestionPrefix}--text">{{{text}}}</div>{{/text}}
-      </div>
-      {{/isTextOrSubcategoryNonEmpty}}
+      ${
+        s.isTextOrSubcategoryNonEmpty
+          ? `
+        <div class="${suggestionPrefix}--content">
+          <div class="${suggestionPrefix}--subcategory-inline">
+            ${s.subcategory}
+          </div>
+          <div class="${suggestionPrefix}--title">${s.title}</div>
+          ${
+            s.text
+              ? `<div class="${suggestionPrefix}--text">${s.text}</div>`
+              : ''
+          }
+        </div>`
+          : ''
+      }
     </div>
   </a>
-  `,
-  suggestionSimple: `
+  `;
+  },
+  suggestionSimple(suggestion) {
+    return `
   <div class="${suggestionPrefix}
-    {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}
-    {{#isSubCategoryHeader}}${suggestionPrefix}__secondary{{/isSubCategoryHeader}}
+    ${suggestion.isCategoryHeader ? `${suggestionPrefix}__main` : ''}
+    ${suggestion.isSubCategoryHeader ? `${suggestionPrefix}__secondary` : ''}
     suggestion-layout-simple
   ">
     <div class="${suggestionPrefix}--category-header">
-        {{^isLvl0}}
-        <span class="${suggestionPrefix}--category-header-lvl0 ${suggestionPrefix}--category-header-item">{{{category}}}</span>
-          {{^isLvl1}}
-          {{^isLvl1EmptyOrDuplicate}}
-          <span class="${suggestionPrefix}--category-header-lvl1 ${suggestionPrefix}--category-header-item">
-              {{{subcategory}}}
-          </span>
-          {{/isLvl1EmptyOrDuplicate}}
-          {{/isLvl1}}
-        {{/isLvl0}}
+        ${
+          !suggestion.isLvl0
+            ? `
+            <span class="${suggestionPrefix}--category-header-lvl0 ${suggestionPrefix}--category-header-item">
+                ${suggestion.category}
+            </span>
+            ${
+              !suggestion.isLvl1 && !suggestion.isLvl1EmptyOrDuplicate
+                ? `
+            <span class="${suggestionPrefix}--category-header-lvl1 ${suggestionPrefix}--category-header-item">
+                ${suggestion.subcategory}
+            </span>`
+                : ''
+            }`
+            : ''
+        }
         <div class="${suggestionPrefix}--title ${suggestionPrefix}--category-header-item">
-            {{#isLvl2}}
-                {{{title}}}
-            {{/isLvl2}}
-            {{#isLvl1}}
-                {{{subcategory}}}
-            {{/isLvl1}}
-            {{#isLvl0}}
-                {{{category}}}
-            {{/isLvl0}}
+            ${suggestion.isLvl2 ? suggestion.title : ''}
+            ${suggestion.isLvl1 ? suggestion.subcategory : ''}
+            ${suggestion.isLvl0 ? suggestion.category : ''}
         </div>
     </div>
     <div class="${suggestionPrefix}--wrapper">
-      {{#text}}
+      ${
+        suggestion.text
+          ? `
       <div class="${suggestionPrefix}--content">
-        <div class="${suggestionPrefix}--text">{{{text}}}</div>
-      </div>
-      {{/text}}
+        <div class="${suggestionPrefix}--text">${suggestion.text}</div>
+      </div>`
+          : ''
+      }
     </div>
   </div>
-  `,
+  `;
+  },
   footer: `
     <div class="${footerPrefix}">
       Search by <a class="${footerPrefix}--logo" href="https://www.algolia.com/docsearch">Algolia</a>
     </div>
   `,
-  empty: `
+  empty(args) {
+    return `
   <div class="${suggestionPrefix}">
     <div class="${suggestionPrefix}--wrapper">
         <div class="${suggestionPrefix}--content ${suggestionPrefix}--no-results">
             <div class="${suggestionPrefix}--title">
                 <div class="${suggestionPrefix}--text">
-                    No results found for query <b>"{{query}}"</b>
+                    No results found for query <b>"${args.query}"</b>
                 </div>
             </div>
         </div>
     </div>
   </div>
-  `,
+  `;
+  },
   searchBox: `
   <form novalidate="novalidate" onsubmit="return false;" class="searchbox">
     <div role="search" class="searchbox__wrapper">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4293,14 +4293,6 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hogan.js@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
-  integrity sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=
-  dependencies:
-    mkdirp "0.3.0"
-    nopt "1.0.10"
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -6207,11 +6199,6 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
-  integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
-
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -6468,13 +6455,6 @@ node-sass@4.12.0:
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
-
-nopt@1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
-  dependencies:
-    abbrev "1"
 
 "nopt@2 || 3", nopt@3.x:
   version "3.0.6"


### PR DESCRIPTION
**Summary**
Hogan.js uses Function objects, which violates CSP policies which do not
add the `unsafe-eval` directive. Given the relatively minor use in the
codebase, replace with ES6 literals and remove the dependency

- Replace Hogan with direct interpolation of data into string template
- Rework/remove tests that make reference to Hogan.js, since not used
- Remove Hogan.js from dependencies

See algolia/instantsearch.js#2868 for further information

Inspect bcc440a for the actual changes - de-linting/prettier was run on affected files before changes committed

**Result**
Tested on local machine. Note the lack of references to Hogan

![image](https://user-images.githubusercontent.com/10572368/62195032-b04c1100-b3ad-11e9-8f5e-6ae458bd9411.png)
