### PR TITLE
chore: add caret to some dependencies

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -23,7 +23,7 @@ module.exports = {
       `yarn workspace docsearch-renderer-downshift add docsearch-types@^${version}`
     );
     exec(`yarn workspace docsearch.js add docsearch-core@^${version}`);
-    exec(`yarn workspace docsearch.js add renderer-downshift@^${version}`);
+    exec(`yarn workspace docsearch.js add docsearch-renderer-downshift@^${version}`);
     exec(`yarn workspace docsearch.js add docsearch-types@^${version}`);
 
     // update lerna.json

--- a/ship.config.js
+++ b/ship.config.js
@@ -12,18 +12,19 @@ module.exports = {
     packagesToPublish: ['packages/*'],
   },
   versionUpdated: ({ version, dir, exec }) => {
-    const update = (package, dependency) =>
-      exec(`yarn workspace ${package} add ${dependency}@${version}`);
-
     // update internal dependencies
-    update('vanilla-example', 'docsearch-theme-light');
-    update('vanilla-example', 'docsearch.js');
-    update('docsearch-core', 'docsearch-types');
-    update('docsearch-renderer-downshift', 'docsearch-core');
-    update('docsearch-renderer-downshift', 'docsearch-types');
-    update('docsearch.js', 'docsearch-core');
-    update('docsearch.js', 'docsearch-renderer-downshift');
-    update('docsearch.js', 'docsearch-types');
+    exec(`yarn workspace vanilla-example add docsearch-theme-light@${version}`);
+    exec(`yarn workspace vanilla-example add docsearch.js@${version}`);
+    exec(`yarn workspace docsearch-core add docsearch-types@^${version}`);
+    exec(
+      `yarn workspace docsearch-renderer-downshift add docsearch-core@^${version}`
+    );
+    exec(
+      `yarn workspace docsearch-renderer-downshift add docsearch-types@^${version}`
+    );
+    exec(`yarn workspace docsearch.js add docsearch-core@^${version}`);
+    exec(`yarn workspace docsearch.js add renderer-downshift@^${version}`);
+    exec(`yarn workspace docsearch.js add docsearch-types@^${version}`);
 
     // update lerna.json
     const lernaConfigPath = path.resolve(dir, 'lerna.json');


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Some of the internal dependencies used to have "caret" but while I was adding `ship.js`, I accidentally [removed it](https://github.com/algolia/docsearch/commit/38a9c8e8109f5c74cf116a64c777fc06f79fb784#diff-e07e93c2309dadc70fc37e6b22ff2e04L31-L32).
This PR brings it back.