### PR TITLE
Fix circle.io logo caption to CircleCI

### DIFF
--- a/docs/src/_layouts/homepage.pug
+++ b/docs/src/_layouts/homepage.pug
@@ -31,8 +31,8 @@ block content
               img(src="assets/logos/bootstrap.jpg", alt="DocSearch + Bootstrap", width=60)
               .glide__caption Bootstrap
             .glide__slide
-              img(src="assets/logos/circleio.jpg", alt="DocSearch + Circle.io", width=60)
-              .glide__caption Circle.io
+              img(src="assets/logos/circleio.jpg", alt="DocSearch + CircleCI", width=60)
+              .glide__caption CircleCI
             .glide__slide
               img(src="assets/logos/electron.jpg", alt="DocSearch + Electron", width=60)
               .glide__caption Electron


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The CircleCI logo is incorrectly labelled as "circle.io" - this PR changes the `alt` attribute and caption to `CircleCI`, although leaves the image name as-is.


**Result**

Glide now reads "CircleCI" as it should