### PR TITLE
chore: update shipjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-terser": "5.1.0",
-    "shipjs": "0.5.1",
+    "shipjs": "0.8.0",
     "typescript": "3.5.2"
   }
 }

--- a/ship.config.js
+++ b/ship.config.js
@@ -7,7 +7,7 @@ module.exports = {
     toSameBranch: ['next'],
   },
   monorepo: {
-    readVersionFrom: 'lerna.json',
+    mainVersionFile: 'lerna.json',
     packagesToBump: ['packages/*'],
     packagesToPublish: ['packages/*'],
   },
@@ -23,16 +23,10 @@ module.exports = {
       `yarn workspace docsearch-renderer-downshift add docsearch-types@^${version}`
     );
     exec(`yarn workspace docsearch.js add docsearch-core@^${version}`);
-    exec(`yarn workspace docsearch.js add docsearch-renderer-downshift@^${version}`);
+    exec(
+      `yarn workspace docsearch.js add docsearch-renderer-downshift@^${version}`
+    );
     exec(`yarn workspace docsearch.js add docsearch-types@^${version}`);
-
-    // update lerna.json
-    const lernaConfigPath = path.resolve(dir, 'lerna.json');
-    const lernaConfig = {
-      ...JSON.parse(fs.readFileSync(lernaConfigPath)),
-      version,
-    };
-    fs.writeFileSync(lernaConfigPath, JSON.stringify(lernaConfig, null, 2));
 
     // update version.ts
     fs.writeFileSync(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR updates the version of Ship.js and its configuration file.

`monorepo.readVersionFrom` has been renamed to `monorepo.mainVersionFile`.
And its functionality has changed a little bit, which is we don't need to update the version of `lerna.json` any more.

**Result**

It works the same.