### PR TITLE
Fix broken link to VuePress and Pkgdown integration docs

### DIFF
--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -26,7 +26,7 @@ If you're a maintaining a similar tool and wants us to add you to the list, get
 [4]: https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-docsearch
 [5]: https://docs.gitbook.com/
 [6]: https://pkgdown.r-lib.org/
-[7]: https://pkgdown.r-lib.org/articles/pkgdown.html?q=search#docsearch-indexing
+[7]: https://pkgdown.r-lib.org/articles/search.html
 [8]: https://larecipe.binarytorch.com.my/docs/1.3/overview
 [9]: https://larecipe.binarytorch.com.my/docs/1.3/configurations#search
 [10]: mailto:docsearch@algolia.com

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -23,7 +23,7 @@ If you're a maintaining a similar tool and wants us to add you to the list, get
 [1]: https://docusaurus.io/
 [2]: https://docusaurus.io/docs/en/search#docsNav
 [3]: https://vuepress.vuejs.org/
-[4]: https://vuepress.vuejs.org/default-theme-config/#search-box
+[4]: https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-docsearch
 [5]: https://docs.gitbook.com/
 [6]: https://pkgdown.r-lib.org/
 [7]: https://pkgdown.r-lib.org/articles/pkgdown.html?q=search#docsearch-indexing


### PR DESCRIPTION
Just fixing a couple of broken links I found in the docs 🙂