### PR TITLE
Fix HTML element syntax in docs

### DIFF
--- a/docs/src/config-file.md
+++ b/docs/src/config-file.md
@@ -54,7 +54,7 @@ different value. This variable can be set in the .env file alongside
 ## `start_urls`
 
 This array contains the list of URLs that will be used to start crawling your
-website. The crawler will recursively follow any links (`<a/>` tags) from those
+website. The crawler will recursively follow any links (`<a>` tags) from those
 pages. It will not follow links that are on another domain and never follow
 links matching `stop_urls`.
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -131,7 +131,7 @@ that some pages are missing from the search. The possible reasons for that are:
 - Makes sure you are not filtering on the search by wrongly using
   `facetFilters`. [See here for more details][11].
 - Make sure that an other indexed page references the page missing thanks to a
-  hyperlink tag `<a/>`.
+  hyperlink tag `<a>`.
 - Make sure you are [providing a compliant sitemap from the configuration][12]
   and that it references the page.
 

--- a/docs/src/required-configuration.md
+++ b/docs/src/required-configuration.md
@@ -63,7 +63,7 @@ These classes can not involve any style changes. These dedicated classes will
 help us to create a great learn as you type experience from your documentation.
 
 - Add a static class `DocSearch-content` to the main container of your textual
-  content. Most of the time, this tag `<main/>` or an `<article/>` HTML element.
+  content. Most of the time, this tag `<main>` or an `<article>` HTML element.
 
 - Every searchable `lvl` elements outside this main documentation container (for
   instance in a sidebar) must be `global` selectors. They will be globally
@@ -81,8 +81,8 @@ help us to create a great learn as you type experience from your documentation.
   the exact place of the matching elements. These attributes defined the right
   anchor to use.
 
-- Every textual element (selector `text`) must be wrapped in a tag `<p/>` or
-  `<li/>`. This content must be atomic and split into small entities. Be careful
+- Every textual element (selector `text`) must be wrapped in a tag `<p>` or
+  `<li>`. This content must be atomic and split into small entities. Be careful
   to never nest one matching elements into another one, it will create
   duplicates.
 


### PR DESCRIPTION
**Summary**

As above. [Best practice](https://developer.mozilla.org/en-US/docs/Web/HTML/Element) is to portray HTML tags without a forward slash `/`,
especially when the tags aren't self-closing.