### PR TITLE
fix(homepage): make logo inline block

### DIFF
--- a/docs/src/_layouts/homepage.pug
+++ b/docs/src/_layouts/homepage.pug
@@ -271,7 +271,7 @@ block content
         span.block.hidden.sm_inline.mx-1 •
         span.block.sm_inline.whitespace-no-wrap Designed and built by
           a(href="https://www.algolia.com/")
-            img.align-top.pl-05(src="assets/algolia-logo.svg", alt="search by Algolia", width=100)
+            img.align-top.pl-05.inline-block(src="assets/algolia-logo.svg", alt="search by Algolia", width=100)
       ul.inline-block.text-2.mb-3
         li.p-1.w-100.md_w-auto.inline-block
           a(href="https://github.com/algolia/docsearch/blob/master/LICENSE") Code licensed under MIT


### PR DESCRIPTION
before|after
---|---
<img width="1440" alt="Screenshot 2019-12-24 at 14 55 27" src="https://user-images.githubusercontent.com/6270048/71415791-d83e5880-265d-11ea-8bb3-10c838d0e28f.png"> | <img width="843" alt="Screenshot 2019-12-24 at 14 56 09" src="https://user-images.githubusercontent.com/6270048/71415792-d8d6ef00-265d-11ea-81d8-5108b6c3b10a.png">
