### PR TITLE
update Bootstrap docs link to current version

### DIFF
--- a/docs/src/_layouts/homepage.pug
+++ b/docs/src/_layouts/homepage.pug
@@ -222,7 +222,7 @@ block content
         |a look.
       .flex.flrw
         .fln.w-100.sm_w-50.md_w-25.p-1.flex.flrnw
-          a.c-card.custom-demo.fla.flex.flcnw.p-05(href='http://getbootstrap.com/docs/4.1/getting-started/introduction/')
+          a.c-card.custom-demo.fla.flex.flcnw.p-05(href='http://getbootstrap.com/docs/4.4/getting-started/introduction/')
             .fln.flc.relative.text-0.max-w-5.m-auto
               img(src='assets/demos/example-bootstrap.gif', alt='Bootstrap')
             .fln.pt-1.flex.flrnw.flc


### PR DESCRIPTION
**Summary**

The link used at the moment goes to an older version.

**Result**

View link at: https://getbootstrap.com/docs/4.4/getting-started/introduction/