### PR TITLE
Include the result name in the aria label

### DIFF
--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -10,7 +10,7 @@ const templates = {
     {{#isCategoryHeader}}${suggestionPrefix}__main{{/isCategoryHeader}}
     {{#isSubCategoryHeader}}${suggestionPrefix}__secondary{{/isSubCategoryHeader}}
     "
-    aria-label="Link to the result"
+    aria-label="Link to the result: {{{subcategory}}}"
     href="{{{url}}}"
     >
     <div class="${suggestionPrefix}--category-header">


### PR DESCRIPTION
**Summary**

When you use a screen reader with the search box, you only hear "Link to the result" for each result - which means you don't know what the result is. This adds the text of the result to the label so that folks can hear it.

