### PR TITLE
docs(readme): add link to new DocSearch website

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Check out our [website][8] for a complete explanation and documentation.
 
 ## Related projects
 
-DocSearch is made of 3 repositories:
+DocSearch is made of 4 repositories:
 
-- [algolia/docsearch][10] contains the `docsearch.js` code source and the
+- [algolia/docsearch][10] contains the `docsearch.js` code source 
+- [algolia/docsearch-website](https://github.com/algolia/docsearch-website) contains the
   documentation website.
 - [algolia/docsearch-configs][11] contains the JSON files representing all the
   configs for all the documentations DocSearch is powering


### PR DESCRIPTION


**Summary**
i was looking for the source code for the docsearch website and couldnt find it, realized the readme was out of date
