### PR TITLE
fix(css): remove `sideEffects` package field

### DIFF
--- a/packages/docsearch-css/package.json
+++ b/packages/docsearch-css/package.json
@@ -9,7 +9,6 @@
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"
   },
-  "sideEffects": false,
   "files": [
     "dist/"
   ],

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -9,7 +9,6 @@
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"
   },
-  "sideEffects": false,
   "files": [
     "dist/",
     "style/",

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -9,6 +9,7 @@
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"
   },
+  "sideEffects": false,
   "files": [
     "dist/",
     "style/",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

When using `@docsearch/css` with webpack like below:

```
import '@docsearch/css'
```
[`sideEffects: false`](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) would cause webpack to prune all the css.

I have to work around with a hack like this:

```
import styles from '@docsearch/css';
// do something with `styles` to keep it around.
```

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
