### PR TITLE
fix: improve contrast ratio for button placeholder

### DIFF
--- a/packages/docsearch-css/src/_variables.css
+++ b/packages/docsearch-css/src/_variables.css
@@ -6,7 +6,7 @@
   --docsearch-spacing: 12px;
   --docsearch-icon-stroke-width: 1.4;
   --docsearch-highlight-color: var(--docsearch-primary-color);
-  --docsearch-muted-color: rgb(150, 159, 175);
+  --docsearch-muted-color: rgb(70, 78, 93);
   --docsearch-container-background: rgba(101, 108, 133, 0.8);
   --docsearch-logo-color: rgba(84, 104, 255);
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Currently there is a11y error in light mode related to insufficient color contrast in the placeholder button.

![image](https://user-images.githubusercontent.com/4408379/106459877-94926100-64a3-11eb-8517-4c01341786d6.png)

**Result**

Checker: https://webaim.org/resources/contrastchecker/

| Before   | After    |
| -------- | -------- |
| ![2021-02-01_15-30](https://user-images.githubusercontent.com/4408379/106459815-7a588300-64a3-11eb-860d-b01cb6b0bb45.png) | ![2021-02-01_15-32](https://user-images.githubusercontent.com/4408379/106459806-788ebf80-64a3-11eb-9a26-c018014fe4c5.png) |

cc @francoischalifour 

