### PR TITLE
fix: use spans inside button tag instead of divs

### DIFF
--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -6,7 +6,6 @@
   color: var(--docsearch-muted-color);
   cursor: pointer;
   display: flex;
-  font-weight: 500;
   height: 36px;
   justify-content: space-between;
   margin: 0 0 0 16px;

--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -6,6 +6,7 @@
   color: var(--docsearch-muted-color);
   cursor: pointer;
   display: flex;
+  font-weight: 500;
   height: 36px;
   justify-content: space-between;
   margin: 0 0 0 16px;

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -30,20 +30,26 @@ export const DocSearchButton = React.forwardRef<
   }, []);
 
   return (
-    <div className="DocSearch DocSearch-Button" {...props} ref={ref}>
-      <div className="DocSearch-Button-Container">
+    <button
+      type="button"
+      className="DocSearch DocSearch-Button"
+      aria-label="Search"
+      {...props}
+      ref={ref}
+    >
+      <span className="DocSearch-Button-Container">
         <SearchIcon />
         <span className="DocSearch-Button-Placeholder">Search</span>
-      </div>
+      </span>
 
       {key !== null ? (
-        <div className="DocSearch-Button-Keys">
+        <span className="DocSearch-Button-Keys">
           <span className="DocSearch-Button-Key">
             {key === ACTION_KEY_DEFAULT ? <ControlKeyIcon /> : key}
           </span>
           <span className="DocSearch-Button-Key">K</span>
-        </div>
+        </span>
       ) : null}
-    </div>
+    </button>
   );
 });

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -30,13 +30,7 @@ export const DocSearchButton = React.forwardRef<
   }, []);
 
   return (
-    <button
-      type="button"
-      className="DocSearch DocSearch-Button"
-      aria-label="Search"
-      {...props}
-      ref={ref}
-    >
+    <div className="DocSearch DocSearch-Button" {...props} ref={ref}>
       <div className="DocSearch-Button-Container">
         <SearchIcon />
         <span className="DocSearch-Button-Placeholder">Search</span>
@@ -50,6 +44,6 @@ export const DocSearchButton = React.forwardRef<
           <span className="DocSearch-Button-Key">K</span>
         </div>
       ) : null}
-    </button>
+    </div>
   );
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

At the moment there is the following HTML issue related to the incorrect use of the `button` tag:

```
Element “div” not allowed as child of element “button” in this context. (Suppressing further errors from this subtree.)
```

I suggest replacing the `button` with a regular `div` element.

**Result**

According to the validator (https://validator.w3.org/nu/#textarea), the error has been fixed.

cc @francoischalifour 