### PR TITLE
feat: add `translations` prop to search button

### DIFF
--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -3,10 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { ControlKeyIcon } from './icons/ControlKeyIcon';
 import { SearchIcon } from './icons/SearchIcon';
 
-export type DocSearchButtonProps = React.DetailedHTMLProps<
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
-  HTMLButtonElement
->;
+export type DocSearchButtonProps = React.ComponentProps<'button'> & {placeholderLabel?: string}
 
 const ACTION_KEY_DEFAULT = 'Ctrl' as const;
 const ACTION_KEY_APPLE = '⌘' as const;
@@ -18,7 +15,7 @@ function isAppleDevice() {
 export const DocSearchButton = React.forwardRef<
   HTMLButtonElement,
   DocSearchButtonProps
->((props, ref) => {
+>(({placeholderLabel = "Search", ...props}, ref) => {
   const [key, setKey] = useState<
     typeof ACTION_KEY_APPLE | typeof ACTION_KEY_DEFAULT | null
   >(null);
@@ -39,7 +36,7 @@ export const DocSearchButton = React.forwardRef<
     >
       <span className="DocSearch-Button-Container">
         <SearchIcon />
-        <span className="DocSearch-Button-Placeholder">Search</span>
+        <span className="DocSearch-Button-Placeholder">{placeholderLabel}</span>
       </span>
 
       {key !== null ? (

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -3,7 +3,12 @@ import React, { useEffect, useState } from 'react';
 import { ControlKeyIcon } from './icons/ControlKeyIcon';
 import { SearchIcon } from './icons/SearchIcon';
 
-export type DocSearchButtonProps = React.ComponentProps<'button'> & {placeholderLabel?: string}
+type Translations = Partial<{
+  buttonText: string;
+  buttonAriaLabel: string;
+}>
+
+export type DocSearchButtonProps = React.ComponentProps<'button'> & {translations?: Translations}
 
 const ACTION_KEY_DEFAULT = 'Ctrl' as const;
 const ACTION_KEY_APPLE = '⌘' as const;
@@ -15,7 +20,12 @@ function isAppleDevice() {
 export const DocSearchButton = React.forwardRef<
   HTMLButtonElement,
   DocSearchButtonProps
->(({placeholderLabel = "Search", ...props}, ref) => {
+>(({translations = {}, ...props}, ref) => {
+  const {
+    buttonText = "Search",
+    buttonAriaLabel = "Search"
+  } = translations;
+  
   const [key, setKey] = useState<
     typeof ACTION_KEY_APPLE | typeof ACTION_KEY_DEFAULT | null
   >(null);
@@ -30,13 +40,13 @@ export const DocSearchButton = React.forwardRef<
     <button
       type="button"
       className="DocSearch DocSearch-Button"
-      aria-label="Search"
+      aria-label={buttonAriaLabel}
       {...props}
       ref={ref}
     >
       <span className="DocSearch-Button-Container">
         <SearchIcon />
-        <span className="DocSearch-Button-Placeholder">{placeholderLabel}</span>
+        <span className="DocSearch-Button-Placeholder">{buttonText}</span>
       </span>
 
       {key !== null ? (


### PR DESCRIPTION


**Summary**

Ability to translate DocSearch placeholder label, a low hanging fruit as it's the most visible one, but there are probably other labels to allow translating (including aria attributes).

This is a pseudo code suggestion, not sure it works yet :) 

You may be happy to know about `ComponentProps` in TS :) 

**Result**

![image](https://user-images.githubusercontent.com/749374/106782852-f04b1e80-664a-11eb-9c6e-2b677b9327de.png)

