### PR TITLE
fix(results): unescaped lvl0

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,11 +6,11 @@
     },
     {
       "path": "packages/docsearch-react/dist/umd/index.js",
-      "maxSize": "18.2 kB"
+      "maxSize": "18.3 kB"
     },
     {
       "path": "packages/docsearch-js/dist/umd/index.js",
-      "maxSize": "25.8 kB"
+      "maxSize": "25.9 kB"
     }
   ]
 }

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -20,7 +20,7 @@ import {
 import { useSearchClient } from './useSearchClient';
 import { useTouchEvents } from './useTouchEvents';
 import { useTrapFocus } from './useTrapFocus';
-import { groupBy, identity, noop } from './utils';
+import { groupBy, identity, noop, unescape } from './utils';
 
 export interface DocSearchModalProps extends DocSearchProps {
   initialScrollY: number;
@@ -224,7 +224,9 @@ export function DocSearchModal({
             .then((results) => {
               const hits = results[0].hits;
               const nbHits: number = results[0].nbHits;
-              const sources = groupBy(hits, (hit) => hit.hierarchy.lvl0);
+              const sources = groupBy(hits, (hit) =>
+                unescape(hit.hierarchy.lvl0)
+              );
 
               // We store the `lvl0`s to display them as search suggestions
               // in the “no results“ screen.

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -20,7 +20,7 @@ import {
 import { useSearchClient } from './useSearchClient';
 import { useTouchEvents } from './useTouchEvents';
 import { useTrapFocus } from './useTrapFocus';
-import { groupBy, identity, noop, unescape } from './utils';
+import { groupBy, identity, noop, removeHighlightTags } from './utils';
 
 export interface DocSearchModalProps extends DocSearchProps {
   initialScrollY: number;
@@ -225,7 +225,7 @@ export function DocSearchModal({
               const hits = results[0].hits;
               const nbHits: number = results[0].nbHits;
               const sources = groupBy(hits, (hit) =>
-                unescape(hit.hierarchy.lvl0)
+                removeHighlightTags(hit.hierarchy.lvl0)
               );
 
               // We store the `lvl0`s to display them as search suggestions

--- a/packages/docsearch-react/src/ResultsScreen.tsx
+++ b/packages/docsearch-react/src/ResultsScreen.tsx
@@ -17,7 +17,7 @@ export function ResultsScreen(props: ResultsScreenProps) {
         }
 
         const title = removeHighlightTags(
-          collection.items[0]._highlightResult.hierarchy_camel[0].lvl0.value
+          collection.items[0]._highlightResult.hierarchy.lvl0.value
         );
 
         return (

--- a/packages/docsearch-react/src/ResultsScreen.tsx
+++ b/packages/docsearch-react/src/ResultsScreen.tsx
@@ -4,7 +4,7 @@ import { SelectIcon, SourceIcon } from './icons';
 import { Results } from './Results';
 import { ScreenStateProps } from './ScreenState';
 import { InternalDocSearchHit } from './types';
-import { unescape } from './utils';
+import { removeHighlightTags } from './utils';
 
 type ResultsScreenProps = ScreenStateProps<InternalDocSearchHit>;
 
@@ -16,7 +16,7 @@ export function ResultsScreen(props: ResultsScreenProps) {
           return null;
         }
 
-        const title = unescape(
+        const title = removeHighlightTags(
           collection.items[0]._highlightResult.hierarchy_camel[0].lvl0.value
         );
 

--- a/packages/docsearch-react/src/ResultsScreen.tsx
+++ b/packages/docsearch-react/src/ResultsScreen.tsx
@@ -4,6 +4,7 @@ import { SelectIcon, SourceIcon } from './icons';
 import { Results } from './Results';
 import { ScreenStateProps } from './ScreenState';
 import { InternalDocSearchHit } from './types';
+import { unescape } from './utils';
 
 type ResultsScreenProps = ScreenStateProps<InternalDocSearchHit>;
 
@@ -15,7 +16,9 @@ export function ResultsScreen(props: ResultsScreenProps) {
           return null;
         }
 
-        const title = collection.items[0].hierarchy.lvl0;
+        const title = unescape(
+          collection.items[0]._highlightResult.hierarchy_camel[0].lvl0.value
+        );
 
         return (
           <Results

--- a/packages/docsearch-react/src/utils/index.ts
+++ b/packages/docsearch-react/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './groupBy';
 export * from './identity';
 export * from './noop';
+export * from './unescape';

--- a/packages/docsearch-react/src/utils/index.ts
+++ b/packages/docsearch-react/src/utils/index.ts
@@ -1,4 +1,4 @@
 export * from './groupBy';
 export * from './identity';
 export * from './noop';
-export * from './unescape';
+export * from './removeHighlightTags';

--- a/packages/docsearch-react/src/utils/removeHighlightTags.ts
+++ b/packages/docsearch-react/src/utils/removeHighlightTags.ts
@@ -1,0 +1,8 @@
+const regexHighlightTags = /(<mark>|<\/mark>)/g;
+const regexHasHighlightTags = RegExp(regexHighlightTags.source);
+
+export function removeHighlightTags(value: string): string {
+  return value && regexHasHighlightTags.test(value)
+    ? value.replace(regexHighlightTags, '')
+    : value;
+}

--- a/packages/docsearch-react/src/utils/unescape.ts
+++ b/packages/docsearch-react/src/utils/unescape.ts
@@ -1,8 +1,0 @@
-const regexEscapedHtml = /(<mark>|<\/mark>)/g;
-const regexHasEscapedHtml = RegExp(regexEscapedHtml.source);
-
-export function unescape(value: string): string {
-  return value && regexHasEscapedHtml.test(value)
-    ? value.replace(regexEscapedHtml, '')
-    : value;
-}

--- a/packages/docsearch-react/src/utils/unescape.ts
+++ b/packages/docsearch-react/src/utils/unescape.ts
@@ -1,0 +1,8 @@
+const regexEscapedHtml = /(<mark>|<\/mark>)/g;
+const regexHasEscapedHtml = RegExp(regexEscapedHtml.source);
+
+export function unescape(value: string): string {
+  return value && regexHasEscapedHtml.test(value)
+    ? value.replace(regexEscapedHtml, '')
+    : value;
+}


### PR DESCRIPTION
**Summary**

In some cases, the hits returned by the engine can contain escaped characters. We now retrieve the `lvl0` from the `_highlightResults` (which are always unescaped) and remove the highlighting tags.

| before | after |
| --- | --- |
| ![Screenshot 2021-03-31 at 16 55 12](https://user-images.githubusercontent.com/20689156/113164960-e0624c00-9241-11eb-81cb-86cc0732c8de.png) |  ![Screenshot 2021-03-31 at 16 59 27](https://user-images.githubusercontent.com/20689156/113165744-76967200-9242-11eb-8edf-d2a9b9a4c7b1.png)|