### PR TITLE
fix(escapedResults): `_highlightResult` is undefined

### DIFF
--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -224,9 +224,7 @@ export function DocSearchModal({
             .then((results) => {
               const hits = results[0].hits;
               const nbHits: number = results[0].nbHits;
-              const sources = groupBy(hits, (hit) =>
-                removeHighlightTags(hit.hierarchy.lvl0)
-              );
+              const sources = groupBy(hits, (hit) => removeHighlightTags(hit));
 
               // We store the `lvl0`s to display them as search suggestions
               // in the “no results“ screen.

--- a/packages/docsearch-react/src/ResultsScreen.tsx
+++ b/packages/docsearch-react/src/ResultsScreen.tsx
@@ -16,9 +16,7 @@ export function ResultsScreen(props: ResultsScreenProps) {
           return null;
         }
 
-        const title = removeHighlightTags(
-          collection.items[0]._highlightResult.hierarchy.lvl0.value
-        );
+        const title = removeHighlightTags(collection.items[0]);
 
         return (
           <Results

--- a/packages/docsearch-react/src/utils/removeHighlightTags.ts
+++ b/packages/docsearch-react/src/utils/removeHighlightTags.ts
@@ -1,7 +1,23 @@
+import { DocSearchHit, InternalDocSearchHit } from './../types';
+
 const regexHighlightTags = /(<mark>|<\/mark>)/g;
 const regexHasHighlightTags = RegExp(regexHighlightTags.source);
 
-export function removeHighlightTags(value: string): string {
+export function removeHighlightTags(
+  hit: DocSearchHit | InternalDocSearchHit
+): string {
+  if (
+    !(hit as InternalDocSearchHit).__docsearch_parent &&
+    !hit._highlightResult
+  ) {
+    return hit.hierarchy.lvl0;
+  }
+
+  const { value } = hit._highlightResult
+    ? hit._highlightResult.hierarchy.lvl0
+    : (hit as InternalDocSearchHit).__docsearch_parent!._highlightResult
+        .hierarchy.lvl0;
+
   return value && regexHasHighlightTags.test(value)
     ? value.replace(regexHighlightTags, '')
     : value;


### PR DESCRIPTION
**Summary**

In https://github.com/algolia/docsearch/pull/1001, we introduced a new internal method to escape the  `hierarachy.lvl0` value from `_highlightResult`. When the hit is "linked" to his parent (image below), `_highlightResult` gets replaced by `__docsearch_parent` (which contains the actual hit).

![Screenshot 2021-04-13 at 13 34 34](https://user-images.githubusercontent.com/20689156/114547686-008d0480-9c5f-11eb-9168-e16e97957950.png)

