### PR TITLE
refactor(searchClient): use client `search` method

### DIFF
--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -173,35 +173,40 @@ export function DocSearchModal({
           }
 
           return searchClient
-            .initIndex(indexName)
-            .search<DocSearchHit>(query, {
-              attributesToRetrieve: [
-                'hierarchy.lvl0',
-                'hierarchy.lvl1',
-                'hierarchy.lvl2',
-                'hierarchy.lvl3',
-                'hierarchy.lvl4',
-                'hierarchy.lvl5',
-                'hierarchy.lvl6',
-                'content',
-                'type',
-                'url',
-              ],
-              attributesToSnippet: [
-                `hierarchy.lvl1:${snippetLength.current}`,
-                `hierarchy.lvl2:${snippetLength.current}`,
-                `hierarchy.lvl3:${snippetLength.current}`,
-                `hierarchy.lvl4:${snippetLength.current}`,
-                `hierarchy.lvl5:${snippetLength.current}`,
-                `hierarchy.lvl6:${snippetLength.current}`,
-                `content:${snippetLength.current}`,
-              ],
-              snippetEllipsisText: '…',
-              highlightPreTag: '<mark>',
-              highlightPostTag: '</mark>',
-              hitsPerPage: 20,
-              ...searchParameters,
-            })
+            .search<DocSearchHit>([
+              {
+                query,
+                indexName,
+                params: {
+                  attributesToRetrieve: [
+                    'hierarchy.lvl0',
+                    'hierarchy.lvl1',
+                    'hierarchy.lvl2',
+                    'hierarchy.lvl3',
+                    'hierarchy.lvl4',
+                    'hierarchy.lvl5',
+                    'hierarchy.lvl6',
+                    'content',
+                    'type',
+                    'url',
+                  ],
+                  attributesToSnippet: [
+                    `hierarchy.lvl1:${snippetLength.current}`,
+                    `hierarchy.lvl2:${snippetLength.current}`,
+                    `hierarchy.lvl3:${snippetLength.current}`,
+                    `hierarchy.lvl4:${snippetLength.current}`,
+                    `hierarchy.lvl5:${snippetLength.current}`,
+                    `hierarchy.lvl6:${snippetLength.current}`,
+                    `content:${snippetLength.current}`,
+                  ],
+                  snippetEllipsisText: '…',
+                  highlightPreTag: '<mark>',
+                  highlightPostTag: '</mark>',
+                  hitsPerPage: 20,
+                  ...searchParameters,
+                },
+              },
+            ])
             .catch((error) => {
               // The Algolia `RetryError` happens when all the servers have
               // failed, meaning that there's no chance the response comes
@@ -213,7 +218,8 @@ export function DocSearchModal({
 
               throw error;
             })
-            .then(({ hits, nbHits }) => {
+            .then(({ results }) => {
+              const { hits, nbHits } = results[0];
               const sources = groupBy(hits, (hit) => removeHighlightTags(hit));
 
               // We store the `lvl0`s to display them as search suggestions


### PR DESCRIPTION
**Summary**

We now use the multi-queries `search` method from the client which allows the user to override the method from `transformSearchClient`.

**Result**

The user can now override the `search` method, to debounce the search for example.

**Example**

[sandbox](https://codesandbox.io/s/docsearch-v3-debounced-search-gnx87)

**Issues**

- Fixes https://github.com/algolia/docsearch/issues/1018
- https://github.com/facebook/docusaurus/issues/5174