### PR TITLE
fix: eliminate keyboard shortcuts UI flash

### DIFF
--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -12,7 +12,6 @@
   margin: 0 0 0 16px;
   padding: 0 8px;
   user-select: none;
-  min-width: 155px;
 }
 
 .DocSearch-Button:hover,
@@ -63,10 +62,6 @@
 }
 
 @media (max-width: 750px) {
-  .DocSearch-Button {
-    min-width: auto;
-  }
-
   .DocSearch-Button-KeySeparator,
   .DocSearch-Button-Key {
     display: none;

--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -12,7 +12,7 @@
   margin: 0 0 0 16px;
   padding: 0 8px;
   user-select: none;
-  width: 155px;
+  min-width: 155px;
 }
 
 .DocSearch-Button:hover,
@@ -64,7 +64,7 @@
 
 @media (max-width: 750px) {
   .DocSearch-Button {
-    width: auto;
+    min-width: auto;
   }
 
   .DocSearch-Button-KeySeparator,

--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -12,6 +12,7 @@
   margin: 0 0 0 16px;
   padding: 0 8px;
   user-select: none;
+  width: 155px;
 }
 
 .DocSearch-Button:hover,
@@ -62,6 +63,10 @@
 }
 
 @media (max-width: 750px) {
+  .DocSearch-Button {
+    width: auto;
+  }
+
   .DocSearch-Button-KeySeparator,
   .DocSearch-Button-Key {
     display: none;

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { ControlKeyIcon } from './icons/ControlKeyIcon';
 import { SearchIcon } from './icons/SearchIcon';
@@ -25,15 +25,14 @@ export const DocSearchButton = React.forwardRef<
 >(({ translations = {}, ...props }, ref) => {
   const { buttonText = 'Search', buttonAriaLabel = 'Search' } = translations;
 
-  const [key, setKey] = useState<
+  const [key] = useState<
     typeof ACTION_KEY_APPLE | typeof ACTION_KEY_DEFAULT | null
-  >(null);
-
-  useEffect(() => {
+  >(() => {
     if (typeof navigator !== 'undefined') {
-      setKey(isAppleDevice() ? ACTION_KEY_APPLE : ACTION_KEY_DEFAULT);
+      return isAppleDevice() ? ACTION_KEY_APPLE : ACTION_KEY_DEFAULT;
     }
-  }, []);
+    return null;
+  });
 
   return (
     <button

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo } from 'react';
 
 import { ControlKeyIcon } from './icons/ControlKeyIcon';
 import { SearchIcon } from './icons/SearchIcon';
@@ -25,14 +25,14 @@ export const DocSearchButton = React.forwardRef<
 >(({ translations = {}, ...props }, ref) => {
   const { buttonText = 'Search', buttonAriaLabel = 'Search' } = translations;
 
-  const [key] = useState<
+  const key = useMemo<
     typeof ACTION_KEY_APPLE | typeof ACTION_KEY_DEFAULT | null
   >(() => {
     if (typeof navigator !== 'undefined') {
       return isAppleDevice() ? ACTION_KEY_APPLE : ACTION_KEY_DEFAULT;
     }
     return null;
-  });
+  }, []);
 
   return (
     <button


### PR DESCRIPTION
There's a flash of unstyled content regarding the search box:

https://user-images.githubusercontent.com/1091472/125940962-202531fe-58aa-40f5-af9c-fc775eb7c9bf.mov

You can check it on https://docsearch.algolia.com/

Setting a width would eliminate the problem, you can check it on https://webpack.js.org/ for how it looks.