### PR TITLE
fix(button): prevent container keys ui flash

### DIFF
--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -63,11 +63,8 @@
 }
 
 @media (max-width: 750px) {
-  .DocSearch-Button-KeySeparator,
-  .DocSearch-Button-Key {
-    display: none;
-  }
-
+  .DocSearch-Button-Keys,
+  .DocSearch-Button-Key,
   .DocSearch-Button-Placeholder {
     display: none;
   }

--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -43,6 +43,7 @@
 
 .DocSearch-Button-Keys {
   display: flex;
+  width: calc(2 * 20px + 2 * 0.4em);
 }
 
 .DocSearch-Button-Key {

--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -43,7 +43,7 @@
 
 .DocSearch-Button-Keys {
   display: flex;
-  width: calc(2 * 20px + 2 * 0.4em);
+  min-width: calc(2 * 20px + 2 * 0.4em);
 }
 
 .DocSearch-Button-Key {
@@ -64,7 +64,6 @@
 
 @media (max-width: 750px) {
   .DocSearch-Button-Keys,
-  .DocSearch-Button-Key,
   .DocSearch-Button-Placeholder {
     display: none;
   }

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { Fragment, useMemo } from 'react';
 
 import { ControlKeyIcon } from './icons/ControlKeyIcon';
 import { SearchIcon } from './icons/SearchIcon';
@@ -47,14 +47,16 @@ export const DocSearchButton = React.forwardRef<
         <span className="DocSearch-Button-Placeholder">{buttonText}</span>
       </span>
 
-      {key !== null && (
-        <span className="DocSearch-Button-Keys">
-          <span className="DocSearch-Button-Key">
-            {key === ACTION_KEY_DEFAULT ? <ControlKeyIcon /> : key}
-          </span>
-          <span className="DocSearch-Button-Key">K</span>
-        </span>
-      )}
+      <span className="DocSearch-Button-Keys">
+        {key !== null && (
+          <Fragment>
+            <span className="DocSearch-Button-Key">
+              {key === ACTION_KEY_DEFAULT ? <ControlKeyIcon /> : key}
+            </span>
+            <span className="DocSearch-Button-Key">K</span>
+          </Fragment>
+        )}
+      </span>
     </button>
   );
 });

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { ControlKeyIcon } from './icons/ControlKeyIcon';
 import { SearchIcon } from './icons/SearchIcon';
@@ -49,12 +49,12 @@ export const DocSearchButton = React.forwardRef<
 
       <span className="DocSearch-Button-Keys">
         {key !== null && (
-          <Fragment>
+          <>
             <span className="DocSearch-Button-Key">
               {key === ACTION_KEY_DEFAULT ? <ControlKeyIcon /> : key}
             </span>
             <span className="DocSearch-Button-Key">K</span>
-          </Fragment>
+          </>
         )}
       </span>
     </button>


### PR DESCRIPTION
_Follow up of https://github.com/algolia/docsearch/pull/1021_

**Summary**

This PR prevent the UI flash for server-side rendered websites. Since [the `key` value](https://github.com/algolia/docsearch/blob/f38276308a4e0ff140e4c1d4db1beced4f610068/packages/docsearch-react/src/DocSearchButton.tsx#L31-L33) is `null`, the `keys` container isn't rendered and therefore causes a UI flash.

**Result**

The condition is now a level below (on the `key`s), and we've added a fixed `width` to the container.

**Preview**


https://user-images.githubusercontent.com/20689156/126791441-7ef26e5f-3b5d-4002-aee3-9fb627634680.mov



**Related**
- https://github.com/webpack/webpack.js.org/pull/5224
- https://github.com/facebook/docusaurus/pull/5214