### PR TITLE
fix(build): remove occurences of `process` in UMD build

### DIFF
--- a/packages/docsearch-js/rollup.config.js
+++ b/packages/docsearch-js/rollup.config.js
@@ -1,3 +1,5 @@
+import replace from '@rollup/plugin-replace';
+
 import { plugins } from '../../rollup.base.config';
 import { getBundleBanner } from '../../scripts/getBundleBanner';
 
@@ -26,5 +28,13 @@ const output = {
 export default {
   input: 'src/index.ts',
   output: output[process.env.BUILD],
-  plugins,
+  plugins:
+    process.env.BUILD === 'umd'
+      ? [
+          ...plugins,
+          replace({
+            'process.env.NODE_ENV': JSON.stringify('production'),
+          }),
+        ]
+      : plugins,
 };

--- a/packages/docsearch-react/rollup.config.js
+++ b/packages/docsearch-react/rollup.config.js
@@ -1,3 +1,5 @@
+import replace from '@rollup/plugin-replace';
+
 import { plugins } from '../../rollup.base.config';
 import { getBundleBanner } from '../../scripts/getBundleBanner';
 
@@ -17,5 +19,10 @@ export default {
     name: pkg.name,
     banner: getBundleBanner(pkg),
   },
-  plugins,
+  plugins: [
+    ...plugins,
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+  ],
 };


### PR DESCRIPTION
**Summary**

With bare minimal HTML implementation, it is not possible to use the UMD build without manually providing the `process.env.NODE_ENV` variable.

See https://github.com/algolia/docsearch/issues/1046 for more details

**Result**

This PR updates the rollup config to replaces occurrences of `process.env.NODE_ENV` by `"production"`, since we only provide an UMD production file.

Fixes https://github.com/algolia/docsearch/issues/1046