### PR TITLE
fix(v3): pass `initialQuery`

### DIFF
--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -39,7 +39,7 @@ export function DocSearch(props: DocSearchProps) {
   const searchButtonRef = React.useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState<string | undefined>(
-    undefined
+    props?.initialQuery || undefined
   );
 
   const onOpen = React.useCallback(() => {


### PR DESCRIPTION
**Summary**

`initialQuery` wasn't passed from the props to the state, which made it unusable.

see [sandbox](https://codesandbox.io/s/hopeful-fast-fjdof?file=/src/App.js)

**Result**

Search input is initialized with `initialQuery`

see [sandbox](https://codesandbox.io/s/festive-sara-7o8nf)

Related issue: https://github.com/algolia/docsearch/issues/1050