### PR TITLE
fix(ci): update docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/docsearch
   docker:
-    - image: circleci/node:14.15.0
+    - image: cimg/node:14.15.0
 
 cypress: &cypress
   working_directory: ~/docsearch


### PR DESCRIPTION
**Summary**

Fixes Circle CI docker image issue

See https://circleci.com/developer/images/image/cimg/node for more informations

TLDR: `This image is designed to supercede the legacy CircleCI Node.js image, circleci/node.`