### PR TITLE
docs(website): add redirects to legacy scraper

### DIFF
--- a/packages/website/static/_redirects
+++ b/packages/website/static/_redirects
@@ -1,0 +1,3 @@
+/docs/run-your-own /docs/legacy/run-your-own
+/docs/config-file /docs/legacy/config-file
+/docs/dropdown /docs/legacy/dropdown


### PR DESCRIPTION
**Summary**

Add Netlify `_redirects` file for the `docsearch-scraper`