### PR TITLE
Fix apply link

### DIFF
--- a/packages/website/docs/what-is-docsearch.md
+++ b/packages/website/docs/what-is-docsearch.md
@@ -26,7 +26,7 @@ You can now [apply to the program][3]
 
 [1]: https://opencollective.com/algolia
 [2]: who-can-apply
-[3]: apply
+[3]: /apply
 [4]: https://www.algolia.com/products/search-and-discovery/crawler/
 [5]: https://crawler.algolia.com/
 [6]: https://www.algolia.com/doc/ui-libraries/autocomplete/introduction/what-is-autocomplete/


### PR DESCRIPTION
The apply link on the what-is-docsearch page resolves to the non-existent `https://docsearch.algolia.com/docs/apply` URL while it should point to `https://docsearch.algolia.com/apply`.

![grafik](https://user-images.githubusercontent.com/17774818/137071262-72bf1a34-5060-47d9-9e2a-0bce311bc153.png)
