### PR TITLE
Prevent linking to who-can-apply relatively

### DIFF
--- a/packages/website/docs/what-is-docsearch.md
+++ b/packages/website/docs/what-is-docsearch.md
@@ -25,7 +25,7 @@ DocSearch is [one of our ways][1] to give back to the open source community for 
 You can now [apply to the program][3]
 
 [1]: https://opencollective.com/algolia
-[2]: who-can-apply
+[2]: /docs/who-can-apply
 [3]: apply
 [4]: https://www.algolia.com/products/search-and-discovery/crawler/
 [5]: https://crawler.algolia.com/


### PR DESCRIPTION
Clicking on `Get started` at `https://docsearch.algolia.com/`, the docs will open at `https://docsearch.algolia.com/docs/what-is-docsearch/`. The trailing slash will cause the relative link to `who-can-apply` to open `https://docsearch.algolia.com/docs/what-is-docsearch/who-can-apply` instead of `https://docsearch.algolia.com/docs/who-can-apply`.

Alternatively, make sure that there will be no trailing slashes for doc urls...

![grafik](https://user-images.githubusercontent.com/17774818/137071696-59593896-1f6f-447e-95d7-92cf987f6e9d.png)
