### PR TITLE
docs(website): fix apply page redirect

### DIFF
--- a/packages/website/static/_redirects
+++ b/packages/website/static/_redirects
@@ -1,3 +1,4 @@
 /docs/run-your-own /docs/legacy/run-your-own
 /docs/config-file /docs/legacy/config-file
+/docs/apply /apply
 /docs/dropdown /docs/legacy/dropdown


### PR DESCRIPTION
**Summary**

We previously had two `apply` pages, I forgot to redirect the one nested in the docs.

- Redirect `/docs/apply` to `/apply`

Fixes https://github.com/facebook/docusaurus/issues/5764