### PR TITLE
chore(tools): add `useWorkspaces` to lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "packages": ["packages/*", "examples/*"],
   "version": "3.0.0-alpha.41",
-  "npmClient": "yarn"
+  "npmClient": "yarn",
+  "useWorkspaces": true
 }


### PR DESCRIPTION
**Summary**

Renovate requires both `npmClient` and `useWorkspaces` option to detect `yarn` and update the `lock` file: https://github.com/algolia/docsearch/pull/1112