### PR TITLE
docs(v3): fix `react` script link, mention `preconnect` in `installation`

### DIFF
--- a/packages/website/docs/DocSearch-v3.mdx
+++ b/packages/website/docs/DocSearch-v3.mdx
@@ -83,12 +83,16 @@ If you don't want to use a package manger, you can add the CSS to the `<head>` o
 And the JavaScript at the end of your `<body>`:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/react@alpha"></script>
 ```
 
 </TabItem>
 
 </Tabs>
+
+### Improve first query speed
+
+You can hint the browser to improve the speed of the first query by adding a `preconnect`, see [#preconnect](#preconnect)
 
 ## Get started
 


### PR DESCRIPTION
## Summary

- Fix `react` script link
- Mention `preconnect` usage in `installation`