### PR TITLE
fix(logo): empty utm campaign

### DIFF
--- a/packages/docsearch-react/src/AlgoliaLogo.tsx
+++ b/packages/docsearch-react/src/AlgoliaLogo.tsx
@@ -10,9 +10,10 @@ type AlgoliaLogoProps = {
 
 export function AlgoliaLogo({ translations = {} }: AlgoliaLogoProps) {
   const { searchByText = 'Search by' } = translations;
+
   return (
     <a
-      href="https://www.algolia.com/docsearch"
+      href={`https://www.algolia.com/ref/docsearch/?utm_source=docsearch&utm_medium=link&utm_term=footer&utm_campaign=${window.location.hostname}`}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/packages/docsearch-react/src/AlgoliaLogo.tsx
+++ b/packages/docsearch-react/src/AlgoliaLogo.tsx
@@ -13,7 +13,7 @@ export function AlgoliaLogo({ translations = {} }: AlgoliaLogoProps) {
 
   return (
     <a
-      href={`https://www.algolia.com/ref/docsearch/?utm_source=docsearch&utm_medium=link&utm_term=footer&utm_campaign=${window.location.hostname}`}
+      href={`https://www.algolia.com/ref/docsearch/?utm_source=${window.location.hostname}&utm_medium=referral&utm_content=powered_by&utm_campaign=docsearch`}
       target="_blank"
       rel="noopener noreferrer"
     >


### PR DESCRIPTION
## Summary

Due to `noreferrer`, the campaign was always empty when clicking the Algolia logo.

We now inline parameters to prevent this issue.