### PR TITLE
docs: document `aggregateContent`, make API ref clearer

### DIFF
--- a/packages/website/docs/DocSearch-v3.mdx
+++ b/packages/website/docs/DocSearch-v3.mdx
@@ -207,7 +207,6 @@ This is useful to limit the scope of the search to one language or one version.
 
 ```js
 docsearch({
-  // ...
   searchParameters: {
     facetFilters: ['language:en', 'version:1.0.0'],
   },
@@ -220,7 +219,6 @@ docsearch({
 
 ```jsx
 <DocSearch
-  // ...
   searchParameters={{
     facetFilters: ['language:en', 'version:1.0.0'],
   }}
@@ -254,6 +252,6 @@ By adding this snippet to the `head` of your website, you can hint the browser t
 [11]: /docs/api#container
 [12]: /docs/api
 [13]: /docs/required-configuration#introduce-global-information-as-meta-tags
-[14]: /docs/record-extractor#with-custom-variables
+[14]: /docs/record-extractor#indexing-content-for-faceting
 [16]: https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/#facetfilters
 [15]: https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/

--- a/packages/website/docs/migrating-from-legacy.mdx
+++ b/packages/website/docs/migrating-from-legacy.mdx
@@ -82,5 +82,5 @@ Below are the keys that can be found in the [`legacy` DocSearch configs][14] and
 [27]: https://github.com/micromatch/micromatch
 [28]: https://www.algolia.com/doc/tools/crawler/apis/configuration/actions/#parameter-param-recordextractor
 [29]: /docs/record-extractor
-[30]: /docs/record-extractor#with-custom-variables
+[30]: /docs/record-extractor#introduction
 [31]: /docs/record-extractor#pagerank

--- a/packages/website/docs/required-configuration.mdx
+++ b/packages/website/docs/required-configuration.mdx
@@ -44,6 +44,7 @@ new Crawler({
             lvl6: ['article h6', 'main h6', 'h6'],
             content: ['article p, article li', 'main p, main li', 'p, li'],
           },
+          aggregateContent: true,
         });
       },
     },
@@ -202,5 +203,5 @@ Any questions? [Send us an email][9].
 [9]: mailto:DocSearch@algolia.com
 [10]: /docs/DocSearch-v3#filtering-your-search
 [11]: /docs/templates
-[12]: /docs/record-extractor#complex-extractors
+[12]: /docs/record-extractor#introduction
 [13]: /docs/integrations

--- a/packages/website/docs/templates.mdx
+++ b/packages/website/docs/templates.mdx
@@ -48,7 +48,7 @@ new Crawler({
           recordProps: {
             lvl0: {
               selectors: '.navBreadcrumb h2 span',
-              defaultValue: 'Blog',
+              defaultValue: 'Docs',
             },
             lvl1: '.post h1',
             lvl2: '.post h2',
@@ -60,6 +60,7 @@ new Crawler({
             },
           },
           indexHeadings: true,
+          aggregateContent: true,
         });
       },
     },
@@ -87,6 +88,7 @@ new Crawler({
             },
           },
           indexHeadings: true,
+          aggregateContent: true,
         });
       },
     },
@@ -212,6 +214,7 @@ new Crawler({
             content: 'article p, article li, article td:last-child',
           },
           indexHeadings: true,
+          aggregateContent: true,
         });
       },
     },
@@ -335,6 +338,7 @@ new Crawler({
             content: '.content__default p, .content__default li',
           },
           indexHeadings: true,
+          aggregateContent: true,
         });
       },
     },
@@ -444,6 +448,7 @@ new Crawler({
             content: '.theme-default-content p, .theme-default-content li',
           },
           indexHeadings: true,
+          aggregateContent: true,
         });
       },
     },
@@ -552,6 +557,7 @@ new Crawler({
             content: '.content p, .content li',
           },
           indexHeadings: true,
+          aggregateContent: true,
         });
       },
     },
@@ -676,6 +682,7 @@ new Crawler({
             },
           },
           indexHeadings: { from: 2, to: 6 },
+          aggregateContent: true,
         });
       },
     },
@@ -701,6 +708,7 @@ new Crawler({
             },
           },
           indexHeadings: { from: 2, to: 6 },
+          aggregateContent: true,
         });
       },
     },
@@ -725,6 +733,7 @@ new Crawler({
             },
           },
           indexHeadings: { from: 2, to: 6 },
+          aggregateContent: true,
         });
       },
     },


### PR DESCRIPTION
## Summary

This PR documents the new `aggregateContent` option available on the crawler.

This option allows users to reduce the number of records outputted by the crawler by aggregating all the records of type `content` in a single record.