### PR TITLE
docs: use support page instead of email

### DIFF
--- a/packages/website/docs/crawler.mdx
+++ b/packages/website/docs/crawler.mdx
@@ -32,9 +32,7 @@ We've deprecated our legacy infrastructure, but you can still use it to [run you
 
 ## Migration seems to have started, but I don't have received any emails
 
-All of the indices from the [Legacy infrastructure](/docs/legacy/required-configuration) have been migrated, please search for emails from `docsearch@algolia.com`.
-
-It is also possible that you were not part of the members of the previous index, don't hesitate to [contact our support team](mailto:support@algolia.com)
+All of the indices from the [Legacy infrastructure](/docs/legacy/required-configuration) have been migrated, please search for emails from `docsearch@algolia.com`. If you were not part of the previous `index` owners, or the maintainer has changed, you can request access via [our support page](https://www.algolia.com/support/).
 
 ## What do I need to do to migrate?
 

--- a/packages/website/src/components/ApplyForm.js
+++ b/packages/website/src/components/ApplyForm.js
@@ -257,7 +257,8 @@ function ApplyForm() {
           <strong>
             Only apply if you don't have a DocSearch application yet.
           </strong>{' '}
-          If you have any issue, please contact us at support@algolia.com
+          If you have any issue, please check our support page:
+          https://www.algolia.com/support/
         </Text>
       </form>
     </Card>


### PR DESCRIPTION
# Summary

This PR removes the support email to redirect to the support page, as it provides better instructions.