### PR TITLE
docs: document resultsFooterComponent

### DIFF
--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -192,6 +192,38 @@ When provided, an informative message wrapped with your link will be displayed o
   />
 </div>
 
+## `resultsFooterComponent`
+
+> `type: ({ state }) => JSX.Element` | **optional**
+
+The component to display a result count and link in the footer.
+
+```js
+docsearch({
+  // ...
+  resultsFooterComponent({ state }) {
+    return {
+      // The HTML `tag`
+      type: 'a',
+      ref: undefined,
+      constructor: undefined,
+      key: state.query,
+      // Its props
+      props: {
+        href: 'https://docsearch.algolia.com/apply',
+        target: '_blank',
+        onClick: (event) => {
+          console.log(event);
+        },
+        // Raw text rendered in the HTML element
+        children: `${state.context.nbHits} hits found!`,
+      },
+      __v: null,
+    };
+  },
+});
+```
+
 </TabItem>
 
 <TabItem value="react">
@@ -351,6 +383,21 @@ When provided, an informative message wrapped with your link will be displayed o
     alt="No results screen with informative message"
   />
 </div>
+
+## `resultsFooterComponent`
+
+> `type: ({ state }) => JSX.Element` | **optional**
+
+The component to display a result count and link in the footer.
+
+```js
+<DocSearch
+  // ...
+  resultsFooterComponent={({ state }) => {
+    return <h1>{state.context.nbHits} hits found</h1>;
+  }}
+/>
+```
 
 </TabItem>
 

--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -196,7 +196,7 @@ When provided, an informative message wrapped with your link will be displayed o
 
 > `type: ({ state }) => JSX.Element` | **optional**
 
-The component to display a result count and link in the footer.
+The component to display a result count below the search results.
 
 ```js
 docsearch({
@@ -388,7 +388,7 @@ When provided, an informative message wrapped with your link will be displayed o
 
 > `type: ({ state }) => JSX.Element` | **optional**
 
-The component to display a result count and link in the footer.
+The component to display a result count below the search results.
 
 ```js
 <DocSearch

--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -196,7 +196,11 @@ When provided, an informative message wrapped with your link will be displayed o
 
 > `type: ({ state }) => JSX.Element` | **optional**
 
-The component to display a result count below the search results.
+The component to display below the search results.
+
+You get access to the [current state](https://github.com/algolia/autocomplete/blob/next/packages/autocomplete-core/src/types/AutocompleteState.ts) which allows you to retrieve the number of hits returned, the query etc.
+
+[You can find a working example without JSX in this sandbox](https://codesandbox.io/s/docsearch-v3-resultsfootercomponent-without-jsx-jperd5).
 
 ```js
 docsearch({
@@ -388,9 +392,13 @@ When provided, an informative message wrapped with your link will be displayed o
 
 > `type: ({ state }) => JSX.Element` | **optional**
 
-The component to display a result count below the search results.
+The component to display below the search results.
 
-```js
+You get access to the [current state](https://github.com/algolia/autocomplete/blob/next/packages/autocomplete-core/src/types/AutocompleteState.ts) which allows you to retrieve the number of hits returned, the query etc.
+
+[You can find a working example in this sandbox](https://codesandbox.io/s/docsearch-v3-resultsfootercomponent-wzie9y).
+
+```jsx
 <DocSearch
   // ...
   resultsFooterComponent={({ state }) => {


### PR DESCRIPTION
Closes #1368 

Documents `resultsFooterComponent`, which was added in https://github.com/algolia/docsearch/commit/9eaf18a81ffff04b7fb8d8389463b56d823f7e9d.