### PR TITLE
fix(searchbutton): fix react hydration error

### DIFF
--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { ControlKeyIcon } from './icons/ControlKeyIcon';
 import { SearchIcon } from './icons/SearchIcon';
@@ -25,14 +25,15 @@ export const DocSearchButton = React.forwardRef<
 >(({ translations = {}, ...props }, ref) => {
   const { buttonText = 'Search', buttonAriaLabel = 'Search' } = translations;
 
-  const key = useMemo<
+  const [key, setKey] = useState<
     typeof ACTION_KEY_APPLE | typeof ACTION_KEY_DEFAULT | null
-  >(() => {
-    if (typeof navigator !== 'undefined') {
-      return isAppleDevice() ? ACTION_KEY_APPLE : ACTION_KEY_DEFAULT;
-    }
-    return null;
-  }, []);
+  >(null);
+
+  useEffect(
+    () =>
+      isAppleDevice() ? setKey(ACTION_KEY_APPLE) : setKey(ACTION_KEY_DEFAULT),
+    []
+  );
 
   return (
     <button


### PR DESCRIPTION
fix #1242 

After upgrading React v18, the error of react hydration mismatch happens not only in dev but also in prod.
I fixed this error by using useEffect, following the Next.js documentation, https://nextjs.org/docs/messages/react-hydration-error.