### PR TITLE
fix(css): prevent `kbd` unwanted style overriding

### DIFF
--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -56,8 +56,9 @@
   height: 18px;
   justify-content: center;
   margin-right: 0.4em;
-  padding-bottom: 2px;
   position: relative;
+  padding: 0px 0px 2px 0px;
+  border: 0px;
   top: -1px;
   width: 20px;
 }

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -549,7 +549,9 @@ svg.DocSearch-Hit-Select-Icon {
   height: 18px;
   justify-content: center;
   margin-right: 0.4em;
-  padding-bottom: 1px;
+  padding: 0px 0px 1px 0px;
+  color: var(--docsearch-muted-color);
+  border: 0px;
   width: 20px;
 }
 


### PR DESCRIPTION
## Summary

We've decided to use `kbd` instead of `span`s in https://github.com/algolia/docsearch/pull/1335 but some of our style were lost/could be overridden by mistake, those should be enough to match what we previously had.

See Netlify preview for preview