### PR TITLE
feat(styles): set medium breakpoint to standarized value

### DIFF
--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -63,7 +63,7 @@
   width: 20px;
 }
 
-@media (max-width: 750px) {
+@media (max-width: 768px) {
   .DocSearch-Button-Keys,
   .DocSearch-Button-Placeholder {
     display: none;

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -556,7 +556,7 @@ svg.DocSearch-Hit-Select-Icon {
 }
 
 /* Responsive */
-@media (max-width: 750px) {
+@media (max-width: 768px) {
   :root {
     --docsearch-spacing: 10px;
     --docsearch-footer-height: 40px;

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -332,7 +332,7 @@ export function DocSearchModal({
   }, []);
 
   React.useEffect(() => {
-    const isMobileMediaQuery = window.matchMedia('(max-width: 750px)');
+    const isMobileMediaQuery = window.matchMedia('(max-width: 768px)');
 
     if (isMobileMediaQuery.matches) {
       snippetLength.current = 5;


### PR DESCRIPTION
768px has been much more common for many years (since 2010), and other major CSS frameworks have used 768px as the breakpoint for years.

Closes #1444

- PR for css: #1447

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)