### PR TITLE
feat(react): set breakpoints the de facto value

### DIFF
--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -332,7 +332,7 @@ export function DocSearchModal({
   }, []);
 
   React.useEffect(() => {
-    const isMobileMediaQuery = window.matchMedia('(max-width: 750px)');
+    const isMobileMediaQuery = window.matchMedia('(max-width: 768px)');
 
     if (isMobileMediaQuery.matches) {
       snippetLength.current = 5;


### PR DESCRIPTION
768px has been much more common for many years (since 2010), and other major CSS frameworks have used 768px as the breakpoint for years.

Closes #1444

- PR for css: #1446

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)