### PR TITLE
chore: rename `next` branch to `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,4 +187,4 @@ workflows:
             - build
           filters:
             branches:
-              only: next
+              only: main

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -18,8 +18,8 @@ about: Help us improve DocSearch.
 
 **Live reproduction:**
 
-- JavaScript: https://codesandbox.io/s/github/algolia/docsearch/tree/next/examples/js-demo
-- React: https://codesandbox.io/s/github/algolia/docsearch/tree/next/examples/demo
+- JavaScript: https://codesandbox.io/s/github/algolia/docsearch/tree/main/examples/js-demo
+- React: https://codesandbox.io/s/github/algolia/docsearch/tree/main/examples/demo
 
 ## Expected behavior
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,5 +15,5 @@ jobs:
           github-token: ${{ secrets.ALGOLIA_BOT_TOKEN }}
           repo-owner: algolia
           repo-name: docsearch
-          branch-base: next
+          branch-base: main
           pull-request-title: 'chore(deps): dependencies'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Opening an issue is very effective way to contribute because many users might al
 
 Before reporting an issue, first check that there is not an already open issue for the same topic using the [issues page](https://github.com/algolia/docsearch/issues). Don't hesitate to thumb up an issue that corresponds to the problem you have.
 
-Another element that will help us go faster at solving the issue is to provide a reproducible test case. We recommend to [use this CodeSandbox template](https://codesandbox.io/s/github/algolia/docsearch/tree/next/examples/js).
+Another element that will help us go faster at solving the issue is to provide a reproducible test case. We recommend to [use this CodeSandbox template](https://codesandbox.io/s/github/algolia/docsearch/tree/main/examples/js).
 
 ## Code contribution
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export default App;
 DocSearch is made of the following repositories:
 
 - **[algolia/docsearch](https://github.com/algolia/docsearch)**: DocSearch source code.
-- **[algolia/docsearch/packages/website](https://github.com/algolia/docsearch/tree/next/packages/website)**: DocSearch website and documentation.
+- **[algolia/docsearch/packages/website](https://github.com/algolia/docsearch/tree/main/packages/website)**: DocSearch website and documentation.
 - **[algolia/docsearch-configs](https://github.com/algolia/docsearch-configs)**: DocSearch websites configurations that DocSearch powers.
 - **[algolia/docsearch-scraper](https://github.com/algolia/docsearch-scraper)**: DocSearch crawler that extracts data from your documentation.
 

--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -432,7 +432,7 @@ You get access to the [current state](https://github.com/algolia/autocomplete/bl
 [5]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors
 [6]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement
 [7]: https://www.algolia.com/doc/api-reference/search-api-parameters/
-[8]: https://github.com/algolia/docsearch/blob/next/packages/docsearch-react/src/Hit.tsx
+[8]: https://github.com/algolia/docsearch/blob/main/packages/docsearch-react/src/Hit.tsx
 [9]: https://codesandbox.io/s/docsearch-v3-debounced-search-gnx87
 [10]: https://www.algolia.com/doc/api-client/getting-started/what-is-the-api-client/javascript/?client=javascript
 [11]: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/keyboard-navigation/

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -25,7 +25,7 @@ const lightCodeTheme = require('prism-react-renderer/themes/github');
             path: 'docs',
             sidebarPath: 'sidebars.js',
             editUrl:
-              'https://github.com/algolia/docsearch/edit/next/packages/website/',
+              'https://github.com/algolia/docsearch/edit/main/packages/website/',
             versions: {
               current: {
                 label: 'current',


### PR DESCRIPTION
## Summary

https://algolia.atlassian.net/browse/CRAW-2419
closes https://github.com/algolia/docsearch/issues/1448

I think it's time, we can rename `next` to `main` :D 