### PR TITLE
Fix: use navigator.userAgentData.platform if available

### DIFF
--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -16,7 +16,9 @@ const ACTION_KEY_DEFAULT = 'Ctrl' as const;
 const ACTION_KEY_APPLE = '⌘' as const;
 
 function isAppleDevice() {
-  return /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+  return /(Mac|iPhone|iPod|iPad)/i.test(
+    (navigator as any)?.userAgentData?.platform || navigator.platform
+  );
 }
 
 export const DocSearchButton = React.forwardRef<


### PR DESCRIPTION
Avoid calling `navigator.platform` on Chromium/Chrome where `navigator.userAgentData.platform` is available. This removes the annoying warning in Chromium "Issues" console which reads:
>Audit usage of navigator.userAgent, navigator.appVersion, and navigator.platform

This PR does not make any real changes to functionality.