### PR TITLE
fix: arrow keys behavior in modal

### DIFF
--- a/packages/docsearch-css/src/_variables.css
+++ b/packages/docsearch-css/src/_variables.css
@@ -16,6 +16,7 @@
   --docsearch-modal-background: rgb(245, 246, 247);
   --docsearch-modal-shadow: inset 1px 1px 0 0 rgba(255, 255, 255, 0.5),
     0 3px 8px 0 rgba(85, 90, 100, 1);
+  --docsearch-modal-source-height: 40px;
 
   /* searchbox */
   --docsearch-searchbox-height: 56px;

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -263,6 +263,7 @@
 }
 
 .DocSearch-Hit {
+  scroll-margin-top: 40px;
   border-radius: 4px;
   display: flex;
   padding-bottom: 4px;
@@ -305,6 +306,10 @@
 .DocSearch-Hit-source {
   background: var(--docsearch-modal-background);
   color: var(--docsearch-highlight-color);
+  height: var(--docsearch-modal-source-height);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
   font-size: 0.85em;
   font-weight: 600;
   line-height: 32px;

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -263,7 +263,7 @@
 }
 
 .DocSearch-Hit {
-  scroll-margin-top: 40px;
+  scroll-margin-top: var(--docsearch-modal-source-height);
   border-radius: 4px;
   display: flex;
   padding-bottom: 4px;


### PR DESCRIPTION
Closes #1572

In order to use `scroll-margin-top` css prop we need to know what the height of `.DocSearch-Hit-source` element is going to be, so I've added an ellipsis to it so it truncates instead of wrapping to a new line - if that's not okay lemme know what behavior is okay.