### PR TITLE
chore: remove ignore build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,6 @@
 [build]
   command="yarn build"
   publish="packages/website/build"
-  ignore="git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- packages/website/ yarn.lock"
 
 [build.environment]
   YARN_VERSION = "1.22.5"


### PR DESCRIPTION
## Summary

I need to deploy the new docs but somehow the netlify cache hits when the preview is deployed on the PR and then needs to be deployed on main 🤔 