### PR TITLE
fix(modal): enable outline for focus state

### DIFF
--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -157,10 +157,6 @@
   display: none;
 }
 
-.DocSearch-Reset:focus {
-  outline: none;
-}
-
 .DocSearch-Reset:hover {
   color: var(--docsearch-highlight-color);
 }


### PR DESCRIPTION
Closes https://github.com/algolia/docsearch/issues/1731

<img width="639" alt="" src="https://user-images.githubusercontent.com/1091472/209656977-be7dec28-093d-4665-aeb7-f13762b4b0e4.png">

Users of DocSearch can always customize as needed.