### PR TITLE
feat: restore focus after closing modal

### DIFF
--- a/examples/demo/src/App.js
+++ b/examples/demo/src/App.js
@@ -8,6 +8,7 @@ function App() {
   return (
     <div>
       <h1>DocSearch v3 - React</h1>
+      <button>A button</button>
       <DocSearch
         indexName="docsearch"
         appId="R2IYF7ETH7"

--- a/examples/js-demo/index.html
+++ b/examples/js-demo/index.html
@@ -11,7 +11,7 @@
   <body>
     <div class="container">
       <h1>DocSearch v3 - Vanilla JavaScript</h1>
-
+      <button>A button</button>
       <div id="docsearch"></div>
     </div>
 

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -42,11 +42,12 @@ export interface DocSearchProps {
   initialQuery?: string;
   navigator?: AutocompleteOptions<InternalDocSearchHit>['navigator'];
   translations?: DocSearchTranslations;
-  getMissingResultsUrl?: ({ query: string }) => string;
+  getMissingResultsUrl?: ({ query }: { query: string }) => string;
 }
 
 export function DocSearch(props: DocSearchProps) {
   const searchButtonRef = React.useRef<HTMLButtonElement>(null);
+  const activeElementRef = React.useRef<Element>(document.body);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState<string | undefined>(
     props?.initialQuery || undefined
@@ -54,9 +55,15 @@ export function DocSearch(props: DocSearchProps) {
 
   const onOpen = React.useCallback(() => {
     setIsOpen(true);
+    activeElementRef.current = document.activeElement || document.body;
   }, [setIsOpen]);
 
   const onClose = React.useCallback(() => {
+    if (activeElementRef.current) {
+      if (activeElementRef.current instanceof HTMLElement) {
+        activeElementRef.current.focus();
+      }
+    }
     setIsOpen(false);
   }, [setIsOpen]);
 


### PR DESCRIPTION
Related issue https://github.com/algolia/docsearch/issues/1370

<img width="1035" alt="" src="https://user-images.githubusercontent.com/1091472/209805595-4a282a06-eb5f-4c34-91b3-8b6c889d0766.png">


cc @patrickhlauke if you don't mind please help review this one.

Basically the code would store the `document.activeElement` when modal is opened, and call `focus` on that stored `document.activeElement` when modal is closed.