### PR TITLE
fix: Correctly type `getMissingResultsUrl` query as `string`

### DIFF
--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -42,7 +42,7 @@ export interface DocSearchProps {
   initialQuery?: string;
   navigator?: AutocompleteOptions<InternalDocSearchHit>['navigator'];
   translations?: DocSearchTranslations;
-  getMissingResultsUrl?: ({ query: string }) => string;
+  getMissingResultsUrl?: ({ query }: { query: string }) => string;
 }
 
 export function DocSearch(props: DocSearchProps) {


### PR DESCRIPTION
`({ query: string }) => string;` was being interpreted as a prop rename, which doesn't make sense in the context of an interface, so I've corrected it to what I assume was the intended outcome where `query` is of type `string`, rather than being inferred as `any`.

NOTE: Technically this is a breaking change as `query` was being inferred with type `any`, so consumers that were using it as such may need to change their code. On the other hand, I doubt many consumers are using this value as if it were anything _but_ a `string`, so IMO a patch fix is also valid in this case. I'll leave this decision to the maintainers.