### PR TITLE
fix: modal layout shift for none overlay scrollbar

### DIFF
--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -6,6 +6,13 @@
    * `style` attribute (e.g. Docusaurus).
    */
   overflow: hidden !important;
+
+  overflow-y: scroll !important;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  /* Set top from js */
 }
 
 /* Container & Modal */

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -318,10 +318,18 @@ export function DocSearchModal({
   useTrapFocus({ container: containerRef.current });
 
   React.useEffect(() => {
-    document.body.classList.add('DocSearch--active');
+    const hasVerticalScrollbar =
+      window.innerWidth > document.documentElement.clientWidth;
+    if (hasVerticalScrollbar) {
+      document.body.classList.add('DocSearch--active');
+      document.body.style.top = `-${initialScrollY}px`;
+    }
 
     return () => {
-      document.body.classList.remove('DocSearch--active');
+      if (hasVerticalScrollbar) {
+        document.body.classList.remove('DocSearch--active');
+        document.body.style.top = '';
+      }
 
       // IE11 doesn't support `scrollTo` so we check that the method exists
       // first.


### PR DESCRIPTION
The current way of preventing scrolling will hide the scrollbar and causing a layout shift when using a none overlay scrollbar (default on windows)

![image](https://user-images.githubusercontent.com/68118705/233797447-f9ba2e68-ff25-47bf-96b9-11880f2581dc.png)
![image](https://user-images.githubusercontent.com/68118705/233797466-aba92391-ff24-4bed-b598-2ad1f9dc2621.png)

I can only think of two ways to handle this, but they all cause a pretty small layout shift on sticky elements (1px)

- Make a padding to the right to fill up the missing scrollbar space
- Set body position fixed and change the z index

But to be honest, I would prefer not to do it at all, able to scroll the things behind the searching UI is not a big problem comparison to a layout shift to me
