### PR TITLE
Fix: Prevent calling `onClose()` when `shiftKey`, `ctrlKey` or `metaKey` is pressed

### DIFF
--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -21,6 +21,7 @@ import { useSearchClient } from './useSearchClient';
 import { useTouchEvents } from './useTouchEvents';
 import { useTrapFocus } from './useTrapFocus';
 import { groupBy, identity, noop, removeHighlightTags } from './utils';
+import { isModifierEvent } from './utils/isModifierEvent';
 
 export type ModalTranslations = Partial<{
   searchBox: SearchBoxTranslations;
@@ -156,7 +157,7 @@ export function DocSearchModal({
                 onSelect({ item, event }) {
                   saveRecentSearch(item);
 
-                  if (!event.shiftKey && !event.ctrlKey && !event.metaKey) {
+                  if (!isModifierEvent(event)) {
                     onClose();
                   }
                 },
@@ -172,7 +173,7 @@ export function DocSearchModal({
                 onSelect({ item, event }) {
                   saveRecentSearch(item);
 
-                  if (!event.shiftKey && !event.ctrlKey && !event.metaKey) {
+                  if (!isModifierEvent(event)) {
                     onClose();
                   }
                 },
@@ -256,7 +257,7 @@ export function DocSearchModal({
                     onSelect({ item, event }) {
                       saveRecentSearch(item);
 
-                      if (!event.shiftKey && !event.ctrlKey && !event.metaKey) {
+                      if (!isModifierEvent(event)) {
                         onClose();
                       }
                     },
@@ -433,7 +434,7 @@ export function DocSearchModal({
             getMissingResultsUrl={getMissingResultsUrl}
             onItemClick={(item, event) => {
               saveRecentSearch(item);
-              if (!event.shiftKey && !event.ctrlKey && !event.metaKey) {
+              if (!isModifierEvent(event)) {
                 onClose();
               }
             }}

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -431,9 +431,11 @@ export function DocSearchModal({
             inputRef={inputRef}
             translations={screenStateTranslations}
             getMissingResultsUrl={getMissingResultsUrl}
-            onItemClick={(item) => {
+            onItemClick={(item, event) => {
               saveRecentSearch(item);
-              onClose();
+              if (!event.shiftKey && !event.ctrlKey && !event.metaKey) {
+                onClose();
+              }
             }}
           />
         </div>

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -20,7 +20,13 @@ import type {
 import { useSearchClient } from './useSearchClient';
 import { useTouchEvents } from './useTouchEvents';
 import { useTrapFocus } from './useTrapFocus';
-import { groupBy, identity, noop, removeHighlightTags, isModifierEvent } from './utils';
+import {
+  groupBy,
+  identity,
+  noop,
+  removeHighlightTags,
+  isModifierEvent,
+} from './utils';
 
 export type ModalTranslations = Partial<{
   searchBox: SearchBoxTranslations;

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -20,8 +20,7 @@ import type {
 import { useSearchClient } from './useSearchClient';
 import { useTouchEvents } from './useTouchEvents';
 import { useTrapFocus } from './useTrapFocus';
-import { groupBy, identity, noop, removeHighlightTags } from './utils';
-import { isModifierEvent } from './utils/isModifierEvent';
+import { groupBy, identity, noop, removeHighlightTags, isModifierEvent } from './utils';
 
 export type ModalTranslations = Partial<{
   searchBox: SearchBoxTranslations;

--- a/packages/docsearch-react/src/Results.tsx
+++ b/packages/docsearch-react/src/Results.tsx
@@ -24,7 +24,7 @@ interface ResultsProps<TItem extends BaseItem>
     runDeleteTransition: (cb: () => void) => void;
     runFavoriteTransition: (cb: () => void) => void;
   }) => React.ReactNode;
-  onItemClick: (item: TItem) => void;
+  onItemClick: (item: TItem, event: KeyboardEvent) => void;
   hitComponent: DocSearchProps['hitComponent'];
 }
 
@@ -104,8 +104,8 @@ function Result<TItem extends StoredDocSearchHit>({
       {...getItemProps({
         item,
         source: collection.source,
-        onClick() {
-          onItemClick(item);
+        onClick(event) {
+          onItemClick(item, event);
         },
       })}
     >

--- a/packages/docsearch-react/src/Results.tsx
+++ b/packages/docsearch-react/src/Results.tsx
@@ -24,7 +24,7 @@ interface ResultsProps<TItem extends BaseItem>
     runDeleteTransition: (cb: () => void) => void;
     runFavoriteTransition: (cb: () => void) => void;
   }) => React.ReactNode;
-  onItemClick: (item: TItem, event: KeyboardEvent) => void;
+  onItemClick: (item: TItem, event: KeyboardEvent | MouseEvent) => void;
   hitComponent: DocSearchProps['hitComponent'];
 }
 

--- a/packages/docsearch-react/src/ScreenState.tsx
+++ b/packages/docsearch-react/src/ScreenState.tsx
@@ -32,7 +32,7 @@ export interface ScreenStateProps<TItem extends BaseItem>
   state: AutocompleteState<TItem>;
   recentSearches: StoredSearchPlugin<StoredDocSearchHit>;
   favoriteSearches: StoredSearchPlugin<StoredDocSearchHit>;
-  onItemClick: (item: InternalDocSearchHit, event: KeyboardEvent) => void;
+  onItemClick: (item: InternalDocSearchHit, event: KeyboardEvent | MouseEvent) => void;
   inputRef: React.MutableRefObject<HTMLInputElement | null>;
   hitComponent: DocSearchProps['hitComponent'];
   indexName: DocSearchProps['indexName'];

--- a/packages/docsearch-react/src/ScreenState.tsx
+++ b/packages/docsearch-react/src/ScreenState.tsx
@@ -32,7 +32,7 @@ export interface ScreenStateProps<TItem extends BaseItem>
   state: AutocompleteState<TItem>;
   recentSearches: StoredSearchPlugin<StoredDocSearchHit>;
   favoriteSearches: StoredSearchPlugin<StoredDocSearchHit>;
-  onItemClick: (item: InternalDocSearchHit) => void;
+  onItemClick: (item: InternalDocSearchHit, event: KeyboardEvent) => void;
   inputRef: React.MutableRefObject<HTMLInputElement | null>;
   hitComponent: DocSearchProps['hitComponent'];
   indexName: DocSearchProps['indexName'];

--- a/packages/docsearch-react/src/ScreenState.tsx
+++ b/packages/docsearch-react/src/ScreenState.tsx
@@ -32,7 +32,10 @@ export interface ScreenStateProps<TItem extends BaseItem>
   state: AutocompleteState<TItem>;
   recentSearches: StoredSearchPlugin<StoredDocSearchHit>;
   favoriteSearches: StoredSearchPlugin<StoredDocSearchHit>;
-  onItemClick: (item: InternalDocSearchHit, event: KeyboardEvent | MouseEvent) => void;
+  onItemClick: (
+    item: InternalDocSearchHit,
+    event: KeyboardEvent | MouseEvent
+  ) => void;
   inputRef: React.MutableRefObject<HTMLInputElement | null>;
   hitComponent: DocSearchProps['hitComponent'];
   indexName: DocSearchProps['indexName'];

--- a/packages/docsearch-react/src/utils/index.ts
+++ b/packages/docsearch-react/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './groupBy';
 export * from './identity';
+export * from './isModifierEvent';
 export * from './noop';
 export * from './removeHighlightTags';

--- a/packages/docsearch-react/src/utils/isModifierEvent.ts
+++ b/packages/docsearch-react/src/utils/isModifierEvent.ts
@@ -1,0 +1,17 @@
+/**
+ * Detect when an event is modified with a special key to let the browser
+ * trigger its default behavior.
+ */
+export function isModifierEvent<TEvent extends MouseEvent | KeyboardEvent>(
+  event: TEvent
+): boolean {
+  const isMiddleClick = (event as MouseEvent).button === 1;
+
+  return (
+    isMiddleClick ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey
+  );
+}

--- a/packages/docsearch-react/src/utils/isModifierEvent.ts
+++ b/packages/docsearch-react/src/utils/isModifierEvent.ts
@@ -2,7 +2,7 @@
  * Detect when an event is modified with a special key to let the browser
  * trigger its default behavior.
  */
-export function isModifierEvent<TEvent extends MouseEvent | KeyboardEvent>(
+export function isModifierEvent<TEvent extends KeyboardEvent | MouseEvent>(
   event: TEvent
 ): boolean {
   const isMiddleClick = (event as MouseEvent).button === 1;


### PR DESCRIPTION
This PR checks for presence of `shiftKey`, `ctrlKey` or `metaKey` when clicking the result so users can open multiple search results without re-opening the search modal.