### PR TITLE
feat(api): allow insights options to be forwarded to Autocomplete

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,11 +6,11 @@
     },
     {
       "path": "packages/docsearch-react/dist/umd/index.js",
-      "maxSize": "20.30 kB"
+      "maxSize": "22.47 kB"
     },
     {
       "path": "packages/docsearch-js/dist/umd/index.js",
-      "maxSize": "28.20 kB"
+      "maxSize": "30.33 kB"
     }
   ]
 }

--- a/examples/demo/src/App.js
+++ b/examples/demo/src/App.js
@@ -12,6 +12,7 @@ function App() {
         indexName="docsearch"
         appId="R2IYF7ETH7"
         apiKey="599cec31baffa4868cae4e79f180729b"
+        insights
       />
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cy:verify": "cypress verify",
     "lint:css": "stylelint **/src/**/*.css",
     "lint": "eslint --ext .js,.ts,.tsx .",
+    "playground:build": "yarn workspace @docsearch/react-example build",
     "playground:start": "yarn workspace @docsearch/react-example start",
     "playground-js:start": "yarn workspace @docsearch/js-example start",
     "release": "shipjs prepare",

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -33,8 +33,8 @@
     "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
   },
   "dependencies": {
-    "@algolia/autocomplete-core": "1.8.2",
-    "@algolia/autocomplete-preset-algolia": "1.8.2",
+    "@algolia/autocomplete-core": "1.9.2",
+    "@algolia/autocomplete-preset-algolia": "1.9.2",
     "@docsearch/css": "3.4.0",
     "algoliasearch": "^4.0.0"
   },

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -44,6 +44,7 @@ export interface DocSearchProps {
   navigator?: AutocompleteOptions<InternalDocSearchHit>['navigator'];
   translations?: DocSearchTranslations;
   getMissingResultsUrl?: ({ query }: { query: string }) => string;
+  insights?: AutocompleteOptions<InternalDocSearchHit>['insights'];
 }
 
 export function DocSearch(props: DocSearchProps) {

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -130,8 +130,6 @@ export function DocSearchModal({
     [favoriteSearches, recentSearches, disableUserPersonalization]
   );
 
-  const insightsActive = Boolean(insights);
-
   const autocomplete = React.useMemo(
     () =>
       createAutocomplete<
@@ -196,6 +194,8 @@ export function DocSearchModal({
               },
             ];
           }
+
+          const insightsActive = Boolean(insights);
 
           return searchClient
             .search<DocSearchHit>([
@@ -346,7 +346,6 @@ export function DocSearchModal({
       transformItems,
       disableUserPersonalization,
       insights,
-      insightsActive,
       appId,
       apiKey,
     ]

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -58,6 +58,7 @@ export function DocSearchModal({
   initialQuery: initialQueryFromProp = '',
   translations = {},
   getMissingResultsUrl,
+  insights = false,
 }: DocSearchModalProps) {
   const {
     footer: footerTranslations,
@@ -147,10 +148,12 @@ export function DocSearchModal({
             searchSuggestions: [],
           },
         },
+        insights,
         navigator,
         onStateChange(props) {
           setState(props.state);
         },
+        // @ts-expect-error
         getSources({ query, state: sourcesState, setContext, setStatus }) {
           if (!query) {
             if (disableUserPersonalization) {
@@ -285,16 +288,18 @@ export function DocSearchModal({
                         .map(transformItems)
                         .map((groupedHits) =>
                           groupedHits.map((item) => {
+                            const parent =
+                              item.type !== 'lvl1' &&
+                              groupedHits.find(
+                                (siblingItem) =>
+                                  siblingItem.type === 'lvl1' &&
+                                  siblingItem.hierarchy.lvl1 ===
+                                    item.hierarchy.lvl1
+                              );
+
                             return {
                               ...item,
-                              __docsearch_parent:
-                                item.type !== 'lvl1' &&
-                                groupedHits.find(
-                                  (siblingItem) =>
-                                    siblingItem.type === 'lvl1' &&
-                                    siblingItem.hierarchy.lvl1 ===
-                                      item.hierarchy.lvl1
-                                ),
+                              __docsearch_parent: parent ? parent : null,
                             };
                           })
                         )
@@ -320,6 +325,7 @@ export function DocSearchModal({
       navigator,
       transformItems,
       disableUserPersonalization,
+      insights,
     ]
   );
 

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -228,7 +228,7 @@ export function DocSearchModal({
                   highlightPreTag: '<mark>',
                   highlightPostTag: '</mark>',
                   hitsPerPage: 20,
-                  clickAnalytics: Boolean(insights),
+                  clickAnalytics: insightsActive,
                   ...searchParameters,
                 },
               },

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -310,7 +310,7 @@ export function DocSearchModal({
                                 siblingItem.type === 'lvl1' &&
                                 siblingItem.hierarchy.lvl1 ===
                                   item.hierarchy.lvl1
-                            ) as InternalDocSearchHit;
+                            ) as InternalDocSearchHit | undefined;
 
                             if (item.type !== 'lvl1' && potentialParent) {
                               parent = potentialParent;

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -130,6 +130,8 @@ export function DocSearchModal({
     [favoriteSearches, recentSearches, disableUserPersonalization]
   );
 
+  const insightsActive = Boolean(insights);
+
   const autocomplete = React.useMemo(
     () =>
       createAutocomplete<
@@ -227,6 +229,7 @@ export function DocSearchModal({
                   highlightPreTag: '<mark>',
                   highlightPostTag: '</mark>',
                   hitsPerPage: 20,
+                  clickAnalytics: Boolean(insights),
                   ...searchParameters,
                 },
               },
@@ -262,6 +265,19 @@ export function DocSearchModal({
               }
 
               setContext({ nbHits });
+
+              let insightsParams = {};
+
+              if (insightsActive) {
+                insightsParams = {
+                  __autocomplete_indexName: indexName,
+                  __autocomplete_queryID: results[0].queryID,
+                  __autocomplete_algoliaCredentials: {
+                    appId,
+                    apiKey,
+                  },
+                };
+              }
 
               return Object.values<DocSearchHit[]>(sources).map(
                 (items, index) => {
@@ -300,6 +316,7 @@ export function DocSearchModal({
                             return {
                               ...item,
                               __docsearch_parent: parent ? parent : null,
+                              ...insightsParams,
                             };
                           })
                         )
@@ -326,6 +343,9 @@ export function DocSearchModal({
       transformItems,
       disableUserPersonalization,
       insights,
+      insightsActive,
+      appId,
+      apiKey,
     ]
   );
 

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -155,7 +155,6 @@ export function DocSearchModal({
         onStateChange(props) {
           setState(props.state);
         },
-        // @ts-expect-error
         getSources({ query, state: sourcesState, setContext, setStatus }) {
           if (!query) {
             if (disableUserPersonalization) {
@@ -176,7 +175,7 @@ export function DocSearchModal({
                   return item.url;
                 },
                 getItems() {
-                  return recentSearches.getAll();
+                  return recentSearches.getAll() as InternalDocSearchHit[];
                 },
               },
               {
@@ -192,7 +191,7 @@ export function DocSearchModal({
                   return item.url;
                 },
                 getItems() {
-                  return favoriteSearches.getAll();
+                  return favoriteSearches.getAll() as InternalDocSearchHit[];
                 },
               },
             ];
@@ -304,18 +303,22 @@ export function DocSearchModal({
                         .map(transformItems)
                         .map((groupedHits) =>
                           groupedHits.map((item) => {
-                            const parent =
-                              item.type !== 'lvl1' &&
-                              groupedHits.find(
-                                (siblingItem) =>
-                                  siblingItem.type === 'lvl1' &&
-                                  siblingItem.hierarchy.lvl1 ===
-                                    item.hierarchy.lvl1
-                              );
+                            let parent: InternalDocSearchHit | null = null;
+
+                            const potentialParent = groupedHits.find(
+                              (siblingItem) =>
+                                siblingItem.type === 'lvl1' &&
+                                siblingItem.hierarchy.lvl1 ===
+                                  item.hierarchy.lvl1
+                            ) as InternalDocSearchHit;
+
+                            if (item.type !== 'lvl1' && potentialParent) {
+                              parent = potentialParent;
+                            }
 
                             return {
                               ...item,
-                              __docsearch_parent: parent ? parent : null,
+                              __docsearch_parent: parent,
                               ...insightsParams,
                             };
                           })

--- a/packages/docsearch-react/src/types/DocSearchHit.ts
+++ b/packages/docsearch-react/src/types/DocSearchHit.ts
@@ -78,4 +78,10 @@ export declare type DocSearchHit = {
     };
   };
   _distinctSeqID?: number;
+  __autocomplete_indexName?: string;
+  __autocomplete_queryID?: string;
+  __autocomplete_algoliaCredentials?: {
+    appId: string;
+    apiKey: string;
+  };
 };

--- a/packages/website/docs/DocSearch-v3.mdx
+++ b/packages/website/docs/DocSearch-v3.mdx
@@ -229,6 +229,46 @@ docsearch({
 
 </Tabs>
 
+### Sending events
+
+You can send search events to your DocSearch index by passing in the `insights` parameter when creating your DocSearch instance.
+
+<Tabs
+  groupId="language"
+  defaultValue="js"
+  values={[
+    { label: 'JavaScript', value: 'js', },
+    { label: 'React', value: 'react', }
+  ]
+}>
+<TabItem value="js">
+
+```js
+docsearch({
+  searchParameters: {
+    facetFilters: ['language:en', 'version:1.0.0'],
+  },
+  insights,
+});
+```
+
+</TabItem>
+
+<TabItem value="react">
+
+```jsx
+<DocSearch
+  searchParameters={{
+    facetFilters: ['language:en', 'version:1.0.0'],
+  }}
+  insights
+/>
+```
+
+</TabItem>
+
+</Tabs>
+
 ## Performance optimization
 
 ### Preconnect

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,24 +7,32 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.0.1.tgz#b38b444ad3aa5fedbb15f2f746dcd934226a12dd"
   integrity sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==
 
-"@algolia/autocomplete-core@1.8.2":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.8.2.tgz#8d758c8652742e2761450d2b615a841fca24e10e"
-  integrity sha512-mTeshsyFhAqw/ebqNsQpMtbnjr+qVOSKXArEj4K0d7sqc8It1XD0gkASwecm9mF/jlOQ4Z9RNg1HbdA8JPdRwQ==
+"@algolia/autocomplete-core@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.2.tgz#1c9ffcfac7fc4733fe97356247b25d9d7a83538c"
+  integrity sha512-hkG80c9kx9ClVAEcUJbTd2ziVC713x9Bji9Ty4XJfKXlxlsx3iXsoNhAwfeR4ulzIUg7OE5gez0UU1zVDdG7kg==
   dependencies:
-    "@algolia/autocomplete-shared" "1.8.2"
+    "@algolia/autocomplete-plugin-algolia-insights" "1.9.2"
+    "@algolia/autocomplete-shared" "1.9.2"
 
-"@algolia/autocomplete-preset-algolia@1.8.2":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.8.2.tgz#706e87f94c5f198c0e90502b97af09adeeddcc79"
-  integrity sha512-J0oTx4me6ZM9kIKPuL3lyU3aB8DEvpVvR6xWmHVROx5rOYJGQcZsdG4ozxwcOyiiu3qxMkIbzntnV1S1VWD8yA==
+"@algolia/autocomplete-plugin-algolia-insights@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.2.tgz#b4672d5662acc2d0a0547d14dfbdcc70c17625de"
+  integrity sha512-2LVsf4W66hVHQ3Ua/8k15oPlxjELCztbAkQm/hP42Sw+GLkHAdY1vaVRYziaWq64+Oljfg6FKkZHCdgXH+CGIA==
   dependencies:
-    "@algolia/autocomplete-shared" "1.8.2"
+    "@algolia/autocomplete-shared" "1.9.2"
 
-"@algolia/autocomplete-shared@1.8.2":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.8.2.tgz#e6972df5c6935a241f16e4909aa82902338e029d"
-  integrity sha512-b6Z/X4MczChMcfhk6kfRmBzPgjoPzuS9KGR4AFsiLulLNRAAqhP+xZTKtMnZGhLuc61I20d5WqlId02AZvcO6g==
+"@algolia/autocomplete-preset-algolia@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.2.tgz#a31fc9a88800ee7312cd177c738e9e4c0e0f78e8"
+  integrity sha512-pqgIm2GNqtCT59Y1ICctIPrYTi34+wNPiNWEclD/yDzp5uDUUsyGe5XrUjCNyQRTKonAlmYxoaEHOn8FWgmBHA==
+  dependencies:
+    "@algolia/autocomplete-shared" "1.9.2"
+
+"@algolia/autocomplete-shared@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.2.tgz#b5b909377439c45774cfb91947ad8e6ebd4652c1"
+  integrity sha512-XxX6YDn+7LG+SmdpXEOnj7fc3TjiVpQ0CbGhjLwrd2tYr6LVY2D4Iiu/iuYJ4shvVDWWnpwArSk0uIWC/8OPUA==
 
 "@algolia/cache-browser-local-storage@4.14.1":
   version "4.14.1"


### PR DESCRIPTION
This PR updates the version of `autocomplete-core` that we are using to allow for sending events within DocSearch.

Allowing for events to be sent will unlock more features in the long run for DocSearch and can help give insight into how users are using DocSearch on each site.