### PR TITLE
docs(v3): fix typo

### DIFF
--- a/packages/website/docs/DocSearch-v3.mdx
+++ b/packages/website/docs/DocSearch-v3.mdx
@@ -45,7 +45,7 @@ npm install @docsearch/js@3
 
 ### Without package manager
 
-If you don't want to use a package manger, you can add the CSS to the `<head>` of your website:
+If you don't want to use a package manager, you can add the CSS to the `<head>` of your website:
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />


### PR DESCRIPTION
This PR fixes tiny typo in [Installation](https://docsearch.algolia.com/docs/DocSearch-v3) section for `JavaScript`

```diff
- manger
+ manager

```
<img width="502" alt="Screenshot 2023-07-07 at 15 08 49" src="https://github.com/algolia/docsearch/assets/19148199/641fafdc-0196-44c6-80dc-dc43663ddd90">
