### PR TITLE
fix(docsearch-react): use dangerouslySetInnerHTML for results title

### DIFF
--- a/packages/docsearch-react/src/Results.tsx
+++ b/packages/docsearch-react/src/Results.tsx
@@ -37,7 +37,10 @@ export function Results<TItem extends StoredDocSearchHit>(
 
   return (
     <section className="DocSearch-Hits">
-      <div className="DocSearch-Hit-source">{props.title}</div>
+      <div
+        className="DocSearch-Hit-source"
+        dangerouslySetInnerHTML={{ __html: props.title }}
+      />
 
       <ul {...props.getListProps()}>
         {props.collection.items.map((item, index) => {


### PR DESCRIPTION
As mentioned in https://github.com/remix-run/remix-website/issues/157, hit titles containing HTML character entities (such as &lt;) are not displayed correctly.

![image](https://github.com/algolia/docsearch/assets/16417858/a700ab75-0726-481f-8564-c285e5690877)

I'm not particularly fond of using dangerouslySetInnerHTML, but I noticed it being utilized in the Snippet component to display hit content. You can find the usage [here](https://github.com/algolia/docsearch/blob/main/packages/docsearch-react/src/Snippet.tsx#L29).
 