### PR TITLE
fix(docsearch-react): add aria-hidden to SearchIcon and add accessible label to SearchBox input

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,15 +2,15 @@
   "files": [
     {
       "path": "packages/docsearch-css/dist/style.css",
-      "maxSize": "3 kB"
+      "maxSize": "3.25 kB"
     },
     {
       "path": "packages/docsearch-react/dist/umd/index.js",
-      "maxSize": "22.80 kB"
+      "maxSize": "23 kB"
     },
     {
       "path": "packages/docsearch-js/dist/umd/index.js",
-      "maxSize": "30.70 kB"
+      "maxSize": "31 kB"
     }
   ]
 }

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -551,6 +551,18 @@ svg.DocSearch-Hit-Select-Icon {
   width: 20px;
 }
 
+/* Hide element accessibly, so that it is still accessible to
+assistive tech users */
+.DocSearch-VisuallyHidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   :root {

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -553,7 +553,7 @@ svg.DocSearch-Hit-Select-Icon {
 
 /* Hide element accessibly, so that it is still accessible to
 assistive tech users */
-.DocSearch-VisuallyHiddenForAccessbility {
+.DocSearch-VisuallyHiddenForAccessibility {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -553,7 +553,7 @@ svg.DocSearch-Hit-Select-Icon {
 
 /* Hide element accessibly, so that it is still accessible to
 assistive tech users */
-.DocSearch-VisuallyHidden {
+.DocSearch-VisuallyHiddenForAccessbility {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -44,7 +44,7 @@ export const DocSearchButton = React.forwardRef<
       ref={ref}
     >
       <span className="DocSearch-Button-Container">
-        <SearchIcon />
+        <SearchIcon aria-hidden="true" />
         <span className="DocSearch-Button-Placeholder">{buttonText}</span>
       </span>
 

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -44,7 +44,7 @@ export const DocSearchButton = React.forwardRef<
       ref={ref}
     >
       <span className="DocSearch-Button-Container">
-        <SearchIcon aria-hidden="true" />
+        <SearchIcon />
         <span className="DocSearch-Button-Placeholder">{buttonText}</span>
       </span>
 

--- a/packages/docsearch-react/src/SearchBox.tsx
+++ b/packages/docsearch-react/src/SearchBox.tsx
@@ -69,7 +69,7 @@ export function SearchBox({ translations = {}, ...props }: SearchBoxProps) {
       >
         <label className="DocSearch-MagnifierLabel" {...props.getLabelProps()}>
           <SearchIcon />
-          <span className="DocSearch-VisuallyHiddenForAccessbility">
+          <span className="DocSearch-VisuallyHiddenForAccessibility">
             {searchInputLabel}
           </span>
         </label>

--- a/packages/docsearch-react/src/SearchBox.tsx
+++ b/packages/docsearch-react/src/SearchBox.tsx
@@ -16,6 +16,7 @@ export type SearchBoxTranslations = Partial<{
   resetButtonAriaLabel: string;
   cancelButtonText: string;
   cancelButtonAriaLabel: string;
+  searchInputLabel: string;
 }>;
 
 interface SearchBoxProps
@@ -39,6 +40,7 @@ export function SearchBox({ translations = {}, ...props }: SearchBoxProps) {
     resetButtonAriaLabel = 'Clear the query',
     cancelButtonText = 'Cancel',
     cancelButtonAriaLabel = 'Cancel',
+    searchInputLabel = 'Search',
   } = translations;
   const { onReset } = props.getFormProps({
     inputElement: props.inputRef.current,
@@ -66,7 +68,8 @@ export function SearchBox({ translations = {}, ...props }: SearchBoxProps) {
         onReset={onReset}
       >
         <label className="DocSearch-MagnifierLabel" {...props.getLabelProps()}>
-          <SearchIcon />
+          <SearchIcon aria-hidden="true" />
+          <span className="DocSearch-VisuallyHidden">{searchInputLabel}</span>
         </label>
 
         <div className="DocSearch-LoadingIndicator">

--- a/packages/docsearch-react/src/SearchBox.tsx
+++ b/packages/docsearch-react/src/SearchBox.tsx
@@ -68,8 +68,10 @@ export function SearchBox({ translations = {}, ...props }: SearchBoxProps) {
         onReset={onReset}
       >
         <label className="DocSearch-MagnifierLabel" {...props.getLabelProps()}>
-          <SearchIcon aria-hidden="true" />
-          <span className="DocSearch-VisuallyHidden">{searchInputLabel}</span>
+          <SearchIcon />
+          <span className="DocSearch-VisuallyHiddenForAccessbility">
+            {searchInputLabel}
+          </span>
         </label>
 
         <div className="DocSearch-LoadingIndicator">

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -34,19 +34,7 @@ function noResultSearch(_queries: any, _requestOptions?: any): Promise<any> {
 }
 
 describe('api', () => {
-  let container: HTMLDivElement;
-
   const docSearchSelector = '.DocSearch';
-
-  beforeEach(() => {
-    container = document.createElement('div');
-    document.body.appendChild(container);
-  });
-
-  afterEach(() => {
-    document.body.removeChild(container);
-    container = null;
-  });
 
   it('renders with minimal parameters', () => {
     render(<DocSearch />);
@@ -68,10 +56,10 @@ describe('api', () => {
       );
       expect(document.querySelector(docSearchSelector)).toBeInTheDocument();
       expect(
-        document.querySelector('.DocSearch-Button-Placeholder').innerHTML
+        document.querySelector('.DocSearch-Button-Placeholder')?.innerHTML
       ).toBe('Recherche');
       expect(
-        document.querySelector('.DocSearch-Button').getAttribute('aria-label')
+        document.querySelector('.DocSearch-Button')?.getAttribute('aria-label')
       ).toBe('Recherche');
     });
 
@@ -154,30 +142,36 @@ describe('api', () => {
                 resetButtonAriaLabel: 'Effacer',
                 cancelButtonText: 'Annuler',
                 cancelButtonAriaLabel: 'Annuler',
+                searchInputLabel: 'Recherche',
               },
             },
           }}
         />
       );
 
-      expect(document.querySelector(docSearchSelector)).toBeInTheDocument();
-
       await act(async () => {
         fireEvent.click(await screen.findByText('Search'));
       });
 
-      expect(document.querySelector('.DocSearch-Cancel').innerHTML).toBe(
+      const searchInputLabel = document.querySelector(
+        '.DocSearch-MagnifierLabel'
+      );
+
+      expect(document.querySelector(docSearchSelector)).toBeInTheDocument();
+
+      expect(document.querySelector('.DocSearch-Cancel')?.innerHTML).toBe(
         'Annuler'
       );
       expect(
-        document.querySelector('.DocSearch-Cancel').getAttribute('aria-label')
+        document.querySelector('.DocSearch-Cancel')?.getAttribute('aria-label')
       ).toBe('Annuler');
       expect(
-        document.querySelector('.DocSearch-Reset').getAttribute('title')
+        document.querySelector('.DocSearch-Reset')?.getAttribute('title')
       ).toBe('Effacer');
       expect(
-        document.querySelector('.DocSearch-Reset').getAttribute('aria-label')
+        document.querySelector('.DocSearch-Reset')?.getAttribute('aria-label')
       ).toBe('Effacer');
+      expect(searchInputLabel?.textContent).toBe('Recherche');
     });
 
     it('overrides the default DocSearchModal footer text', async () => {
@@ -292,7 +286,7 @@ describe('api', () => {
       expect(screen.getByText(/No results for/)).toBeInTheDocument();
       const link = document.querySelector('.DocSearch-Help a');
       expect(link).toBeInTheDocument();
-      expect(link.getAttribute('href')).toBe(
+      expect(link?.getAttribute('href')).toBe(
         'https://github.com/algolia/docsearch/issues/new?title=q'
       );
     });

--- a/packages/docsearch-react/src/icons/SearchIcon.tsx
+++ b/packages/docsearch-react/src/icons/SearchIcon.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
-export function SearchIcon() {
+export function SearchIcon({ ...rest }) {
   return (
     <svg
       width="20"
       height="20"
       className="DocSearch-Search-Icon"
       viewBox="0 0 20 20"
+      {...rest}
     >
       <path
         d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z"

--- a/packages/docsearch-react/src/icons/SearchIcon.tsx
+++ b/packages/docsearch-react/src/icons/SearchIcon.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-export function SearchIcon({ ...rest }) {
+export function SearchIcon() {
   return (
     <svg
       width="20"
       height="20"
       className="DocSearch-Search-Icon"
       viewBox="0 0 20 20"
-      {...rest}
+      aria-hidden="true"
     >
       <path
         d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z"

--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -171,6 +171,7 @@ const translations: DocSearchTranslations = {
       resetButtonAriaLabel: 'Clear the query',
       cancelButtonText: 'Cancel',
       cancelButtonAriaLabel: 'Cancel',
+      searchInputLabel: 'Search',
     },
     startScreen: {
       recentSearchesTitle: 'Recent',


### PR DESCRIPTION
There are 2 main changes in this PR:
- **Allows passing `aria-hidden` to the SearchIcon** so it can be hidden to assistive tech users. The unlabelled SVG can be accessed by screenreaders and can also get caught by automated accessibility audits. Since it's decorative, we can safely hide it with `aria-hidden="true"` in `<SearchBox />` and `<SearchButton />`
- **Adds an accessible label, `searchInputLabel`, to the search form's input.** Currently the `<input />` is associated with a `<label>` that does not have an accessible label, only an unlabelled SVG as a child element. This PR adds accessibly hidden text within the `<label>`. I opted to use visually hidden text (using CSS to hide the text but still make it available for assistive tech users) for the label text because it's generally a better practice than reaching for `aria-label`.

Additionally, this PR:
- Updates test to check for the new label text and translation, as well as fixes some TS related linting errors in that file.
- Updates the related docs to show the new translation option for `searchInputLabel`