### PR TITLE
fix(email): docsearch@algolia.com is being retired

### DIFF
--- a/packages/website/docs/DocSearch-program.md
+++ b/packages/website/docs/DocSearch-program.md
@@ -2,7 +2,7 @@
 title: DocSearch program
 ---
 
-If you're not finding the answer to your question on this website, this page will help you. If you're still unsure, don't hesitate to send [your question to us][1] directly.
+If you're not finding the answer to your question on this website, this page will help you. If you're still unsure, don't hesitate to connect with us on [Discord][1] or let our [support][4] team know.
 
 For questions related to the DocSearch x Algolia Crawler, please see our [Crawler FAQ](/docs/crawler).
 
@@ -68,7 +68,7 @@ Code samples are a great way for humans to understand how people use a specific 
 
 We'd love to help!
 
-If one of your favorite tool documentation websites is missing DocSearch, we encourage you to file an issue in their repository explaining how DocSearch could help. Feel free to [send us an email][1] as well, and we'll provide all the help we can.
+If one of your favorite tool documentation websites is missing DocSearch, we encourage you to file an issue in their repository explaining how DocSearch could help. Feel free to [let us know on Discord][1] as well and we'll provide all the help we can.
 
 ## How did we build this website?
 
@@ -127,6 +127,7 @@ Please be informed that while Algolia does not provide support for DocSearch its
 
 For any issue related to [the DocSearch UI library](https://github.com/algolia/docsearch), please open a [GitHub issues](https://github.com/algolia/docsearch/issues).
 
-[1]: mailto:docsearch@algolia.com
+[1]: https://alg.li/discord
 [2]: https://www.algolia.com/
 [3]: /docs/legacy/run-your-own
+[4]: https://support.algolia.com/

--- a/packages/website/docs/crawler.mdx
+++ b/packages/website/docs/crawler.mdx
@@ -5,7 +5,7 @@ title: DocSearch x Algolia Crawler
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-If you're not finding the answer to your question on this website, this page will help you. If you're still unsure, don't hesitate to send [your question to us][1] directly.
+If you're not finding the answer to your question on this website, this page will help you. If you're still unsure, don't hesitate to connect with us on [Discord][1] or let our [support][3] team know.
 
 You can also read our [Crawler FAQ](https://www.algolia.com/doc/tools/crawler/troubleshooting/faq), to understand how it behaves:
 
@@ -32,7 +32,7 @@ We've deprecated our legacy infrastructure, but you can still use it to [run you
 
 ## How to migrate
 
-> Every owners should have received a migration email from `docsearch@algolia.com` with the details. If you were not part of the previous `index` owners, or the maintainer has changed, you can request access via [our support page](https://www.algolia.com/support/).
+> Every owners should have received a migration email from Algolia with the details. If you were not part of the previous `index` owners, or the maintainer has changed, you can request access via [our support page](https://www.algolia.com/support/).
 
 All the steps are detailed in the email you've received, but in order to use the new infrastructure you need to:
 
@@ -111,5 +111,6 @@ The fastest way will be to connect with us on our [Discord](https://alg.li/disco
 - [Docusaurus blog post](https://docusaurus.io/blog/2021/11/21/algolia-docsearch-migration)
 - [Algolia Dev chat 11-23-2021](https://www.youtube.com/watch?v=htsjpojpKtc&t=2404s)
 
-[1]: mailto:docsearch@algolia.com
+[1]: https://alg.li/discord
 [2]: https://crawler.algolia.com/
+[3]: https://support.algolia.com/

--- a/packages/website/docs/required-configuration.mdx
+++ b/packages/website/docs/required-configuration.mdx
@@ -171,7 +171,7 @@ You can then [transform these attributes as `facetFilters`][3] to [filter over t
 
 - Make sure your documentation content is also available without JavaScript rendering on the client-side. If you absolutely need JavaScript turned on, you need to [set `renderJavaScript: true` in your configuration][8].
 
-Any questions? [Send us an email][9].
+Any questions? Connect with us on [Discord][14] or [support][9].
 
 [1]: /docs/integrations
 [2]: record-extractor#recordProps-api-reference
@@ -180,8 +180,9 @@ Any questions? [Send us an email][9].
 [6]: https://semver.org/
 [7]: https://www.sitemaps.org/
 [8]: https://www.algolia.com/doc/tools/crawler/apis/configuration/render-java-script/
-[9]: mailto:DocSearch@algolia.com
+[9]: https://support.algolia.com/
 [10]: /docs/DocSearch-v3#filtering-your-search
 [11]: /docs/templates
 [12]: /docs/record-extractor#introduction
 [13]: /docs/integrations
+[14]: https://alg.li/discord

--- a/packages/website/versioned_docs/version-legacy/faq.md
+++ b/packages/website/versioned_docs/version-legacy/faq.md
@@ -2,7 +2,7 @@
 title: FAQ
 ---
 
-If you're not finding the answer to your question on this website, this page will help you. If you're still unsure, don't hesitate to send [your question to us][1] directly.
+If you're not finding the answer to your question on this website, this page will help you. If you're still unsure, don't hesitate to connect with us on [Discord][1] or let our [support][19] team know.
 
 ## What data are you collecting?
 
@@ -79,7 +79,7 @@ We are pre-releasing the v3 on Docusaurus 2. It will help us to iterate faster o
 
 The `apiKey` the DocSearch team provides is [a search-only key][17] and can be safely shared publicly. You can track it in your version control system (for example Git). If you are running the scraper on your own, please make sure to create a search-only key and [do not share your Admin key][18].
 
-[1]: mailto:docsearch@algolia.com
+[1]: https://alg.li/discord
 [4]: https://www.algolia.com/doc/guides/infrastructure/servers/
 [5]: https://www.algolia.com/policies/privacy
 [6]: /docs/legacy/run-your-own
@@ -93,3 +93,4 @@ The `apiKey` the DocSearch team provides is [a search-only key][17] and can be s
 [16]: https://youtu.be/OXRjnG7SHJM
 [17]: https://www.algolia.com/doc/guides/security/api-keys/#search-only-api-key
 [18]: https://www.algolia.com/doc/guides/security/api-keys/#admin-api-key
+[19]: https://support.algolia.com/

--- a/packages/website/versioned_docs/version-legacy/how-do-we-build-an-index.mdx
+++ b/packages/website/versioned_docs/version-legacy/how-do-we-build-an-index.mdx
@@ -72,6 +72,7 @@ Based on the position within the flow, we nest elements as much as possible to k
 
 Contextual information and hierarchy must be updated once we encounter a new level. We are doing that because it highlights a new sub-section not related to the previous one.
 
-If you need any further information, please [contact us][1].
+If you need any further information, please connect with us on [Discord][1] or let our [support][2] team know.
 
-[1]: mailto:docsearch@algolia.com
+[1]: https://alg.li/discord
+[2]: https://support.algolia.com/

--- a/packages/website/versioned_docs/version-legacy/integrations.md
+++ b/packages/website/versioned_docs/version-legacy/integrations.md
@@ -17,7 +17,7 @@ If you're using one of the following tools, checkout their documentation to see 
 - [Smooth DOC][13] - [DocSearch][14]
 - [Docsy][15] - [Configure Algolia DocSearch][16]
 
-If you're maintaining a similar tool and want us to add you to the list, [get in touch with us][17]. We'd be happy to help.
+If you're maintaining a similar tool and want us to add you to the list, [get in touch with us on Discord][17]. We'd be happy to help.
 
 [1]: https://v1.docusaurus.io/
 [2]: https://v1.docusaurus.io/docs/en/search
@@ -35,4 +35,4 @@ If you're maintaining a similar tool and want us to add you to the list, [get in
 [14]: https://smooth-doc.com/docs/docsearch/
 [15]: https://www.docsy.dev/
 [16]: https://www.docsy.dev/docs/adding-content/navigation/#configure-algolia-docsearch
-[17]: mailto:docsearch@algolia.com
+[17]: https://alg.li/discord

--- a/packages/website/versioned_docs/version-legacy/required-configuration.md
+++ b/packages/website/versioned_docs/version-legacy/required-configuration.md
@@ -116,7 +116,7 @@ version:["2.0.0-alpha.62" , "latest"]
 
 - Make sure your documentation content is also available without JavaScript rendering on the client-side. If you absolutely need JavaScript turned on, you need to [set `js_render: true` in your configuration][8].
 
-Any questions? [Send us an email][9].
+Any questions? Connect with us on [Discord][9] or let our [support][10] team know.
 
 [1]: /docs/legacy/how-do-we-build-an-index
 [2]: /docs/legacy/config-file#selectors
@@ -126,4 +126,5 @@ Any questions? [Send us an email][9].
 [6]: https://semver.org/
 [7]: https://www.sitemaps.org/
 [8]: /docs/legacy/config-file#js_render-optional
-[9]: mailto:DocSearch@algolia.com
+[9]: https://alg.li/discord
+[10]: https://support.algolia.com/


### PR DESCRIPTION
This is a change by support (this email goes to support and automatically creates a ticket), support is no longer accepting ticket creation via email. Replacing with links to Discord or proper support site. More info can be found at https://algolia.atlassian.net/browse/ZA-268