### PR TITLE
fix: DocSearch-Hit-source is empty in certain cases

### DIFF
--- a/packages/docsearch-react/src/utils/removeHighlightTags.ts
+++ b/packages/docsearch-react/src/utils/removeHighlightTags.ts
@@ -1,24 +1,14 @@
 import type { DocSearchHit, InternalDocSearchHit } from '../types';
 
 const regexHighlightTags = /(<mark>|<\/mark>)/g;
-const regexHasHighlightTags = RegExp(regexHighlightTags.source);
 
 export function removeHighlightTags(
   hit: DocSearchHit | InternalDocSearchHit
 ): string {
-  const internalDocSearchHit = hit as InternalDocSearchHit;
+  const highlightedValue =
+    ('__docsearch_parent' in hit
+      ? hit.__docsearch_parent?._highlightResult?.hierarchy?.lvl0?.value
+      : hit._highlightResult?.hierarchy?.lvl0?.value) ?? hit.hierarchy.lvl0;
 
-  if (!internalDocSearchHit.__docsearch_parent && !hit._highlightResult) {
-    return hit.hierarchy.lvl0;
-  }
-
-  const { value } =
-    (internalDocSearchHit.__docsearch_parent
-      ? internalDocSearchHit.__docsearch_parent?._highlightResult?.hierarchy
-          ?.lvl0
-      : hit._highlightResult?.hierarchy?.lvl0) || {};
-
-  return value && regexHasHighlightTags.test(value)
-    ? value.replace(regexHighlightTags, '')
-    : value;
+  return highlightedValue.replace(regexHighlightTags, '');
 }


### PR DESCRIPTION
fixes #2294 

Earlier `hit.hierarchy.lvl0` was returned only if `hit._highlightResult` is falsy. But in certain cases `hit._highlightResult.hierarchy` is not there even if `hit._highlightResult` is present. This PR returns `hit.hierarchy.lvl0` as a fallback always.

I'm not sure, but some change in Algolia's response triggered this. Earlier it was working fine. The types still indicate that `hit._highlightResult.hierarchy.lvl0.value` will always be set. So, it might be regression in some other service and other parts might also break 👀 

https://github.com/algolia/docsearch/blob/3067715a6b9e10f3daf3275b620e9a82c02aade6/packages/docsearch-react/src/types/DocSearchHit.ts#L28-L32

<img width="1097" alt="image" src="https://github.com/user-attachments/assets/3f3dae63-7ec2-4541-a511-d44b3d5c05e1"><br>

PS: the original issue didn't share the crawler config. Here it is:

<details>
  <summary>Expand</summary>

```js
new Crawler({
  appId: "8J64VVRP8K",
  apiKey: "---",
  rateLimit: 8,
  startUrls: ["https://vitepress.dev/"],
  renderJavaScript: false,
  sitemaps: [],
  exclusionPatterns: [],
  ignoreCanonicalTo: false,
  discoveryPatterns: ["https://vitepress.dev/**"],
  schedule: "at 05:10 on Saturday",
  actions: [
    {
      indexName: "vitepress",
      pathsToMatch: ["https://vitepress.dev/**"],
      recordExtractor: ({ $, helpers }) => {
        return helpers.docsearch({
          recordProps: {
            lvl1: ".content h1",
            content: ".content p, .content li",
            lvl0: {
              selectors: "",
              defaultValue: "Documentation",
            },
            lvl2: ".content h2",
            lvl3: ".content h3",
            lvl4: ".content h4",
            lvl5: ".content h5",
          },
          indexHeadings: true,
        });
      },
    },
  ],
  initialIndexSettings: {
    vitepress: {
      attributesForFaceting: ["type", "lang"],
      attributesToRetrieve: ["hierarchy", "content", "anchor", "url"],
      attributesToHighlight: ["hierarchy", "hierarchy_camel", "content"],
      attributesToSnippet: ["content:10"],
      camelCaseAttributes: ["hierarchy", "hierarchy_radio", "content"],
      searchableAttributes: [
        "unordered(hierarchy_radio_camel.lvl0)",
        "unordered(hierarchy_radio.lvl0)",
        "unordered(hierarchy_radio_camel.lvl1)",
        "unordered(hierarchy_radio.lvl1)",
        "unordered(hierarchy_radio_camel.lvl2)",
        "unordered(hierarchy_radio.lvl2)",
        "unordered(hierarchy_radio_camel.lvl3)",
        "unordered(hierarchy_radio.lvl3)",
        "unordered(hierarchy_radio_camel.lvl4)",
        "unordered(hierarchy_radio.lvl4)",
        "unordered(hierarchy_radio_camel.lvl5)",
        "unordered(hierarchy_radio.lvl5)",
        "unordered(hierarchy_radio_camel.lvl6)",
        "unordered(hierarchy_radio.lvl6)",
        "unordered(hierarchy_camel.lvl0)",
        "unordered(hierarchy.lvl0)",
        "unordered(hierarchy_camel.lvl1)",
        "unordered(hierarchy.lvl1)",
        "unordered(hierarchy_camel.lvl2)",
        "unordered(hierarchy.lvl2)",
        "unordered(hierarchy_camel.lvl3)",
        "unordered(hierarchy.lvl3)",
        "unordered(hierarchy_camel.lvl4)",
        "unordered(hierarchy.lvl4)",
        "unordered(hierarchy_camel.lvl5)",
        "unordered(hierarchy.lvl5)",
        "unordered(hierarchy_camel.lvl6)",
        "unordered(hierarchy.lvl6)",
        "content",
      ],
      distinct: true,
      attributeForDistinct: "url",
      customRanking: [
        "desc(weight.pageRank)",
        "desc(weight.level)",
        "asc(weight.position)",
      ],
      ranking: [
        "words",
        "filters",
        "typo",
        "attribute",
        "proximity",
        "exact",
        "custom",
      ],
      highlightPreTag: '<span class="algolia-docsearch-suggestion--highlight">',
      highlightPostTag: "</span>",
      minWordSizefor1Typo: 3,
      minWordSizefor2Typos: 7,
      allowTyposOnNumericTokens: false,
      minProximity: 1,
      ignorePlurals: true,
      advancedSyntax: true,
      attributeCriteriaComputedByMinProximity: true,
      removeWordsIfNoResults: "allOptional",
    },
  },
});
```

</details>

Just sharing in case it's something specific to vitepress-recommended crawler.