### PR TITLE
fix(hits): default to hierarchy lvl0 if highlights present

### DIFF
--- a/examples/demo/src/App.js
+++ b/examples/demo/src/App.js
@@ -9,9 +9,9 @@ function App() {
     <div>
       <h1>DocSearch v3 - React</h1>
       <DocSearch
-        indexName="docsearch"
-        appId="R2IYF7ETH7"
-        apiKey="599cec31baffa4868cae4e79f180729b"
+        indexName="vuejs"
+        appId="ML0LEBN7FQ"
+        apiKey="21cf9df0734770a2448a9da64a700c22"
         insights
       />
     </div>

--- a/packages/docsearch-react/src/utils/removeHighlightTags.ts
+++ b/packages/docsearch-react/src/utils/removeHighlightTags.ts
@@ -12,13 +12,15 @@ export function removeHighlightTags(
     return hit.hierarchy.lvl0;
   }
 
-  const { value } =
-    (internalDocSearchHit.__docsearch_parent
-      ? internalDocSearchHit.__docsearch_parent?._highlightResult?.hierarchy
-          ?.lvl0
-      : hit._highlightResult?.hierarchy?.lvl0) || {};
+  const lvl0 = internalDocSearchHit.__docsearch_parent
+    ? internalDocSearchHit.__docsearch_parent?._highlightResult?.hierarchy?.lvl0
+    : hit._highlightResult?.hierarchy?.lvl0;
 
-  return value && regexHasHighlightTags.test(value)
-    ? value.replace(regexHighlightTags, '')
-    : value;
+  if (!lvl0) {
+    return hit.hierarchy.lvl0;
+  }
+
+  return lvl0.value && regexHasHighlightTags.test(lvl0.value)
+    ? lvl0.value.replace(regexHighlightTags, '')
+    : lvl0.value;
 }


### PR DESCRIPTION
https://algolia.atlassian.net/browse/DI-2986

There seems to be a bug on the indexing side which impacts some DocSearch users. This bug has been reported to me by @rickhanlonii and fixed in https://github.com/reactjs/react.dev/pull/7183 temporarily, but we can globally mitigate this issue which also impacts other DocSearch users such as https://vuejs.org/, https://tailwindcss.com/

We now default to the non highlighted lvl0 in case the highlightResult value is not present

You can try this fix by running `yarn playground:start` on `main` and this branch:
- On main (or just https://vuejs.org/), no section appears (cf screenshot 1
- On this branch (cf screenshot 2)

![Screenshot 2024-09-27 at 10 31 16](https://github.com/user-attachments/assets/e471dd15-46c0-4edb-af16-0d34d62e4ed6)

![Screenshot 2024-09-27 at 10 31 53](https://github.com/user-attachments/assets/6dde009f-2e77-47eb-8807-a6d37373045b)