### PR TITLE
fix: use npm for release

### DIFF
--- a/packages/docsearch-css/package.json
+++ b/packages/docsearch-css/package.json
@@ -4,7 +4,10 @@
   "version": "3.7.0",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
-  "repository": "algolia/docsearch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/docsearch.git"
+  },
   "author": {
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"

--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -4,7 +4,10 @@
   "version": "3.7.0",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
-  "repository": "algolia/docsearch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/docsearch.git"
+  },
   "author": {
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -4,7 +4,10 @@
   "version": "3.7.0",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
-  "repository": "algolia/docsearch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/docsearch.git"
+  },
   "author": {
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"

--- a/ship.config.js
+++ b/ship.config.js
@@ -11,7 +11,7 @@ export default {
     packagesToPublish: packages,
   },
   publishCommand({ tag }) {
-    return `yarn publish --access public --tag ${tag}`;
+    return `npm publish --tag ${tag}`;
   },
   versionUpdated({ exec, dir, version }) {
     // Update package dependencies


### PR DESCRIPTION
`yarn publish` doesn't exists anymore