### PR TITLE
chore: add `repository.directory` property to `package.json`

### DIFF
--- a/packages/docsearch-css/package.json
+++ b/packages/docsearch-css/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://docsearch.algolia.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/algolia/docsearch.git"
+    "url": "git+https://github.com/algolia/docsearch.git",
+    "directory": "packages/docsearch-css"
   },
   "author": {
     "name": "Algolia, Inc.",

--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://docsearch.algolia.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/algolia/docsearch.git"
+    "url": "git+https://github.com/algolia/docsearch.git",
+    "directory": "packages/docsearch-js"
   },
   "author": {
     "name": "Algolia, Inc.",

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://docsearch.algolia.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/algolia/docsearch.git"
+    "url": "git+https://github.com/algolia/docsearch.git",
+    "directory": "packages/docsearch-react"
   },
   "author": {
     "name": "Algolia, Inc.",


### PR DESCRIPTION
Hello,  

I’ve added the `repository.directory` property to `package.json`.  

This property is mentioned in the [npm documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository) and can be useful for maintaining a monorepo.  

It helps tools like npm and GitHub identify the specific directory within the repository where the package is located, which is especially beneficial in monorepo setups.

![image](https://github.com/user-attachments/assets/8231d415-c56b-4981-91f5-10c58c88402f)

