### PR TITLE
docs: update ApplyForm.js

### DIFF
--- a/packages/website/src/components/ApplyForm.js
+++ b/packages/website/src/components/ApplyForm.js
@@ -221,7 +221,6 @@ function ApplyForm() {
 
         <Text small={true} className="uil-ta-center">
           <strong>
-            Only apply if you don't have a DocSearch application yet. <br />
             For support requests, make sure to first{' '}
             <InlineLink href="/docs/docsearch-program#support">read our policy</InlineLink>.
           </strong>{' '}


### PR DESCRIPTION
A user asked a question about this text. I felt like it was misleading since you can apply again if you already have a docsearch application. Users do this when they need to cover another domain and want a separate index.

What we won't accept is an application that covers a domain that has previously been approved. In that scenario, the submitted form has an obvious message that its a duplicate domain.