### PR TITLE
fix(css): older sass supported syntax

### DIFF
--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -68,7 +68,7 @@
   box-shadow: var(--docsearch-key-pressed-shadow);
 }
 
-@media (width <= 768px) {
+@media (max-width: 768px) {
   .DocSearch-Button-Keys,
   .DocSearch-Button-Placeholder {
     display: none;

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -564,7 +564,7 @@ assistive tech users */
 }
 
 /* Responsive */
-@media (width <= 768px) {
+@media (max-width: 768px) {
   :root {
     --docsearch-spacing: 10px;
     --docsearch-footer-height: 40px;

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -29,7 +29,7 @@ html[data-theme='dark'] {
 }
 
 /* DocSearch x Algolia logo */
-@media (width <=565px) {
+@media (max-width: 565px) {
   .navbar__logo .docsearch-nav-logo {
     width: 70%;
     height: auto;
@@ -38,7 +38,7 @@ html[data-theme='dark'] {
 }
 
 /* DocSearch x Algolia logo in sidebar */
-@media (width >=997px) {
+@media (min-width: 997px) {
   .theme-doc-sidebar-container .docsearch-nav-logo {
     height: auto;
   }


### PR DESCRIPTION
closes https://github.com/algolia/docsearch/issues/2414

> LibSass and older versions of Dart Sass and Ruby Sass don’t support media queries with features written in a [range context](https://www.w3.org/TR/mediaqueries-4/#mq-range-context). They do support other standard media queries.

https://www.w3.org/TR/mediaqueries-4/#mq-range-context
https://sass-lang.com/documentation/at-rules/css/#media