### PR TITLE
fix(a11y): have unique ids for favorite/recent lists

### DIFF
--- a/cypress/e2e/search/actions.spec.ts
+++ b/cypress/e2e/search/actions.spec.ts
@@ -111,6 +111,10 @@ describe('Search', () => {
     cy.typeQueryNotMatching();
     cy.contains('No results for').should('be.visible');
   });
+
+  it('should not refer to Recent/Favorite in aria-controls', () => {
+    cy.get('.DocSearch-Input').should('not.have.attr', 'aria-controls');
+  });
 });
 
 describe('Recent and Favorites', () => {
@@ -143,5 +147,27 @@ describe('Recent and Favorites', () => {
     cy.contains('Favorite').should('be.visible');
     cy.get('#docsearch-favoriteSearches-item-0').find('[title="Remove this search from favorites"]').trigger('click');
     cy.contains('No recent searches').should('be.visible');
+  });
+
+  it('Input controls Recent and Favorite lists', () => {
+    // Mark one result as favorite
+    cy.get('#docsearch-recentSearches-item-0').find('[title="Save this search"]').trigger('click');
+    cy.contains('Favorite').should('be.visible');
+    // Search for something else to add a new recent search
+    cy.typeQueryMatching();
+    cy.get('#docsearch-hits1-item-5 > a').click({ force: true }).wait(1000);
+
+    cy.openModal();
+    cy.contains('Recent').should('be.visible');
+    cy.contains('Favorite').should('be.visible');
+
+    // Make sure the specified elements exist
+    cy.get('.DocSearch-Input')
+      .invoke('attr', 'aria-controls')
+      .then((value) => {
+        const ids = value!.split(' ');
+        expect(ids).to.have.length(2);
+        ids.forEach(id => cy.get(`#${id}`).should('exist'));
+      });
   });
 });

--- a/cypress/e2e/search/actions.spec.ts
+++ b/cypress/e2e/search/actions.spec.ts
@@ -167,7 +167,7 @@ describe('Recent and Favorites', () => {
       .then((value) => {
         const ids = value!.split(' ');
         expect(ids).to.have.length(2);
-        ids.forEach(id => cy.get(`#${id}`).should('exist'));
+        ids.forEach((id) => cy.get(`#${id}`).should('exist'));
       });
   });
 });

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -36,8 +36,8 @@
     "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
   },
   "dependencies": {
-    "@algolia/autocomplete-core": "1.17.9",
-    "@algolia/autocomplete-preset-algolia": "1.17.9",
+    "@algolia/autocomplete-core": "1.18.1",
+    "@algolia/autocomplete-preset-algolia": "1.18.1",
     "@docsearch/css": "3.9.0",
     "algoliasearch": "^5.14.2"
   },

--- a/packages/docsearch-react/src/Results.tsx
+++ b/packages/docsearch-react/src/Results.tsx
@@ -28,7 +28,7 @@ export function Results<TItem extends StoredDocSearchHit>(props: ResultsProps<TI
     <section className="DocSearch-Hits">
       <div className="DocSearch-Hit-source">{props.title}</div>
 
-      <ul {...props.getListProps()}>
+      <ul {...props.getListProps({ source: props.collection.source })}>
         {props.collection.items.map((item, index) => {
           return <Result key={[props.title, item.objectID].join(':')} item={item} index={index} {...props} />;
         })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,46 +12,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-core@npm:1.17.9":
-  version: 1.17.9
-  resolution: "@algolia/autocomplete-core@npm:1.17.9"
+"@algolia/autocomplete-core@npm:1.18.1":
+  version: 1.18.1
+  resolution: "@algolia/autocomplete-core@npm:1.18.1"
   dependencies:
-    "@algolia/autocomplete-plugin-algolia-insights": "npm:1.17.9"
-    "@algolia/autocomplete-shared": "npm:1.17.9"
-  checksum: 10c0/e1111769a8723b9dd45fc38cd7edc535c86c1f908b84b5fdc5de06ba6b8c7aca14e5f52ebce84fa5f7adf857332e396b93b7e7933b157b2c9aefc0a19d9574ab
+    "@algolia/autocomplete-plugin-algolia-insights": "npm:1.18.1"
+    "@algolia/autocomplete-shared": "npm:1.18.1"
+  checksum: 10c0/4b1f5f742690ad9cfc8b365f98b4a0b67002c81e83bd43ee92d70c0702b0fe9e26255dbd2fa36d6949d0184f35a8ecdd0d2eb87c9dc6fbc6f1cd091fb7c8149d
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-plugin-algolia-insights@npm:1.17.9":
-  version: 1.17.9
-  resolution: "@algolia/autocomplete-plugin-algolia-insights@npm:1.17.9"
+"@algolia/autocomplete-plugin-algolia-insights@npm:1.18.1":
+  version: 1.18.1
+  resolution: "@algolia/autocomplete-plugin-algolia-insights@npm:1.18.1"
   dependencies:
-    "@algolia/autocomplete-shared": "npm:1.17.9"
+    "@algolia/autocomplete-shared": "npm:1.18.1"
   peerDependencies:
     search-insights: ">= 1 < 3"
-  checksum: 10c0/05c21502631643abdcd6e9f70b5814a60d34bad59bca501e26e030fd72e689be5cecfb6e8939a0a1bdcb2394591e55e26a42a82c7247528eafeff714db0819a4
+  checksum: 10c0/af159286998ed5804b8bed540e3ec1c9ef5d58131364899d75019e3d8a9f8212e2f33865881beba47b93e537dbaa8daf29ba3a637b5760d1b3bf2324c92a4d92
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-preset-algolia@npm:1.17.9":
-  version: 1.17.9
-  resolution: "@algolia/autocomplete-preset-algolia@npm:1.17.9"
+"@algolia/autocomplete-preset-algolia@npm:1.18.1":
+  version: 1.18.1
+  resolution: "@algolia/autocomplete-preset-algolia@npm:1.18.1"
   dependencies:
-    "@algolia/autocomplete-shared": "npm:1.17.9"
+    "@algolia/autocomplete-shared": "npm:1.18.1"
   peerDependencies:
     "@algolia/client-search": ">= 4.9.1 < 6"
     algoliasearch: ">= 4.9.1 < 6"
-  checksum: 10c0/99159c7e02a927d0d96717cb4cfd2f8dbc4da73267a8eae4f83af5bf74087089f6e7dbffd316512e713a4cc534e936b6a7ccb5c4a5ff84b4bf73f2d3cc050e79
+  checksum: 10c0/122bac3bcad4e3da9a697409cae8f75322aaf5e6d4954ffb7599005e076ce51594b4c248622b9e6820f82244e5b44f90eabb339a5dd2c55d0882e5594f1c9c5c
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-shared@npm:1.17.9":
-  version: 1.17.9
-  resolution: "@algolia/autocomplete-shared@npm:1.17.9"
+"@algolia/autocomplete-shared@npm:1.18.1":
+  version: 1.18.1
+  resolution: "@algolia/autocomplete-shared@npm:1.18.1"
   peerDependencies:
     "@algolia/client-search": ">= 4.9.1 < 6"
     algoliasearch: ">= 4.9.1 < 6"
-  checksum: 10c0/b318281aecdaae09171b47ee4f7bc66b613852cad4506e9d6278fff35ba68a12dd9cce2d90b5f4c3ba0e3d7d780583cbe46b22275260e41bbf09fb01e4a18f49
+  checksum: 10c0/8012e6e5a6ae0cf5ac0a5ab126d51486ddf63570751aa8b86fd35dd6ffc1a52080eddf5889a0726fe464e8126efc6fcddd5dbd5c10822894ec75a2d65b4b0f0d
   languageName: node
   linkType: hard
 
@@ -2203,8 +2203,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@docsearch/react@workspace:packages/docsearch-react"
   dependencies:
-    "@algolia/autocomplete-core": "npm:1.17.9"
-    "@algolia/autocomplete-preset-algolia": "npm:1.17.9"
+    "@algolia/autocomplete-core": "npm:1.18.1"
+    "@algolia/autocomplete-preset-algolia": "npm:1.18.1"
     "@docsearch/css": "npm:3.9.0"
     "@rollup/plugin-replace": "npm:6.0.2"
     "@testing-library/jest-dom": "npm:6.6.3"


### PR DESCRIPTION
There are two distinct a11y bugs which are related to each-other:

1. The main input `.DocSearch-Input` contains `aria-controls="docsearch-recentSearches-list docsearch-favoriteSearches-list"` which is not compliant because the `recentSearches` or `favoriteSearches` elements do not exist all the time in the DOM. Only if existing favorites or recent searches they should be added - see https://github.com/microsoft/playwright.dev/issues/1628. The fix for this is in https://github.com/algolia/autocomplete/pull/1302. 
2. When there is a _Recent_ and a _Favourite_ results list is shown, they share the same underlying `id="docsearch-list"`. This PR addresses that and adds a test for both issues.

**Investigation**

This seems to render the search list here:

https://github.com/algolia/docsearch/blob/aa666decccb465a56d458d09379837342b520d73/packages/docsearch-react/src/StartScreen.tsx#L49

Which calls `<ul {...props.getListProps()}>` here:

https://github.com/algolia/docsearch/blob/7f670b6ba9d09bd8adf2455239c1c96ceb208851/packages/docsearch-react/src/Results.tsx#L31

Which gets its value from a different package:

https://github.com/algolia/autocomplete/blob/f05a701724d75fc3ade5e49c93d23077fb200371/packages/autocomplete-core/src/getPropGetters.ts#L302

And reads its value from here:

https://github.com/algolia/docsearch/blob/db8edeb818f8a788efe89b97f954308a1b1e2b32/packages/docsearch-react/src/DocSearchModal.tsx#L131

So it looks like `getListProps`  reads source only from the passed parameters. This PR passes the source over in the params.

Thanks for the review. Max.