### PR TITLE
chore(deps): replace yarn watch with nodemon

### DIFF
--- a/packages/docsearch-css/package.json
+++ b/packages/docsearch-css/package.json
@@ -23,6 +23,9 @@
     "build:clean": "rm -rf ./dist",
     "build:css": "node build-css.js",
     "build": "yarn build:clean && mkdir dist && yarn build:css",
-    "watch": "watch \"yarn build:css\" --ignoreDirectoryPattern \"/dist/\""
+    "watch": "nodemon --watch 'src/**/*.css' --exec 'yarn build:css' --ext css"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.9"
   }
 }

--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -30,13 +30,14 @@
     "build:clean-types": "rm -rf ./dist/esm/types",
     "build": "yarn build:clean && yarn build:types && rollup --config --bundleConfigAsCjs && yarn build:clean-types",
     "on:change": "yarn build",
-    "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
+    "watch": "nodemon --watch src --exec \"yarn on:change\" --ignore dist/ --ext ts,tsx"
   },
   "dependencies": {
     "@docsearch/react": "3.9.0",
     "preact": "^10.0.0"
   },
   "devDependencies": {
-    "@rollup/plugin-replace": "6.0.2"
+    "@rollup/plugin-replace": "6.0.2",
+    "nodemon": "^3.1.9"
   }
 }

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -33,7 +33,7 @@
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/esm/types",
     "build": "yarn build:clean && yarn build:types && rollup --config --bundleConfigAsCjs && yarn build:clean-types",
     "on:change": "yarn build",
-    "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
+    "watch": "nodemon --watch src --ext ts,tsx,js,jsx,json --ignore dist/ --ignore node_modules/ --verbose --delay 250ms --exec \"yarn on:change\""
   },
   "dependencies": {
     "@algolia/autocomplete-core": "1.18.1",
@@ -45,6 +45,7 @@
     "@rollup/plugin-replace": "6.0.2",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",
+    "nodemon": "^3.1.0",
     "vitest": "3.0.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,6 +2092,8 @@ __metadata:
 "@docsearch/css@npm:3.9.0, @docsearch/css@workspace:*, @docsearch/css@workspace:packages/docsearch-css":
   version: 0.0.0-use.local
   resolution: "@docsearch/css@workspace:packages/docsearch-css"
+  dependencies:
+    nodemon: "npm:^3.1.9"
   languageName: unknown
   linkType: soft
 
@@ -2109,8 +2111,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@docsearch/js@workspace:packages/docsearch-js"
   dependencies:
-    "@docsearch/react": "npm:3.9.0"
+    "@docsearch/react": "npm:3"
     "@rollup/plugin-replace": "npm:6.0.2"
+    nodemon: "npm:^3.1.9"
     preact: "npm:^10.0.0"
   languageName: unknown
   linkType: soft
@@ -2199,7 +2202,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@docsearch/react@npm:3.9.0, @docsearch/react@npm:^3.8.1, @docsearch/react@workspace:*, @docsearch/react@workspace:packages/docsearch-react":
+"@docsearch/react@npm:3, @docsearch/react@npm:3.9.0, @docsearch/react@npm:^3.8.1, @docsearch/react@workspace:*, @docsearch/react@workspace:packages/docsearch-react":
   version: 0.0.0-use.local
   resolution: "@docsearch/react@workspace:packages/docsearch-react"
   dependencies:
@@ -2210,6 +2213,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:6.6.3"
     "@testing-library/react": "npm:16.2.0"
     algoliasearch: "npm:^5.14.2"
+    nodemon: "npm:^3.1.0"
     vitest: "npm:3.0.2"
   peerDependencies:
     "@types/react": ">= 16.8.0 < 20.0.0"
@@ -7489,7 +7493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.4.2, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
+"chokidar@npm:^3.4.2, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -8991,7 +8995,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:4.4.0, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.6, debug@npm:^4.3.7, debug@npm:^4.4.0":
+"debug@npm:4, debug@npm:4.4.0, debug@npm:^4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.6, debug@npm:^4.3.7, debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -12379,6 +12383,13 @@ __metadata:
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
+  languageName: node
+  linkType: hard
+
+"ignore-by-default@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "ignore-by-default@npm:1.0.1"
+  checksum: 10c0/9ab6e70e80f7cc12735def7ecb5527cfa56ab4e1152cd64d294522827f2dcf1f6d85531241537dc3713544e88dd888f65cb3c49c7b2cddb9009087c75274e533
   languageName: node
   linkType: hard
 
@@ -15785,6 +15796,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nodemon@npm:^3.1.0, nodemon@npm:^3.1.9":
+  version: 3.1.9
+  resolution: "nodemon@npm:3.1.9"
+  dependencies:
+    chokidar: "npm:^3.5.2"
+    debug: "npm:^4"
+    ignore-by-default: "npm:^1.0.1"
+    minimatch: "npm:^3.1.2"
+    pstree.remy: "npm:^1.1.8"
+    semver: "npm:^7.5.3"
+    simple-update-notifier: "npm:^2.0.0"
+    supports-color: "npm:^5.5.0"
+    touch: "npm:^3.1.0"
+    undefsafe: "npm:^2.0.5"
+  bin:
+    nodemon: bin/nodemon.js
+  checksum: 10c0/dbd6fab40e6be18929ac02366bfdc2203c1688f45186d9468f6bdeb192f0666d044500dfb729d825526715196456e6a17509a13de019b058cbce428d72d04eb5
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^6.0.0":
   version: 6.0.0
   resolution: "nopt@npm:6.0.0"
@@ -18908,6 +18939,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pstree.remy@npm:^1.1.8":
+  version: 1.1.8
+  resolution: "pstree.remy@npm:1.1.8"
+  checksum: 10c0/30f78c88ce6393cb3f7834216cb6e282eb83c92ccb227430d4590298ab2811bc4a4745f850a27c5178e79a8f3e316591de0fec87abc19da648c2b3c6eb766d14
+  languageName: node
+  linkType: hard
+
 "pump@npm:^3.0.0":
   version: 3.0.2
   resolution: "pump@npm:3.0.2"
@@ -20720,6 +20758,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-update-notifier@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "simple-update-notifier@npm:2.0.0"
+  dependencies:
+    semver: "npm:^7.5.3"
+  checksum: 10c0/2a00bd03bfbcbf8a737c47ab230d7920f8bfb92d1159d421bdd194479f6d01ebc995d13fbe13d45dace23066a78a3dc6642999b4e3b38b847e6664191575b20c
+  languageName: node
+  linkType: hard
+
 "sirv@npm:^2.0.3":
   version: 2.0.4
   resolution: "sirv@npm:2.0.4"
@@ -21636,7 +21683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0":
+"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
@@ -22097,6 +22144,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"touch@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "touch@npm:3.1.1"
+  bin:
+    nodetouch: bin/nodetouch.js
+  checksum: 10c0/d2e4d269a42c846a22a29065b9af0b263de58effc85a1764bb7a2e8fc4b47700e9e2fcbd7eb1f5bffbb7c73d860f93600cef282b93ddac8f0b62321cb498b36e
+  languageName: node
+  linkType: hard
+
 "tough-cookie@npm:^5.0.0":
   version: 5.1.0
   resolution: "tough-cookie@npm:5.1.0"
@@ -22446,6 +22502,13 @@ __metadata:
     has-symbols: "npm:^1.1.0"
     which-boxed-primitive: "npm:^1.1.1"
   checksum: 10c0/7dbd35ab02b0e05fe07136c72cb9355091242455473ec15057c11430129bab38b7b3624019b8778d02a881c13de44d63cd02d122ee782fb519e1de7775b5b982
+  languageName: node
+  linkType: hard
+
+"undefsafe@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "undefsafe@npm:2.0.5"
+  checksum: 10c0/96c0466a5fbf395917974a921d5d4eee67bca4b30d3a31ce7e621e0228c479cf893e783a109af6e14329b52fe2f0cb4108665fad2b87b0018c0df6ac771261d5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,7 +2111,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@docsearch/js@workspace:packages/docsearch-js"
   dependencies:
-    "@docsearch/react": "npm:3"
+    "@docsearch/react": "npm:3.9.0"
     "@rollup/plugin-replace": "npm:6.0.2"
     nodemon: "npm:^3.1.9"
     preact: "npm:^10.0.0"
@@ -2202,7 +2202,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@docsearch/react@npm:3, @docsearch/react@npm:3.9.0, @docsearch/react@npm:^3.8.1, @docsearch/react@workspace:*, @docsearch/react@workspace:packages/docsearch-react":
+"@docsearch/react@npm:3.9.0, @docsearch/react@npm:^3.8.1, @docsearch/react@workspace:*, @docsearch/react@workspace:packages/docsearch-react":
   version: 0.0.0-use.local
   resolution: "@docsearch/react@workspace:packages/docsearch-react"
   dependencies:


### PR DESCRIPTION
## Replace `yarn watch` with `nodemon` in 3 packages

### 🛠️ What’s changed
Replaced the usage of `yarn watch` with `nodemon` in three packages.

### 📌 Motivation
We're making this change due to performance issues observed with the native `yarn watch` command. It tends to be less reliable and slower in larger projects or when multiple watchers are involved.

Switching to `nodemon` improves:
- File change detection
- Restart times
- Overall developer experience

### ✅ Benefits
- Better performance during development
- More reliable and consistent watch behavior
- Easier to customize and debug