### PR TITLE
chore: Switch Preact to be a devDep of '@docsearch/js'

### DIFF
--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -33,10 +33,10 @@
     "watch": "watch \"yarn on:change\" --ignoreDirectoryPattern \"/dist/\""
   },
   "dependencies": {
-    "@docsearch/react": "3.9.0",
-    "preact": "^10.0.0"
+    "@docsearch/react": "3.9.0"
   },
   "devDependencies": {
-    "@rollup/plugin-replace": "6.0.2"
+    "@rollup/plugin-replace": "6.0.2",
+    "preact": "^10.0.0"
   }
 }


### PR DESCRIPTION
As `@docsearch/js` inlines Preact into its bundle, there's no reason for it to be listed as a dependency. Package managers will install Preact alongside this module but that'll never be used.

Won't have any effect on usage, just strips out an unnecessary dependency for those consuming from NPM (as opposed to a CDN, which tend to be a bit smarter about this sort of thing).