### PR TITLE
fix: size and background scroll fixes

### DIFF
--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -576,10 +576,8 @@ assistive tech users */
   }
 
   .DocSearch-Container {
-    height: 100vh;
-    height: -webkit-fill-available;
     height: calc(var(--docsearch-vh, 1vh) * 100);
-    position: absolute;
+    height: 100dvh;
   }
 
   .DocSearch-Footer {
@@ -597,9 +595,8 @@ assistive tech users */
   .DocSearch-Modal {
     border-radius: 0;
     box-shadow: none;
-    height: 100vh;
-    height: -webkit-fill-available;
     height: calc(var(--docsearch-vh, 1vh) * 100);
+    height: 100dvh;
     margin: 0;
     max-width: 100%;
     width: 100%;

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -570,6 +570,12 @@ assistive tech users */
     --docsearch-spacing: 10px;
     --docsearch-footer-height: 40px;
   }
+  /* Prevent body scroll on modal-open for mobile */
+  /* https://stackoverflow.com/a/24727206/6276948 */
+  body:has(.DocSearch-Container) {
+    overflow: hidden;
+    position: fixed;
+  }
 
   .DocSearch-Dropdown {
     height: 100%;


### PR DESCRIPTION
Fixes #2243 

- **fix(docsearch-css): use correct size and position**
- **fix(docksearch-css): prevent mobile body scrolling**

Makes the modal sized correctly and prevents background scroll on mobile (the trade-off of no-background-scroll is that you get scrolled to top of page, but this is only necessary on mobile).

---

-webkit-fill-available is no longer even an option:
- https://caniuse.com/intrinsic-width
- https://developer.mozilla.org/en-US/docs/Web/CSS/WebKit_Extensions

`max-content` is close equivalent, but it is not what you want when you actually want the thing to take up the full viewport.