### PR TITLE
fix(v4): ask ai updates

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,11 +6,11 @@
     },
     {
       "path": "packages/docsearch-react/dist/umd/index.js",
-      "maxSize": "65 kB"
+      "maxSize": "70 kB"
     },
     {
       "path": "packages/docsearch-js/dist/umd/index.js",
-      "maxSize": "80 kB"
+      "maxSize": "85 kB"
     }
   ]
 }

--- a/cypress/e2e/search.spec.ts
+++ b/cypress/e2e/search.spec.ts
@@ -83,7 +83,6 @@ describe('Search', () => {
     cy.typeQueryMatching();
     cy.get('.DocSearch-Clear').click();
     cy.get('.DocSearch-Hits').should('not.exist');
-    cy.contains('No recent searches').should('be.visible');
   });
 
   it('Keyboard navigation leads to result', () => {
@@ -135,7 +134,7 @@ describe('Recent and Favorites', () => {
 
   it('Recent search can be deleted', () => {
     cy.get('#docsearch-recentSearches-item-0').find('[title="Remove this search from history"]').trigger('click');
-    cy.contains('No recent searches').should('be.visible');
+    cy.get('.DocSearch-Hits').should('not.exist');
   });
 
   it('Recent search can be favorited', () => {
@@ -148,7 +147,7 @@ describe('Recent and Favorites', () => {
     cy.get('#docsearch-recentSearches-item-0').find('[title="Save this search"]').trigger('click');
     cy.contains('Favorite').should('be.visible');
     cy.get('#docsearch-favoriteSearches-item-0').find('[title="Remove this search from favorites"]').trigger('click');
-    cy.contains('No recent searches').should('be.visible');
+    cy.get('.DocSearch-Hits').should('not.exist');
   });
 
   it('Input controls Recent and Favorite lists', () => {

--- a/examples/demo-askai/src/App.tsx
+++ b/examples/demo-askai/src/App.tsx
@@ -9,10 +9,10 @@ function App(): JSX.Element {
     <div>
       <h1>DocSearch v4 - AskAI</h1>
       <DocSearch
-        indexName="beta-react"
+        indexName="tailwindcss"
         appId="betaHAXPMHIMMC"
         apiKey="8b00405cba281a7d800ccec393e9af24"
-        askAi="askai-react-demo"
+        askAi="aHnEb7mOlt6A"
         insights={true}
       />
     </div>

--- a/examples/demo-askai/src/App.tsx
+++ b/examples/demo-askai/src/App.tsx
@@ -9,10 +9,10 @@ function App(): JSX.Element {
     <div>
       <h1>DocSearch v4 - AskAI</h1>
       <DocSearch
-        indexName="tailwindcss"
-        appId="betaHAXPMHIMMC"
-        apiKey="8b00405cba281a7d800ccec393e9af24"
-        askAi="aHnEb7mOlt6A"
+        indexName="docsearch"
+        appId="PMZUYBQDAK"
+        apiKey="24b09689d5b4223813d9b8e48563c8f6"
+        askAi="askAIDemo"
         insights={true}
       />
     </div>

--- a/packages/docsearch-css/src/_variables.css
+++ b/packages/docsearch-css/src/_variables.css
@@ -56,6 +56,13 @@
   --ease-smooth: cubic-bezier(0.25, 0.8, 0.4, 1);
   --ease-fast: cubic-bezier(0.45, 0.15, 0.6, 0.9);
   --shadow-pop: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shimmer-bg: linear-gradient(
+    90deg,
+    rgb(224, 227, 232) 0%,
+    var(--docsearch-muted-color) 20%,
+    var(--docsearch-muted-color) 60%,
+    rgb(224, 227, 232) 95%
+  );
 }
 
 /* Darkmode */
@@ -87,4 +94,11 @@ html[data-theme='dark'] {
     0 -4px 8px 0 rgba(0, 0, 0, 0.2);
   --docsearch-logo-color: rgb(255, 255, 255);
   --docsearch-muted-color: rgb(127, 132, 151);
+  --shimmer-bg: linear-gradient(
+    90deg,
+    rgb(224, 227, 232) 0%,
+    var(--docsearch-muted-color) 20%,
+    var(--docsearch-muted-color) 60%,
+    rgb(224, 227, 232) 95%
+  );
 }

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -923,13 +923,22 @@ assistive tech users */
   padding: var(--docsearch-spacing);
   display: flex;
   align-items: center;
+  padding: 1em;
   gap: 8px;
   color: var(--docsearch-error-color);
   background-color: rgb(239 83 80 / 0.1);
   border-radius: 4px;
-  font-size: 0.8em;
-  margin-top: 1em;
+  font-size: 1em;
   font-weight: 400;
+}
+
+.DocSearch-AskAiScreen-Error svg {
+  width: 16px;
+  height: 16px;
+}
+
+.DocSearch-AskAiScreen-Error p {
+  margin: 0;
 }
 
 .DocSearch-AskAiScreen-RelatedSources {
@@ -1182,7 +1191,7 @@ assistive tech users */
   display: flex;
   align-items: center;
   gap: 4px;
-  font-size: 0.8em;
+  font-size: 1em;
   color: var(--docsearch-muted-color);
 }
 
@@ -1192,6 +1201,10 @@ assistive tech users */
   padding: 1em 0;
   width: 100%;
   color: var(--docsearch-muted-color);
+}
+
+.DocSearch-AskAiScreen-MessageContent-Tool.Tool--Result:first-child {
+  padding-top: 0;
 }
 
 .DocSearch-AskAiScreen-MessageContent-Tool > svg {
@@ -1230,36 +1243,23 @@ assistive tech users */
 }
 
 .shimmer {
-  position: relative;
-  overflow: hidden;
-}
-
-.shimmer::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -120%;
-  width: 60%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.1) 40%,
-    rgba(255, 255, 255, 0.8) 50%,
-    rgba(255, 255, 255, 0.1) 60%,
-    transparent 100%
-  );
-  transform: skewX(-20deg);
-  animation: shimmer 6s ease-in-out infinite;
+  background: var(--shimmer-bg);
+  background-size: 200% auto;
+  background-clip: text;
+  display: flex;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: shimmerText 2.5s linear infinite;
   pointer-events: none;
 }
 
-@keyframes shimmer {
+@keyframes shimmerText {
   0% {
-    left: -120%;
+    background-position: 200% 0;
   }
   100% {
-    left: 120%;
+    background-position: -200% 0;
   }
 }
 

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -17,6 +17,8 @@
 
 .DocSearch-Container {
   background-color: var(--docsearch-container-background);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
   height: 100vh;
   left: 0;
   position: fixed;
@@ -455,6 +457,7 @@
 .DocSearch-Hit mark {
   color: var(--docsearch-highlight-color);
   text-decoration: underline;
+  text-underline-offset: 0.3em;
 }
 
 .DocSearch-Hit-Container {
@@ -533,7 +536,7 @@ svg.DocSearch-Hit-Select-Icon {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  font-weight: 500;
+  font-weight: 400;
   justify-content: center;
   line-height: 1.2em;
   margin: 0 8px;
@@ -767,13 +770,12 @@ assistive tech users */
 .DocSearch-Hit-AskAIButton-title {
   display: flex;
   flex: 1 1 auto;
-  font-weight: 500;
+  font-weight: 400;
   line-height: 1.2em;
   overflow-x: hidden;
   position: relative;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 500;
   width: 80%;
   gap: 4px;
   color: var(--docsearch-hit-color);
@@ -781,8 +783,8 @@ assistive tech users */
 
 .DocSearch-Hit-AskAIButton-title-query {
   white-space: nowrap;
-  font-weight: 400;
   overflow: hidden;
+  background: none;
   margin-left: 4px;
   text-overflow: ellipsis;
 }

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -886,6 +886,7 @@ assistive tech users */
   display: flex;
   flex-direction: row;
   gap: 12px;
+  align-items: center;
   margin-left: auto;
 }
 
@@ -939,6 +940,17 @@ assistive tech users */
 
 .DocSearch-AskAiScreen-Error p {
   margin: 0;
+}
+
+.DocSearch-AskAiScreen-FeedbackText {
+  font-size: 0.7em;
+  font-weight: 400;
+  color: var(--docsearch-muted-color);
+}
+
+/* fade in animation when feedback has been given */
+.DocSearch-AskAiScreen-FeedbackText--visible {
+  animation: fade-in 0.3s ease-in forwards;
 }
 
 .DocSearch-AskAiScreen-RelatedSources {
@@ -1238,8 +1250,8 @@ assistive tech users */
 }
 
 .DocSearch-AskAiScreen-SmallerLoadingIcon {
-  width: 12px;
-  height: 12px;
+  width: 16px;
+  height: 16px;
 }
 
 .shimmer {

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -1209,6 +1209,7 @@ assistive tech users */
 .DocSearch-AskAiScreen-MessageContent-Tool {
   display: flex;
   padding: 1em 0;
+  align-items: center;
   width: 100%;
   color: var(--docsearch-muted-color);
 }
@@ -1220,7 +1221,6 @@ assistive tech users */
 .DocSearch-AskAiScreen-MessageContent-Tool > svg {
   color: var(--docsearch-icon-color);
   margin-right: 8px;
-  margin-top: 3px;
 }
 
 .DocSearch-AskAiScreen-MessageContent-Tool-Query {

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -997,6 +997,7 @@ assistive tech users */
   border-radius: 4px;
   color: var(--docsearch-text-color);
   font-size: 0.75em;
+  max-width: 30%;
   text-decoration: none;
   transition: background-color 0.2s ease;
 }
@@ -1207,7 +1208,6 @@ assistive tech users */
 
 .DocSearch-AskAiScreen-MessageContent-Tool {
   display: flex;
-  align-items: center;
   padding: 1em 0;
   width: 100%;
   color: var(--docsearch-muted-color);
@@ -1223,13 +1223,7 @@ assistive tech users */
 }
 
 .DocSearch-AskAiScreen-MessageContent-Tool-Query {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  all: unset;
   color: var(--docsearch-muted-color);
-  padding: 0.1em;
-  margin: 0 0.2em;
   transition: box-shadow 0.2s ease;
 }
 

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -610,7 +610,6 @@ svg.DocSearch-Hit-Select-Icon {
 
 .DocSearch-NoResults--withAskAi {
   height: 60%;
-  gap: 0;
 }
 
 .DocSearch-StartScreen,

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -138,15 +138,14 @@
   justify-content: center;
 }
 
-.DocSearch-Container--Stalled .DocSearch-MagnifierLabel {
-  display: none;
-}
-
 .DocSearch-LoadingIndicator {
-  display: none;
+  align-items: center;
+  color: var(--docsearch-highlight-color);
+  display: flex;
+  justify-content: center;
 }
 
-.DocSearch-Container--Stalled .DocSearch-LoadingIndicator {
+.DocSearch-StreamingIndicator {
   align-items: center;
   color: var(--docsearch-highlight-color);
   display: flex;

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -601,16 +601,17 @@ svg.DocSearch-Hit-Select-Icon {
   height: 80%;
 }
 
-.DocSearch-NoResults--withAskAi {
-  height: 70%;
-}
-
 .DocSearch-StartScreen {
   height: 100%;
 }
 
 .DocSearch-NoResults {
   gap: 24px;
+}
+
+.DocSearch-NoResults--withAskAi {
+  height: 60%;
+  gap: 0;
 }
 
 .DocSearch-StartScreen,
@@ -639,9 +640,15 @@ svg.DocSearch-Hit-Select-Icon {
 .DocSearch-NoResults-Prefill-List ul {
   display: flex;
   flex-direction: column;
-  gap: 8px;
   height: 40px;
-  padding: 8px 0 0;
+}
+
+div.DocSearch-NoResults.DocSearch-NoResults--withAskAi
+  > div.DocSearch-NoResults-Prefill-List
+  > ul {
+  height: 0;
+  gap: 1em;
+  flex-direction: row;
 }
 
 .DocSearch-NoResults-Prefill-List li {
@@ -813,21 +820,12 @@ assistive tech users */
 
 .DocSearch-AskAiScreen-Disclaimer {
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 12px;
-  font-size: 0.65em;
+  font-size: 0.6em;
   font-weight: 300;
-  padding: 1em 0;
-}
-
-.DocSearch-AskAiScreen-Disclaimer-Icon {
-  color: var(--docsearch-icon-color);
-}
-
-.DocSearch-AskAiScreen-Disclaimer-Text {
-  padding: 0;
+  padding: 1.5em 0 0.5em 0;
+  text-align: left;
   margin: 0;
+  align-self: flex-start;
 }
 
 .DocSearch-AskAiScreen-Body {
@@ -923,8 +921,14 @@ assistive tech users */
 
 .DocSearch-AskAiScreen-Error {
   padding: var(--docsearch-spacing);
+  display: flex;
+  align-items: center;
+  gap: 8px;
   color: var(--docsearch-error-color);
+  background-color: rgb(239 83 80 / 0.1);
+  border-radius: 4px;
   font-size: 0.8em;
+  margin-top: 1em;
   font-weight: 400;
 }
 
@@ -1185,10 +1189,14 @@ assistive tech users */
 .DocSearch-AskAiScreen-MessageContent-Tool {
   display: flex;
   align-items: center;
-  font-size: 1em;
   padding: 1em 0;
   width: 100%;
   color: var(--docsearch-muted-color);
+}
+
+.DocSearch-AskAiScreen-MessageContent-Tool > svg {
+  color: var(--docsearch-icon-color);
+  margin-right: 8px;
 }
 
 .DocSearch-AskAiScreen-MessageContent-Tool-Query {
@@ -1196,12 +1204,10 @@ assistive tech users */
   align-items: center;
   gap: 4px;
   all: unset;
-  border: 1px solid transparent;
   color: var(--docsearch-muted-color);
-  border-radius: 4px;
-  padding: 0.1em 0.2em;
+  padding: 0.1em;
   margin: 0 0.2em;
-  transition: border-color 0.2s ease;
+  transition: box-shadow 0.2s ease;
 }
 
 .DocSearch-AskAiScreen-MessageContent-Tool-Query svg {
@@ -1209,9 +1215,8 @@ assistive tech users */
 }
 
 .DocSearch-AskAiScreen-MessageContent-Tool-Query:hover {
-  border-color: var(--docsearch-highlight-color);
+  box-shadow: 0 1px 0 0 var(--docsearch-highlight-color);
   color: var(--docsearch-highlight-color);
-  background-color: var(--docsearch-hit-highlight-color);
   cursor: pointer;
 }
 

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -997,7 +997,7 @@ assistive tech users */
   border-radius: 4px;
   color: var(--docsearch-text-color);
   font-size: 0.75em;
-  max-width: 30%;
+  max-width: 70%;
   text-decoration: none;
   transition: background-color 0.2s ease;
 }
@@ -1220,6 +1220,7 @@ assistive tech users */
 .DocSearch-AskAiScreen-MessageContent-Tool > svg {
   color: var(--docsearch-icon-color);
   margin-right: 8px;
+  margin-top: 3px;
 }
 
 .DocSearch-AskAiScreen-MessageContent-Tool-Query {

--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "6.0.2",
-    "preact": "^10.0.0",
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "preact": "^10.0.0"
   }
 }

--- a/packages/docsearch-react/src/AggregatedSearchBlock.tsx
+++ b/packages/docsearch-react/src/AggregatedSearchBlock.tsx
@@ -1,0 +1,78 @@
+import React, { type JSX, Fragment } from 'react';
+
+import type { AskAiScreenTranslations } from './AskAiScreen';
+import { SearchIcon } from './icons';
+
+interface AggregatedSearchBlockProps {
+  queries: string[];
+  translations: AskAiScreenTranslations;
+  onSearchQueryClick: (query: string) => void;
+}
+
+// allow translators to return either simple string parts or a fully custom node
+export interface AggregatedToolCallParts {
+  before?: string;
+  separator?: string;
+  lastSeparator?: string;
+  after?: string;
+}
+
+// default english implementation ("Searched for \"A\", \"B\" and \"C\"")
+const defaultAggregatedToolCallParts: AggregatedToolCallParts = {
+  before: 'Searched for ',
+  separator: ', ',
+  lastSeparator: ' and ',
+  after: '',
+};
+
+export function AggregatedSearchBlock({
+  queries,
+  translations,
+  onSearchQueryClick,
+}: AggregatedSearchBlockProps): JSX.Element | null {
+  // no queries? no render
+  if (queries.length === 0) return null;
+
+  // if the translator provides a fully custom node, render it and bail out.
+  if (typeof translations.aggregatedToolCallNode === 'function') {
+    return <>{translations.aggregatedToolCallNode(queries, onSearchQueryClick)}</>;
+  }
+
+  // otherwise fall back to the classic english-pattern renderer.
+  const parts = translations.aggregatedToolCallText
+    ? translations.aggregatedToolCallText(queries)
+    : defaultAggregatedToolCallParts;
+
+  const { before = '', separator = ', ', lastSeparator = ' and ', after = '' } = parts || {};
+
+  return (
+    <div className="DocSearch-AskAiScreen-MessageContent-Tool Tool--AggregatedResult">
+      <SearchIcon size={18} />
+      <span>
+        {before && <span>{before}</span>}
+        {queries.map((q, idx) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Fragment key={q + idx}>
+            <span
+              role="button"
+              tabIndex={0}
+              className="DocSearch-AskAiScreen-MessageContent-Tool-Query"
+              onKeyDown={(e) => {
+                if (e.key === 'enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onSearchQueryClick(q);
+                }
+              }}
+              onClick={() => onSearchQueryClick(q)}
+            >
+              &quot;{q}&quot;
+            </span>
+            {idx < queries.length - 2 && separator}
+            {idx === queries.length - 2 && lastSeparator}
+          </Fragment>
+        ))}
+        {after && <span>{after}</span>}
+      </span>
+    </div>
+  );
+}

--- a/packages/docsearch-react/src/AlgoliaLogo.tsx
+++ b/packages/docsearch-react/src/AlgoliaLogo.tsx
@@ -19,7 +19,7 @@ export function AlgoliaLogo({ translations = {} }: AlgoliaLogoProps): JSX.Elemen
     >
       <span className="DocSearch-Label">{poweredByText}</span>
       <svg
-        width="77"
+        width="80"
         height="24"
         aria-label="Algolia"
         role="img"

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -15,6 +15,10 @@ export type AskAiScreenTranslations = Partial<{
   thinkingText: string;
   copyButtonText: string;
   copyButtonCopiedText: string;
+  // Feedback buttons
+  copyButtonTitle: string;
+  likeButtonTitle: string;
+  dislikeButtonTitle: string;
   // Tool call texts
   preToolCallText: string;
   duringToolCallText: string;
@@ -160,6 +164,7 @@ function AskAiExchangeCard({
           <AskAiScreenFooterActions
             showActions={showActions}
             latestAssistantMessageContent={assistantMessage?.content || null}
+            translations={translations}
           />
         </div>
       </div>
@@ -175,20 +180,25 @@ function AskAiExchangeCard({
 interface AskAiScreenFooterActionsProps {
   showActions: boolean;
   latestAssistantMessageContent: string | null;
+  translations: AskAiScreenTranslations;
 }
 
 function AskAiScreenFooterActions({
   showActions,
   latestAssistantMessageContent,
+  translations,
 }: AskAiScreenFooterActionsProps): JSX.Element | null {
   if (!showActions || !latestAssistantMessageContent) {
     return null;
   }
   return (
     <div className="DocSearch-AskAiScreen-Actions">
-      <CopyButton onClick={() => navigator.clipboard.writeText(latestAssistantMessageContent)} />
-      <LikeButton />
-      <DislikeButton />
+      <CopyButton
+        translations={translations}
+        onClick={() => navigator.clipboard.writeText(latestAssistantMessageContent)}
+      />
+      <LikeButton title={translations.likeButtonTitle || 'Like'} />
+      <DislikeButton title={translations.dislikeButtonTitle || 'Dislike'} />
     </div>
   );
 }
@@ -298,7 +308,15 @@ function RelatedSourceIcon(): JSX.Element {
   );
 }
 
-function CopyButton({ onClick }: { onClick: () => void }): JSX.Element {
+function CopyButton({
+  onClick,
+  translations,
+}: {
+  onClick: () => void;
+  translations: AskAiScreenTranslations;
+}): JSX.Element {
+  const { copyButtonTitle = 'Copy', copyButtonCopiedText = 'Copied!' } = translations;
+
   const [isCopied, setIsCopied] = useState(false);
 
   useEffect(() => {
@@ -323,6 +341,7 @@ function CopyButton({ onClick }: { onClick: () => void }): JSX.Element {
         isCopied ? 'DocSearch-AskAiScreen-CopyButton--copied' : ''
       }`}
       disabled={isCopied} // disable button briefly after copy
+      title={isCopied ? copyButtonCopiedText : copyButtonTitle}
       onClick={handleClick}
     >
       {isCopied ? (
@@ -361,10 +380,10 @@ function CopyButton({ onClick }: { onClick: () => void }): JSX.Element {
   );
 }
 
-function LikeButton(): JSX.Element {
+function LikeButton({ title }: { title: string }): JSX.Element {
   // @todo: implement like button
   return (
-    <button type="button" className="DocSearch-AskAiScreen-ActionButton DocSearch-AskAiScreen-LikeButton">
+    <button type="button" className="DocSearch-AskAiScreen-ActionButton DocSearch-AskAiScreen-LikeButton" title={title}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"
@@ -384,10 +403,14 @@ function LikeButton(): JSX.Element {
   );
 }
 
-function DislikeButton(): JSX.Element {
+function DislikeButton({ title }: { title: string }): JSX.Element {
   // @todo: implement dislike button
   return (
-    <button type="button" className="DocSearch-AskAiScreen-ActionButton DocSearch-AskAiScreen-DislikeButton">
+    <button
+      type="button"
+      className="DocSearch-AskAiScreen-ActionButton DocSearch-AskAiScreen-DislikeButton"
+      title={title}
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -1,7 +1,7 @@
 import type { UseChatHelpers } from '@ai-sdk/react';
 import React, { type JSX, useState, useEffect, useMemo } from 'react';
 
-import { SparklesIcon, LoadingIcon, SearchIcon } from './icons';
+import { AlertIcon, LoadingIcon, SearchIcon } from './icons';
 import { MemoizedMarkdown } from './MemoizedMarkdown';
 import type { ScreenStateProps } from './ScreenState';
 import type { InternalDocSearchHit } from './types';
@@ -44,14 +44,7 @@ interface Exchange {
 }
 
 function AskAiScreenHeader({ disclaimerText }: AskAiScreenHeaderProps): JSX.Element {
-  return (
-    <div className="DocSearch-AskAiScreen-Disclaimer">
-      <div className="DocSearch-AskAiScreen-Disclaimer-Icon">
-        <SparklesIcon />
-      </div>
-      <p className="DocSearch-AskAiScreen-Disclaimer-Text">{disclaimerText}</p>
-    </div>
-  );
+  return <p className="DocSearch-AskAiScreen-Disclaimer">{disclaimerText}</p>;
 }
 
 interface AskAiExchangeCardProps {
@@ -125,21 +118,21 @@ function AskAiExchangeCard({
                             <div key={index} className="DocSearch-AskAiScreen-MessageContent-Tool Tool--Call shimmer">
                               <LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />
                               <span>
-                                {`${translations.duringToolCallText || 'Searching through the docs for '} "${toolInvocation.args?.query || ''}" ...`}
+                                {`${translations.duringToolCallText || 'Searching documentation for '} "${toolInvocation.args?.query || ''}" ...`}
                               </span>
                             </div>
                           );
                         case 'result':
                           return (
                             <div key={index} className="DocSearch-AskAiScreen-MessageContent-Tool Tool--Result">
-                              <span>{`${translations.afterToolCallText || 'Looked through the docs for'}`}</span>
+                              <SearchIcon size={18} />
+                              <span>{`${translations.afterToolCallText || 'Searched documentation for'}`}</span>
                               <button
                                 type="button"
                                 className="DocSearch-AskAiScreen-MessageContent-Tool-Query"
                                 onClick={() => onSearchQueryClick(toolInvocation.args?.query || '')}
                               >
                                 &quot;{toolInvocation.args?.query || ''}&quot;
-                                <SearchIcon size={16} />
                               </button>
                             </div>
                           );
@@ -232,9 +225,7 @@ function AskAiSourcesPanel({ urlsToDisplay, relatedSourcesText }: AskAiSourcesPa
 }
 
 export function AskAiScreen({ translations = {}, ...props }: AskAiScreenProps): JSX.Element | null {
-  const {
-    disclaimerText = 'Answers are generated using artificial intelligence. This is an experimental technology, and information may occasionally be incorrect or misleading.',
-  } = translations;
+  const { disclaimerText = 'Answers are generated with AI which can make mistakes. Verify responses.' } = translations;
 
   const { messages } = props;
 
@@ -261,9 +252,11 @@ export function AskAiScreen({ translations = {}, ...props }: AskAiScreenProps): 
 
   return (
     <div className="DocSearch-AskAiScreen DocSearch-AskAiScreen-Container">
+      <AskAiScreenHeader disclaimerText={disclaimerText} />
       <div className="DocSearch-AskAiScreen-Body">
         {props.askAiStreamError && (
           <div className="DocSearch-AskAiScreen-Error">
+            <AlertIcon />
             <p>{props.askAiStreamError.message}</p>
           </div>
         )}
@@ -283,7 +276,6 @@ export function AskAiScreen({ translations = {}, ...props }: AskAiScreenProps): 
             ))}
         </div>
       </div>
-      <AskAiScreenHeader disclaimerText={disclaimerText} />
     </div>
   );
 }

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -187,7 +187,7 @@ function AskAiExchangeCard({
                             <div key={index} className="DocSearch-AskAiScreen-MessageContent-Tool Tool--Call shimmer">
                               <LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />
                               <span>
-                                {`${translations.duringToolCallText || 'Searching documentation for '} "${toolInvocation.args?.query || ''}" ...`}
+                                {`${translations.duringToolCallText || 'Searching for '} "${toolInvocation.args?.query || ''}" ...`}
                               </span>
                             </div>
                           );
@@ -196,7 +196,7 @@ function AskAiExchangeCard({
                             <div key={index} className="DocSearch-AskAiScreen-MessageContent-Tool Tool--Result">
                               <SearchIcon size={18} />
                               <span>
-                                {`${translations.afterToolCallText || 'Searched documentation for'}`}{' '}
+                                {`${translations.afterToolCallText || 'Searched for'}`}{' '}
                                 <span
                                   role="button"
                                   tabIndex={0}

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -179,7 +179,7 @@ function AskAiExchangeCard({
                               className="DocSearch-AskAiScreen-MessageContent-Tool Tool--PartialCall shimmer"
                             >
                               <LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />
-                              <span>{translations.preToolCallText || 'Searching through the docs...'}</span>
+                              <span>{translations.preToolCallText || 'Searching...'}</span>
                             </div>
                           );
                         case 'call':

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -49,6 +49,7 @@ function AskAiScreenHeader({ disclaimerText }: AskAiScreenHeaderProps): JSX.Elem
 
 interface AskAiExchangeCardProps {
   exchange: Exchange;
+  askAiStreamError: Error | null;
   isLastExchange: boolean;
   loadingStatus: UseChatHelpers['status'];
   onSearchQueryClick: (query: string) => void;
@@ -57,6 +58,7 @@ interface AskAiExchangeCardProps {
 
 function AskAiExchangeCard({
   exchange,
+  askAiStreamError,
   isLastExchange,
   loadingStatus,
   onSearchQueryClick,
@@ -76,7 +78,18 @@ function AskAiExchangeCard({
         </div>
         <div className="DocSearch-AskAiScreen-Message DocSearch-AskAiScreen-Message--assistant">
           <div className="DocSearch-AskAiScreen-MessageContent">
-            {Array.isArray(assistantMessage?.parts)
+            {loadingStatus === 'error' && askAiStreamError && isLastExchange && (
+              <div className="DocSearch-AskAiScreen-MessageContent DocSearch-AskAiScreen-Error">
+                <AlertIcon />
+                <p>{askAiStreamError.message}</p>
+              </div>
+            )}
+            {loadingStatus === 'submitted' && (
+              <div className="DocSearch-AskAiScreen-MessageContent-Reasoning">
+                <span className="italic shimmer">{translations.thinkingText || 'Thinking...'}</span>
+              </div>
+            )}
+            {loadingStatus !== 'submitted' && Array.isArray(assistantMessage?.parts)
               ? assistantMessage.parts.map((part, idx) => {
                   const index = idx;
 
@@ -143,7 +156,7 @@ function AskAiExchangeCard({
                     // fallback for unknown tool, should never happen in theory. :shrug:
                     return (
                       <span key={index} className="text-sm italic shimmer">
-                        Thinking...
+                        {translations.thinkingText || 'Thinking...'}
                       </span>
                     );
                   }
@@ -254,12 +267,6 @@ export function AskAiScreen({ translations = {}, ...props }: AskAiScreenProps): 
     <div className="DocSearch-AskAiScreen DocSearch-AskAiScreen-Container">
       <AskAiScreenHeader disclaimerText={disclaimerText} />
       <div className="DocSearch-AskAiScreen-Body">
-        {props.askAiStreamError && (
-          <div className="DocSearch-AskAiScreen-Error">
-            <AlertIcon />
-            <p>{props.askAiStreamError.message}</p>
-          </div>
-        )}
         <div className="DocSearch-AskAiScreen-ExchangesList">
           {exchanges
             .slice()
@@ -268,6 +275,7 @@ export function AskAiScreen({ translations = {}, ...props }: AskAiScreenProps): 
               <AskAiExchangeCard
                 key={exchange.id}
                 exchange={exchange}
+                askAiStreamError={props.askAiStreamError}
                 isLastExchange={index === 0}
                 loadingStatus={props.status}
                 translations={translations}

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -234,7 +234,7 @@ function AskAiExchangeCard({
         </div>
         <div className="DocSearch-AskAiScreen-Answer-Footer">
           <AskAiScreenFooterActions
-            id={assistantMessage?.id || exchange.id}
+            id={userMessage?.id || exchange.id}
             showActions={showActions}
             latestAssistantMessageContent={assistantMessage?.content || null}
             translations={translations}

--- a/packages/docsearch-react/src/DocSearchButton.tsx
+++ b/packages/docsearch-react/src/DocSearchButton.tsx
@@ -36,7 +36,8 @@ export const DocSearchButton = React.forwardRef<HTMLButtonElement, DocSearchButt
       key === ACTION_KEY_DEFAULT
         ? // eslint-disable-next-line react/jsx-key -- false flag
           ([ACTION_KEY_DEFAULT, 'Control', <ControlKeyIcon />] as const)
-        : (['Meta', 'Meta', key] as const);
+        : // eslint-disable-next-line react/jsx-key -- false flag
+          (['Meta', 'Meta', <MetaKeyIcon />] as const);
 
     const shortcut = `${actionKeyAltText}+k`;
 

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -430,6 +430,10 @@ export function DocSearchModal({
         content: query,
       });
 
+      if (dropdownRef.current) {
+        dropdownRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+
       // clear the query
       if (autocompleteRef.current) {
         autocompleteRef.current.setQuery('');
@@ -616,10 +620,10 @@ export function DocSearchModal({
   }, []);
 
   React.useEffect(() => {
-    if (dropdownRef.current) {
+    if (dropdownRef.current && !isAskAiActive) {
       dropdownRef.current.scrollTop = 0;
     }
-  }, [state.query]);
+  }, [state.query, isAskAiActive]);
 
   // We don't focus the input when there's an initial query (i.e. Selection
   // Search) because users rather want to see the results directly, without the

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -668,10 +668,7 @@ export function DocSearchModal({
   // hide the dropdown on idle and no collections
   let showDocsearchDropdown = true;
   const hasCollections = state.collections.some((collection) => collection.items.length > 0);
-  if (state.status === 'idle' && hasCollections === false) {
-    showDocsearchDropdown = false;
-  }
-  if (hasCollections === false) {
+  if (state.status === 'idle' && hasCollections === false && state.query.length === 0) {
     showDocsearchDropdown = false;
   }
 

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -452,7 +452,7 @@ export function DocSearchModal({
         messageId,
         appId,
       });
-      if (res.status !== 200) throw new Error('Failed, try again later');
+      if (res.status >= 300) throw new Error('Failed, try again later');
       conversations.addFeedback?.(messageId, thumbs === 1 ? 'like' : 'dislike');
     },
     [askAiConfigurationId, appId, conversations],

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -431,7 +431,7 @@ export function DocSearchModal({
       });
 
       if (dropdownRef.current) {
-        dropdownRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+        (dropdownRef.current as HTMLElement).scrollTo({ top: 0, behavior: 'smooth' });
       }
 
       // clear the query

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -339,6 +339,7 @@ export function DocSearchModal({
     error: askAiFetchError,
   } = useChat({
     api: ASK_AI_API_URL,
+    sendExtraMessageFields: true,
     fetch: async (input, init) => {
       if (!USE_ASK_AI_TOKEN) {
         return fetch(input, init);

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -24,7 +24,7 @@ import type { DocSearchHit, DocSearchState, InternalDocSearchHit, StoredAskAiSta
 import { useSearchClient } from './useSearchClient';
 import { useTouchEvents } from './useTouchEvents';
 import { useTrapFocus } from './useTrapFocus';
-import { groupBy, identity, noop, removeHighlightTags, isModifierEvent } from './utils';
+import { groupBy, identity, noop, removeHighlightTags, isModifierEvent, scrollTo as scrollToUtils } from './utils';
 import { buildDummyAskAiHit } from './utils/ai';
 
 export type ModalTranslations = Partial<{
@@ -431,7 +431,14 @@ export function DocSearchModal({
       });
 
       if (dropdownRef.current) {
-        (dropdownRef.current as HTMLElement).scrollTo({ top: 0, behavior: 'smooth' });
+        // some test environments (like jsdom) don't implement element.scrollTo
+        const el = dropdownRef.current;
+        if (typeof (el as any).scrollTo === 'function') {
+          el.scrollTo({ top: 0, behavior: 'smooth' });
+        } else {
+          // fallback for environments without scrollTo support
+          el.scrollTop = 0;
+        }
       }
 
       // clear the query
@@ -621,7 +628,7 @@ export function DocSearchModal({
 
   React.useEffect(() => {
     if (dropdownRef.current && !isAskAiActive) {
-      dropdownRef.current.scrollTop = 0;
+      scrollToUtils(dropdownRef.current);
     }
   }, [state.query, isAskAiActive]);
 

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -9,7 +9,7 @@ import {
 import type { SearchResponse } from 'algoliasearch/lite';
 import React, { type JSX } from 'react';
 
-import { getValidToken } from './askai';
+import { getValidToken, postFeedback } from './askai';
 import { ASK_AI_API_URL, MAX_QUERY_SIZE, USE_ASK_AI_TOKEN } from './constants';
 import type { DocSearchProps } from './DocSearch';
 import type { FooterTranslations } from './Footer';
@@ -438,6 +438,22 @@ export function DocSearchModal({
     [onAskAiToggle, append],
   );
 
+  // feedback handler
+  const handleFeedbackSubmit = React.useCallback(
+    async (messageId: string, thumbs: 0 | 1): Promise<void> => {
+      if (!askAiConfigurationId || !appId) return;
+      const res = await postFeedback({
+        assistantId: askAiConfigurationId,
+        thumbs,
+        messageId,
+        appId,
+      });
+      if (res.status !== 200) throw new Error('Failed, try again later');
+      conversations.addFeedback?.(messageId, thumbs === 1 ? 'like' : 'dislike');
+    },
+    [askAiConfigurationId, appId, conversations],
+  );
+
   if (!autocompleteRef.current) {
     autocompleteRef.current = createAutocomplete({
       id: 'docsearch',
@@ -743,6 +759,7 @@ export function DocSearchModal({
                   onClose();
                 }
               }}
+              onFeedback={handleFeedbackSubmit}
             />
           </div>
         )}

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -703,6 +703,7 @@ export function DocSearchModal({
             isFromSelection={Boolean(initialQuery) && initialQuery === initialQueryFromSelection}
             translations={searchBoxTranslations}
             isAskAiActive={isAskAiActive}
+            askAiStatus={status}
             onClose={onClose}
             onAskAiToggle={onAskAiToggle}
             onAskAgain={(query) => {

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -9,6 +9,7 @@ import {
 import type { SearchResponse } from 'algoliasearch/lite';
 import React, { type JSX } from 'react';
 
+import { getValidToken } from './askai';
 import { ASK_AI_API_URL, MAX_QUERY_SIZE, USE_ASK_AI_TOKEN } from './constants';
 import type { DocSearchProps } from './DocSearch';
 import type { FooterTranslations } from './Footer';
@@ -19,7 +20,6 @@ import { ScreenState } from './ScreenState';
 import type { SearchBoxTranslations } from './SearchBox';
 import { SearchBox } from './SearchBox';
 import { createStoredConversations, createStoredSearches } from './stored-searches';
-import { getValidToken } from './token';
 import type { DocSearchHit, DocSearchState, InternalDocSearchHit, StoredAskAiState, StoredDocSearchHit } from './types';
 import { useSearchClient } from './useSearchClient';
 import { useTouchEvents } from './useTouchEvents';
@@ -345,9 +345,9 @@ export function DocSearchModal({
       }
 
       if (!askAiConfigurationId) {
-        throw new Error('Ask AI configuration ID is required');
+        throw new Error('Ask AI assistant ID is required');
       }
-      const token = await getValidToken({ configId: askAiConfigurationId });
+      const token = await getValidToken({ assistantId: askAiConfigurationId });
       const headers = new Headers(init.headers);
       headers.set('authorization', `TOKEN ${token}`);
 

--- a/packages/docsearch-react/src/MemoizedMarkdown.tsx
+++ b/packages/docsearch-react/src/MemoizedMarkdown.tsx
@@ -31,6 +31,14 @@ renderer.code = ({ text, lang = '', escaped }: Tokens.Code): string => {
   `;
 };
 
+// ensure all markdown links open in a new tab with rel noopener for security
+renderer.link = ({ href, title, text }: Tokens.Link): string => {
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+  const hrefAttr = href ? escapeHtml(href) : '';
+  const textEscaped = escapeHtml(text);
+  return `<a href="${hrefAttr}"${titleAttr} target="_blank" rel="noopener noreferrer">${textEscaped}</a>`;
+};
+
 export const MemoizedMarkdown = memo(
   ({
     content,

--- a/packages/docsearch-react/src/Results.tsx
+++ b/packages/docsearch-react/src/Results.tsx
@@ -194,7 +194,7 @@ function AskAiButton<TItem extends StoredDocSearchHit>({
           </div>
           <div className="DocSearch-Hit-AskAIButton-title">
             <span className="DocSearch-Hit-AskAIButton-title-highlight">{askAiPlaceholder}</span>
-            <span className="DocSearch-Hit-AskAIButton-title-query">"{item.query || ''}"</span>
+            <mark className="DocSearch-Hit-AskAIButton-title-query">{item.query || ''}</mark>
           </div>
         </div>
       </div>

--- a/packages/docsearch-react/src/ScreenState.tsx
+++ b/packages/docsearch-react/src/ScreenState.tsx
@@ -45,6 +45,7 @@ export interface ScreenStateProps<TItem extends BaseItem>
   resultsFooterComponent: DocSearchProps['resultsFooterComponent'];
   translations: ScreenStateTranslations;
   getMissingResultsUrl?: DocSearchProps['getMissingResultsUrl'];
+  hasCollections: boolean;
 }
 
 export const ScreenState = React.memo(
@@ -66,13 +67,11 @@ export const ScreenState = React.memo(
       return <ErrorScreen translations={translations?.errorScreen} />;
     }
 
-    const hasCollections = props.state.collections.some((collection) => collection.items.length > 0);
-
     if (!props.state.query) {
-      return <StartScreen {...props} hasCollections={hasCollections} translations={translations?.startScreen} />;
+      return <StartScreen {...props} hasCollections={props.hasCollections} translations={translations?.startScreen} />;
     }
 
-    if (hasCollections === false && !props.canHandleAskAi) {
+    if (!props.hasCollections && !props.canHandleAskAi) {
       return <NoResultsScreen {...props} translations={translations?.noResultsScreen} />;
     }
 

--- a/packages/docsearch-react/src/ScreenState.tsx
+++ b/packages/docsearch-react/src/ScreenState.tsx
@@ -46,6 +46,7 @@ export interface ScreenStateProps<TItem extends BaseItem>
   translations: ScreenStateTranslations;
   getMissingResultsUrl?: DocSearchProps['getMissingResultsUrl'];
   hasCollections: boolean;
+  onFeedback?: (messageId: string, thumbs: 0 | 1) => Promise<void>;
 }
 
 export const ScreenState = React.memo(

--- a/packages/docsearch-react/src/SearchBox.tsx
+++ b/packages/docsearch-react/src/SearchBox.tsx
@@ -14,6 +14,7 @@ export type SearchBoxTranslations = Partial<{
   closeButtonAriaLabel: string;
   placeholderText: string;
   placeholderTextAskAi: string;
+  placeholderTextAskAiStreaming: string;
   enterKeyHint: string;
   enterKeyHintAskAi: string;
   searchInputLabel: string;
@@ -45,6 +46,7 @@ export function SearchBox({ translations = {}, ...props }: SearchBoxProps): JSX.
     searchInputLabel = 'Search',
     backToKeywordSearchButtonText = 'Back to keyword search',
     backToKeywordSearchButtonAriaLabel = 'Back to keyword search',
+    placeholderTextAskAiStreaming = 'Answering...',
   } = translations;
   const { onReset } = props.getFormProps({
     inputElement: props.inputRef.current,
@@ -157,7 +159,12 @@ export function SearchBox({ translations = {}, ...props }: SearchBoxProps): JSX.
           </>
         )}
 
-        <input className="DocSearch-Input" ref={props.inputRef} {...inputProps} placeholder={props.placeholder} />
+        <input
+          className="DocSearch-Input"
+          ref={props.inputRef}
+          {...inputProps}
+          placeholder={isAskAiStreaming ? placeholderTextAskAiStreaming : props.placeholder}
+        />
 
         <div className="DocSearch-Actions">
           {isAskAiStreaming && (

--- a/packages/docsearch-react/src/StartScreen.tsx
+++ b/packages/docsearch-react/src/StartScreen.tsx
@@ -1,6 +1,6 @@
 import React, { type JSX } from 'react';
 
-import { RecentIcon, CloseIcon, StarIcon, SearchIcon, SparklesIcon } from './icons';
+import { RecentIcon, CloseIcon, StarIcon, SparklesIcon } from './icons';
 import { Results } from './Results';
 import type { ScreenStateProps } from './ScreenState';
 import type { InternalDocSearchHit } from './types';
@@ -24,7 +24,6 @@ type StartScreenProps = Omit<ScreenStateProps<InternalDocSearchHit>, 'translatio
 export function StartScreen({ translations = {}, ...props }: StartScreenProps): JSX.Element | null {
   const {
     recentSearchesTitle = 'Recent',
-    noRecentSearchesText = 'Search results will appear here',
     saveRecentSearchButtonTitle = 'Save this search',
     removeRecentSearchButtonTitle = 'Remove this search from history',
     favoriteSearchesTitle = 'Favorite',
@@ -32,25 +31,6 @@ export function StartScreen({ translations = {}, ...props }: StartScreenProps): 
     recentConversationsTitle = 'Recent conversations',
     removeRecentConversationButtonTitle = 'Remove this conversation from history',
   } = translations;
-
-  if (props.state.status === 'idle' && props.hasCollections === false) {
-    if (props.disableUserPersonalization) {
-      return null;
-    }
-
-    return (
-      <div className="DocSearch-StartScreen">
-        <div className="DocSearch-StartScreen-Icon">
-          <SearchIcon size={64} color="#5a5e9a" />
-        </div>
-        <p className="DocSearch-Help">{noRecentSearchesText}</p>
-      </div>
-    );
-  }
-
-  if (props.hasCollections === false) {
-    return null;
-  }
 
   return (
     <div className="DocSearch-Dropdown-Container">

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -82,7 +82,6 @@ describe('api', () => {
       });
 
       expect(document.querySelector('.DocSearch-Modal')).toBeInTheDocument();
-      expect(screen.getByText('Pas de recherche récentes')).toBeInTheDocument();
     });
 
     it('overrides the default DocSearchModal noResultsScreen text', async () => {

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -299,13 +299,9 @@ describe('api', () => {
       });
 
       expect(document.querySelector('.DocSearch-AskAiScreen')).toBeInTheDocument();
-      expect(screen.getByPlaceholderText('Ask another question...')).toBeInTheDocument();
 
-      await act(() => {
-        fireEvent.click(document.querySelector('.DocSearch-AskAi-Return')!);
-      });
-
-      expect(screen.getByPlaceholderText('Search docs or ask AI a question')).toBeInTheDocument();
+      // could be "Answering..." or "Ask another question..."
+      expect(screen.getByPlaceholderText('Answering...')).toBeInTheDocument();
     });
   });
 });

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -307,46 +307,5 @@ describe('api', () => {
 
       expect(screen.getByPlaceholderText('Search docs or ask AI a question')).toBeInTheDocument();
     });
-
-    it('sets enter key hint when ask AI is active', async () => {
-      render(
-        <DocSearch
-          askAi="assistant"
-          transformSearchClient={(searchClient) => ({
-            ...searchClient,
-            search: noResultSearch,
-          })}
-        />,
-      );
-
-      await act(async () => {
-        fireEvent.click(await screen.findByText('Search'));
-      });
-
-      await act(async () => {
-        fireEvent.input(await screen.findByPlaceholderText('Search docs or ask AI a question'), {
-          target: { value: 'hello' },
-        });
-      });
-
-      // before activating ask ai
-      const input = screen.getByPlaceholderText('Search docs or ask AI a question');
-      expect(input).toHaveAttribute('enterkeyhint', 'search');
-
-      await act(async () => {
-        fireEvent.click(await screen.findByText(/Ask AI:/));
-      });
-
-      const askInput = screen.getByPlaceholderText('Ask another question...');
-      expect(askInput).toHaveAttribute('enterkeyhint', 'enter');
-
-      // ask another question with enter
-      await act(() => {
-        fireEvent.change(askInput, { target: { value: 'next' } });
-        fireEvent.keyDown(askInput, { key: 'Enter' });
-      });
-
-      expect((askInput as HTMLInputElement).value).toBe('');
-    });
   });
 });

--- a/packages/docsearch-react/src/__tests__/askai.test.tsx
+++ b/packages/docsearch-react/src/__tests__/askai.test.tsx
@@ -21,10 +21,19 @@ const baseProps = {
 } as any;
 
 describe('AskAiScreen', () => {
-  it('displays stream errors', () => {
+  it('displays stream errors in the latest exchange', () => {
+    const messages = [{ id: '1', role: 'user', content: 'hello' } as any];
+
     const { getByText } = render(
-      <AskAiScreen {...baseProps} askAiStreamError={new Error('oh no')} askAiFetchError={undefined} />,
+      <AskAiScreen
+        {...baseProps}
+        messages={messages}
+        status="error"
+        askAiStreamError={new Error('oh no')}
+        askAiFetchError={undefined}
+      />,
     );
+
     expect(getByText('oh no')).toBeInTheDocument();
   });
 });

--- a/packages/docsearch-react/src/askai.ts
+++ b/packages/docsearch-react/src/askai.ts
@@ -53,21 +53,14 @@ export const postFeedback = async ({
   thumbs,
   messageId,
   appId,
-  indexName,
-  apiKey,
 }: {
   assistantId: string;
   thumbs: 0 | 1;
   messageId: string;
   appId: string;
-  indexName: string;
-  apiKey: string;
 }): Promise<Response> => {
   const headers = new Headers();
   headers.set('x-algolia-assistant-id', assistantId);
-  headers.set('x-algolia-app-id', appId);
-  headers.set('x-algolia-index-name', indexName);
-  headers.set('x-algolia-api-key', apiKey);
   headers.set('content-type', 'application/json');
 
   if (USE_ASK_AI_TOKEN) {

--- a/packages/docsearch-react/src/constants.ts
+++ b/packages/docsearch-react/src/constants.ts
@@ -1,2 +1,3 @@
-export const MAX_QUERY_SIZE = 256;
-export const ASK_AI_API_URL = 'https://motivated-perfection-production.up.railway.app/chat';
+export const MAX_QUERY_SIZE = 512;
+export const ASK_AI_API_URL = 'https://beta-askai.algolia.com/chat';
+export const USE_ASK_AI_TOKEN = true;

--- a/packages/docsearch-react/src/constants.ts
+++ b/packages/docsearch-react/src/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_QUERY_SIZE = 512;
-export const ASK_AI_API_URL = 'https://beta-askai.algolia.com/chat';
+export const ASK_AI_API_URL = 'https://askai.algolia.com/chat';
 export const USE_ASK_AI_TOKEN = true;

--- a/packages/docsearch-react/src/icons/AlertIcon.tsx
+++ b/packages/docsearch-react/src/icons/AlertIcon.tsx
@@ -1,0 +1,22 @@
+import React, { type JSX } from 'react';
+
+export function AlertIcon(): JSX.Element {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      fillRule="evenodd"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      className="lucide lucide-triangle-alert-icon lucide-triangle-alert"
+    >
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
+    </svg>
+  );
+}

--- a/packages/docsearch-react/src/icons/SparklesIcon.tsx
+++ b/packages/docsearch-react/src/icons/SparklesIcon.tsx
@@ -8,7 +8,7 @@ export function SparklesIcon(): JSX.Element {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.5"
+      strokeWidth="1.3"
       strokeLinecap="round"
       strokeLinejoin="round"
       className="DocSearch-Hit-icon-sparkles"

--- a/packages/docsearch-react/src/icons/index.ts
+++ b/packages/docsearch-react/src/icons/index.ts
@@ -4,6 +4,7 @@ export * from './SparklesIcon';
 export * from './RecentIcon';
 export * from './CloseIcon';
 export * from './SearchIcon';
+export * from './AlertIcon';
 export * from './SelectIcon';
 export * from './SourceIcon';
 export * from './StarIcon';

--- a/packages/docsearch-react/src/token.ts
+++ b/packages/docsearch-react/src/token.ts
@@ -1,0 +1,49 @@
+import { ASK_AI_API_URL } from './constants';
+
+// ... existing imports ...
+const TOKEN_KEY = 'askai_token';
+
+type TokenPayload = { exp: number };
+
+const decode = (token: string): TokenPayload => {
+  const [b64] = token.split('.');
+  return JSON.parse(atob(b64));
+};
+
+const isExpired = (token?: string | null): boolean => {
+  if (!token) return true;
+  try {
+    const { exp } = decode(token);
+    // refresh 30 s before the backend rejects it
+    return Date.now() / 1000 > exp - 30;
+  } catch {
+    return true;
+  }
+};
+
+let inflight: Promise<string> | null = null;
+
+// call /token once, cache the promise while it’s running
+// eslint-disable-next-line require-await
+export const getValidToken = async ({ configId }: { configId: string }): Promise<string> => {
+  const cached = sessionStorage.getItem(TOKEN_KEY);
+  if (!isExpired(cached)) return cached!;
+
+  if (!inflight) {
+    inflight = fetch(`${ASK_AI_API_URL}/token`, {
+      method: 'POST',
+      headers: {
+        'x-algolia-assistant-id': configId,
+        'content-type': 'application/json',
+      },
+    })
+      .then((r) => r.json())
+      .then(({ token }) => {
+        sessionStorage.setItem(TOKEN_KEY, token);
+        return token;
+      })
+      .finally(() => (inflight = null));
+  }
+
+  return inflight;
+};

--- a/packages/docsearch-react/src/types/StoredDocSearchHit.ts
+++ b/packages/docsearch-react/src/types/StoredDocSearchHit.ts
@@ -3,4 +3,12 @@ import type { Message } from '@ai-sdk/react';
 import type { DocSearchHit } from './DocSearchHit';
 
 export type StoredDocSearchHit = Omit<DocSearchHit, '_highlightResult' | '_snippetResult'>;
-export type StoredAskAiState = Omit<DocSearchHit, '_highlightResult' | '_snippetResult'> & { messages?: Message[] };
+
+export type StoredAskAiMessage = Message & {
+  /** Optional user feedback on this assistant message. */
+  feedback?: 'dislike' | 'like';
+};
+
+export type StoredAskAiState = Omit<DocSearchHit, '_highlightResult' | '_snippetResult'> & {
+  messages?: StoredAskAiMessage[];
+};

--- a/packages/docsearch-react/src/utils/groupConsecutiveToolResults.ts
+++ b/packages/docsearch-react/src/utils/groupConsecutiveToolResults.ts
@@ -1,0 +1,56 @@
+export interface AggregatedToolCallPart {
+  type: 'aggregated-tool-call';
+  queries: string[];
+}
+
+/**
+ * Groups consecutive `searchIndex` tool invocation result parts together.
+ * Empty or falsy queries are ignored.
+ */
+export function groupConsecutiveToolResults<T extends { type: string }>(parts: T[]): Array<AggregatedToolCallPart | T> {
+  const aggregatedParts: Array<AggregatedToolCallPart | T> = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const part: any = parts[i];
+
+    if (
+      part?.type === 'tool-invocation' &&
+      part.toolInvocation?.toolName === 'searchIndex' &&
+      part.toolInvocation?.state === 'result'
+    ) {
+      // build list of consecutive result queries
+      const queries: string[] = [];
+      let j = i;
+      while (j < parts.length) {
+        const candidate: any = parts[j];
+        if (
+          candidate?.type === 'tool-invocation' &&
+          candidate.toolInvocation?.toolName === 'searchIndex' &&
+          candidate.toolInvocation?.state === 'result'
+        ) {
+          const q = (candidate.toolInvocation?.args?.query || '').trim();
+          // eslint-disable-next-line max-depth
+          if (q) {
+            queries.push(q);
+          }
+          j++;
+        } else {
+          break;
+        }
+      }
+
+      if (queries.length > 1) {
+        aggregatedParts.push({ type: 'aggregated-tool-call', queries });
+      } else if (queries.length === 1) {
+        // only one valid query, push the original part so rendering remains unchanged
+        aggregatedParts.push(part);
+      }
+
+      i = j - 1; // skip processed items
+    } else {
+      aggregatedParts.push(part);
+    }
+  }
+
+  return aggregatedParts;
+}

--- a/packages/docsearch-react/src/utils/index.ts
+++ b/packages/docsearch-react/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './identity';
 export * from './isModifierEvent';
 export * from './noop';
 export * from './removeHighlightTags';
+export * from './scrollTo';

--- a/packages/docsearch-react/src/utils/scrollTo.ts
+++ b/packages/docsearch-react/src/utils/scrollTo.ts
@@ -1,0 +1,9 @@
+export function scrollTo(el: HTMLElement): void {
+  // some test environments (like jsdom) don't implement element.scrollTo
+  if (typeof el.scrollTo === 'function') {
+    el.scrollTo({ top: 0, behavior: 'smooth' });
+  } else {
+    // fallback for environments without scrollTo support
+    el.scrollTop = 0;
+  }
+}


### PR DESCRIPTION
**What & Why**

DocSearch v4’s “Ask AI” beta is getting a round of polish so that we can start onboarding external users.  
This PR tightens the UX, improves visual consistency and, most importantly, adds the bearer-token flow required by the new Ask AI API.

---

### ✨  User-facing improvements
* Ask AI screen  
  * disclaimer is now shown at the top, smaller and left-aligned (less noise, keeps context visible)  
  * error banner redesigned with an alert icon, red tint and better spacing  
  * “copy / like / dislike” action bar added to every answer (tool-tips translated)  
  * search tool calls are clearer (`🔍  Searched documentation for "<query>"`)  
  * highlighted query in Ask-AI-button now uses `<mark>` to match Algolia highlighting
* Dropdown behaviour  
  * when the query is empty AND there are no stored/favourite searches we now keep the dropdown closed instead of showing an empty panel
* CSS tweaks  
  * subtle backdrop blur behind the modal  
  * lighter font-weights, better underline offset, improved gaps & heights for the No-results + Ask AI layout
* Logo width bumped from 77 → 80 px so it doesn’t look cropped on HiDPI screens
* Demo updated to hit `tailwindcss` index + new assistant id `aHnEb7mOlt6A` will probably change

### 🔐  Token-based auth
* new helper `packages/docsearch-react/src/token.ts`  
  * requests a JWT from `/chat/token` once per session and refreshes it ~30 s before expiry  
  * cached in `sessionStorage`
* `DocSearchModal` wraps the `useChat` fetcher: when `USE_ASK_AI_TOKEN` is `true` it injects `Authorization: TOKEN <jwt>` automatically
* `constants.ts`  
  * Ask AI endpoint switched to `https://beta-askai.algolia.com/chat`  
  * `MAX_QUERY_SIZE` doubled to 512  
  * feature flag `USE_ASK_AI_TOKEN`

### 🛠️  Developer odds & ends
* new `AlertIcon` and export in `icons/index.ts`
* added `hasCollections` prop to `ScreenState` to avoid recomputing it everywhere
* reordered dev-deps in `docsearch-js/package.json` (lint noise)

---

## QA steps
1. `yarn workspace examples/demo-askai dev`
2. Open the demo, hit ⌘ K and type a query with no hits → Ask AI prompt appears as before
3. Confirm:
   * no-results screen height is smaller, Ask AI card hugs the bottom
   * dropdown stays hidden when history is empty
4. Trigger Ask AI, copy answer, like/dislike tool-tips present
5. Check dev-tools: first request to `/chat` returns 401, token POST follows, subsequent stream includes `Authorization: TOKEN …`

---

## Follow-ups
* Wire like/dislike buttons to feedback endpoint once backend is ready
* Use production endpoint