### PR TITLE
chore(deps): change react to dev deps on js package

### DIFF
--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -32,10 +32,8 @@
     "on:change": "yarn build",
     "watch": "nodemon --watch src --exec \"yarn on:change\" --ignore dist/ --ext ts,tsx"
   },
-  "dependencies": {
-    "@docsearch/react": "4.0.0-beta.2"
-  },
   "devDependencies": {
+    "@docsearch/react": "4.0.0-beta.2",
     "@rollup/plugin-replace": "6.0.2",
     "nodemon": "^3.1.9",
     "preact": "^10.0.0"

--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -32,8 +32,10 @@
     "on:change": "yarn build",
     "watch": "nodemon --watch src --exec \"yarn on:change\" --ignore dist/ --ext ts,tsx"
   },
+  "dependencies": {
+    "@docsearch/react": "4.0.0-beta.2"
+  },
   "devDependencies": {
-    "@docsearch/react": "4.0.0-beta.2",
     "@rollup/plugin-replace": "6.0.2",
     "nodemon": "^3.1.9",
     "preact": "^10.0.0"

--- a/packages/docsearch-js/rollup.config.js
+++ b/packages/docsearch-js/rollup.config.js
@@ -8,6 +8,26 @@ import pkg from './package.json';
 export default [
   {
     input: 'src/index.ts',
+    external: ['@docsearch/react'],
+    output: [
+      {
+        file: 'dist/esm/index.js',
+        format: 'es',
+        sourcemap: true,
+        banner: getBundleBanner(pkg),
+        plugins: [...plugins],
+      },
+    ],
+    plugins: [
+      ...plugins,
+      replace({
+        preventAssignment: true,
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      }),
+    ],
+  },
+  {
+    input: 'src/index.ts',
     output: [
       {
         file: 'dist/umd/index.js',
@@ -15,13 +35,6 @@ export default [
         sourcemap: true,
         name: 'docsearch',
         banner: getBundleBanner(pkg),
-      },
-      {
-        file: 'dist/esm/index.js',
-        format: 'es',
-        sourcemap: true,
-        banner: getBundleBanner(pkg),
-        plugins: [...plugins],
       },
     ],
     plugins: [


### PR DESCRIPTION
Since the js package is shipped as a bundle, there's no need to bundle the react dependency in it. 

We changed it to a dev dependency. It should help reduce the bundle size and fix a few issues with installing the dependency in non-react frameworks.

see https://github.com/vuejs/vitepress/issues/472 for more context on this fix.