### PR TITLE
feat(askai): add facet filtering

### DIFF
--- a/examples/demo-askai/src/App.tsx
+++ b/examples/demo-askai/src/App.tsx
@@ -12,7 +12,12 @@ function App(): JSX.Element {
         indexName="docsearch"
         appId="PMZUYBQDAK"
         apiKey="24b09689d5b4223813d9b8e48563c8f6"
-        askAi="askAIDemo"
+        askAi={{
+          assistantId: 'askAIDemo',
+          searchParameters: {
+            facetFilters: ['language:en'],
+          },
+        }}
         insights={true}
       />
     </div>

--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -10,7 +10,6 @@
   width: 320px;
   height: 36px;
   justify-content: space-between;
-  margin: 0 0 0 16px;
   padding: 0 8px;
   user-select: none;
 }
@@ -54,8 +53,8 @@
   color: var(--docsearch-key-color);
   box-shadow: none !important;
   display: flex;
-  height: 20px;
-  width: 20px;
+  height: 24px;
+  width: 24px;
   justify-content: center;
   position: relative;
   border: 0;

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -43,6 +43,12 @@ export type DocSearchAskAi = {
    * The assistant ID to use for the ask AI feature.
    */
   assistantId: string | null;
+  /**
+   * The search parameters to use for the ask AI feature.
+   */
+  searchParameters?: {
+    facetFilters?: SearchParamsObject['facetFilters'];
+  };
 };
 
 export interface DocSearchProps {

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -330,6 +330,7 @@ export function DocSearchModal({
 
   const askAiConfig = typeof askAi === 'object' ? askAi : null;
   const askAiConfigurationId = typeof askAi === 'string' ? askAi : askAiConfig?.assistantId || null;
+  const askAiSearchParameters = askAiConfig?.searchParameters;
 
   const [askAiStreamError, setAskAiStreamError] = React.useState<Error | null>(null);
 
@@ -363,6 +364,7 @@ export function DocSearchModal({
       'X-Algolia-Index-Name': askAiConfig?.indexName || indexName,
       'X-Algolia-Assistant-Id': askAiConfigurationId || '',
     },
+    body: askAiSearchParameters ? { searchParameters: askAiSearchParameters } : {},
     onError(streamError) {
       setAskAiStreamError(streamError);
     },

--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -87,7 +87,7 @@ docsearch({
 });
 ```
 
-or
+or if you want to use different credentials for askAi and add search parameters
 
 ```js
 docsearch({
@@ -97,6 +97,9 @@ docsearch({
     apiKey: 'ANOTHER_SEARCH_API_KEY',
     appId: 'ANOTHER_APP_ID',
     assistantId: 'YOUR_ALGOLIA_ASSISTANT_ID',
+    searchParameters: {
+      facetFilters: ['language:en'],
+    },
   },
   // ...
 });

--- a/packages/website/docs/docsearch.mdx
+++ b/packages/website/docs/docsearch.mdx
@@ -204,6 +204,8 @@ docsearch({
 
 ### Filtering search results
 
+#### Keyword search
+
 If your website uses [DocSearch meta tags][13] or if you've added [custom variables to your config][14], you'll be able to use the [`facetFilters`][16] option to scope your search results to a [`facet`][15]
 
 This is useful to limit the scope of the search to one language or one version.
@@ -238,6 +240,54 @@ docsearch({
 />
 ```
 
+</TabItem>
+
+</Tabs>
+
+#### AskAI
+
+Filtering also applies when using AskAI. This is useful to limit the scope of the LLM's search to only relevant results.
+
+:::info
+We recommend using the `facetFilters` option when using AskAI with multiple languages or any multi-faceted index.
+:::
+
+<Tabs
+  groupId="language"
+  defaultValue="js"
+  values={[
+    { label: 'JavaScript', value: 'js', },
+    { label: 'React', value: 'react', }
+  ]
+}>
+<TabItem value="js">
+```js
+docsearch({
+  askAi: {
+    assistantId: 'YOUR_ALGOLIA_ASSISTANT_ID',
+    searchParameters: {
+      facetFilters: ['language:en', 'version:1.0.0'],
+    },
+  },
+});
+```
+</TabItem>
+
+<TabItem value="react">
+```js
+
+```
+
+```jsx
+<DocSearch
+  askAi={{
+    assistantId: 'YOUR_ALGOLIA_ASSISTANT_ID',
+    searchParameters: {
+      facetFilters: ['language:en', 'version:1.0.0'],
+    },
+  }}
+/>
+```
 </TabItem>
 
 </Tabs>


### PR DESCRIPTION
### Summary  
This PR adds first-class **facet filtering support for Ask AI** and ships a small visual tweak to the DocSearch button.

---

### Features  
1. **Ask AI `searchParameters`**
   * `askAi` can now be an object that accepts optional Algolia `searchParameters` (currently `facetFilters`).
   * The modal sends these parameters in the request body so the LLM only sees results that match the filter scope (e.g. language, version).

2. **Updated typings & docs**
   * `DocSearchAskAi` type extended with `searchParameters`.
   * Documentation and demo code show how to specify filters.
   * Adds an Ask AI filtering section in the “Filtering search results” docs.

3. **CSS polish**
   * DocSearch button icon size increased from **20 px → 24 px** for better alignment.
   * Removed the left margin so the button can sit flush when used inline.
---

### 🧪 Testing  
* Verified Ask AI responses respect `language:en` filter in demo.  
* Ensured legacy string form (`askAi="assistantId"`) still works.  

---

### 🔥 Why it matters  
Facet filtering is critical for multi-language or multi-version sites; this brings parity between keyword search and Ask AI, delivering more relevant, scoped answers.

---

_No breaking changes expected._