### PR TITLE
fix: revert to internal package

### DIFF
--- a/packages/docsearch-js/rollup.config.js
+++ b/packages/docsearch-js/rollup.config.js
@@ -8,7 +8,6 @@ import pkg from './package.json';
 export default [
   {
     input: 'src/index.ts',
-    external: ['@docsearch/react'],
     output: [
       {
         file: 'dist/esm/index.js',


### PR DESCRIPTION
JS package fails at runtime due to lack in dependency,

We are undoing this change for now.

https://github.com/vuejs/vitepress/issues/472

We will further investigate on this issue.