### PR TITLE
feat(docsearch): trying field mapping

### DIFF
--- a/examples/demo-askai/src/App.tsx
+++ b/examples/demo-askai/src/App.tsx
@@ -9,9 +9,9 @@ function App(): JSX.Element {
     <div>
       <h1>DocSearch v4 - AskAI</h1>
       <DocSearch
-        indexName="docsearch"
-        appId="PMZUYBQDAK"
-        apiKey="24b09689d5b4223813d9b8e48563c8f6"
+        indexName="INDEX_NAME"
+        appId="APP_ID"
+        apiKey="KEY"
         askAi={{
           assistantId: 'askAIDemo',
           searchParameters: {
@@ -19,6 +19,25 @@ function App(): JSX.Element {
           },
         }}
         insights={true}
+        fieldMapping={{
+          content: 'body_safe',
+          url: (record) => `/help/articles/${record.objectID}`,
+          hierarchy: {
+            lvl0: 'category.title',          // Uses dot notation - simpler
+            lvl1: 'section.title',           // Access nested properties directly
+            lvl2: 'title'
+          },
+          metadata: {
+            locale: 'locale.locale',         // "en-gb"
+            language: 'locale.name',         // "British English"
+            fullPath: 'section.full_path',   // "In-store FAQs > Technical advice and support"
+            voteSum: 'vote_sum',
+            promoted: 'promoted'
+          }
+        }}
+        recordMapperConfig={{
+          maxContentLength: 180
+        }}
       />
     </div>
   );

--- a/packages/docsearch-react/examples/field-mapping-usage.md
+++ b/packages/docsearch-react/examples/field-mapping-usage.md
@@ -1,0 +1,283 @@
+# Field Mapping Usage Examples
+
+This document shows how to use DocSearch's field mapping feature to work with custom record schemas.
+
+## Basic E-commerce Example
+
+### Your Index Records
+```json
+{
+  "objectID": "product-123",
+  "title": "MacBook Pro M3",
+  "description": "Latest MacBook with M3 chip and enhanced performance",
+  "category": "Laptops",
+  "brand": "Apple", 
+  "price": 1999,
+  "permalink": "/products/macbook-pro-m3",
+  "tags": ["premium", "professional"]
+}
+```
+
+### DocSearch Configuration
+```js
+import { docsearch } from '@docsearch/js';
+
+docsearch({
+  appId: 'YOUR_APP_ID',
+  indexName: 'products',
+  apiKey: 'YOUR_API_KEY',
+  container: '#docsearch',
+  
+  // Field mapping configuration
+  fieldMapping: {
+    content: 'description',           // Use 'description' as main content
+    url: 'permalink',                 // Use 'permalink' as URL
+    hierarchy: {
+      lvl0: 'category',              // Top level = category
+      lvl1: 'title',                 // Second level = product title
+      lvl2: 'brand'                  // Third level = brand
+    },
+    metadata: {
+      price: 'price',
+      tags: 'tags'
+    }
+  },
+  
+  // Optional: Configure record transformation
+  recordMapperConfig: {
+    maxContentLength: 150,           // Truncate content to 150 characters
+    preserveOriginal: true,          // Keep original record in _original field
+    fallbackValues: {
+      content: 'No description available',
+      hierarchy: {
+        lvl0: 'Uncategorized'
+      }
+    }
+  }
+});
+```
+
+### Result
+DocSearch will automatically transform your records to:
+```json
+{
+  "objectID": "product-123",
+  "content": "Latest MacBook with M3 chip and enhanced performance",
+  "url": "/products/macbook-pro-m3",
+  "hierarchy": {
+    "lvl0": "Laptops",
+    "lvl1": "MacBook Pro M3", 
+    "lvl2": "Apple",
+    "lvl3": null,
+    "lvl4": null,
+    "lvl5": null,
+    "lvl6": null
+  },
+  "_original": { /* your original record */ },
+  "_metadata": {
+    "price": 1999,
+    "tags": ["premium", "professional"]
+  }
+}
+```
+
+## Advanced: Function Mappings
+
+### Your Records
+```json
+{
+  "objectID": "article-456",
+  "headline": "Getting Started with React",
+  "body": "Learn the basics of React development...",
+  "author": {
+    "name": "Jane Doe",
+    "title": "Senior Developer"
+  },
+  "category": "Tutorials",
+  "slug": "getting-started-react",
+  "publishedAt": "2024-01-15"
+}
+```
+
+### Configuration with Functions
+```js
+docsearch({
+  // ... basic config
+  
+  fieldMapping: {
+    content: 'body',
+    url: (record) => `/blog/${record.slug}`,
+    hierarchy: {
+      lvl0: 'category',
+      lvl1: 'headline',
+      lvl2: (record) => `By ${record.author.name}`
+    },
+    metadata: {
+      author: (record) => record.author.name,
+      authorTitle: (record) => record.author.title,
+      publishDate: 'publishedAt'
+    }
+  }
+});
+```
+
+## Presets for Common Use Cases
+
+### Using Built-in Presets
+```js
+import { MAPPING_PRESETS } from '@docsearch/react';
+
+docsearch({
+  // ... basic config
+  fieldMapping: MAPPING_PRESETS.ecommerce
+});
+
+// Available presets:
+// - MAPPING_PRESETS.ecommerce
+// - MAPPING_PRESETS.blog  
+// - MAPPING_PRESETS.documentation
+// - MAPPING_PRESETS.knowledgeBase
+```
+
+### Custom Hit Rendering with Metadata
+```js
+docsearch({
+  // ... config with fieldMapping
+  
+  hitComponent: ({ hit, children }) => (
+    <div>
+      {children}
+      {hit._metadata && (
+        <div className="custom-metadata">
+          <span className="price">${hit._metadata.price}</span>
+          <span className="rating">★ {hit._metadata.rating}</span>
+        </div>
+      )}
+    </div>
+  )
+});
+```
+
+## Auto-Detection Helper
+
+### Generate Mapping from Sample
+```js
+import { generateMappingFromSample } from '@docsearch/react';
+
+const sampleRecord = {
+  title: "Sample Product",
+  description: "Product description",
+  category: "Electronics", 
+  permalink: "/products/sample"
+};
+
+const autoMapping = generateMappingFromSample(sampleRecord);
+
+docsearch({
+  // ... basic config
+  fieldMapping: autoMapping
+});
+```
+
+## Migration Strategy
+
+### Phase 1: Start with Basic Mapping
+```js
+// Simple field mapping to get started
+fieldMapping: {
+  content: 'description',
+  url: 'permalink',
+  hierarchy: {
+    lvl0: 'category',
+    lvl1: 'title'
+  }
+}
+```
+
+### Phase 2: Add Custom Rendering
+```js
+// Add metadata and custom hit components
+fieldMapping: {
+  // ... existing mapping
+  metadata: {
+    price: 'price',
+    availability: 'in_stock'
+  }
+},
+hitComponent: CustomHitComponent
+```
+
+### Phase 3: Optimize for Your Use Case
+```js
+// Fine-tune with functions and advanced mappings
+fieldMapping: {
+  content: (record) => `${record.description} ${record.features.join(' ')}`,
+  url: (record) => `/products/${record.category}/${record.slug}`,
+  hierarchy: {
+    lvl0: 'department',
+    lvl1: 'category',
+    lvl2: (record) => `${record.brand} ${record.title}`,
+    lvl3: (record) => record.variants?.length > 1 ? 'Multiple Options' : null
+  }
+}
+```
+
+## Validation and Debugging
+
+### Validate Your Mapping
+```js
+import { validateFieldMapping } from '@docsearch/react';
+
+const errors = validateFieldMapping(yourMapping);
+if (errors.length > 0) {
+  console.error('Mapping validation errors:', errors);
+}
+```
+
+### Common Issues
+
+1. **Missing URL mapping**
+   ```js
+   // ❌ Wrong - no URL mapping
+   fieldMapping: {
+     content: 'description'
+   }
+   
+   // ✅ Correct - include URL mapping
+   fieldMapping: {
+     content: 'description',
+     url: 'permalink'
+   }
+   ```
+
+2. **Nested field access**
+   ```js
+   // ✅ Use dot notation for nested fields
+   fieldMapping: {
+     content: 'content.body',
+     url: 'metadata.permalink'
+   }
+   ```
+
+3. **Fallback values**
+   ```js
+   docsearch({
+     // ... config
+     fieldMapping: yourMapping,
+     recordMapperConfig: {
+       fallbackValues: {
+         content: 'No description available',
+         hierarchy: {
+           lvl0: 'Uncategorized'
+         }
+       }
+     }
+   });
+   ```
+
+## Performance Considerations
+
+- Field mapping happens at search time, not index time
+- Function mappings are called for each search result
+- Consider caching computed values in your index if performance is critical
+- The original record is preserved by default (set `preserveOriginal: false` to save memory) 

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -8,6 +8,8 @@ import { DocSearchModal } from './DocSearchModal';
 import type { DocSearchHit, DocSearchTheme, InternalDocSearchHit, StoredDocSearchHit } from './types';
 import { useDocSearchKeyboardEvents } from './useDocSearchKeyboardEvents';
 import { useTheme } from './useTheme';
+import type { FieldMapping, RecordMapperConfig } from './utils/recordMapper';
+import { validateFieldMapping } from './utils/recordMapper';
 
 import type { ButtonTranslations, ModalTranslations } from '.';
 
@@ -70,9 +72,27 @@ export interface DocSearchProps {
   translations?: DocSearchTranslations;
   getMissingResultsUrl?: ({ query }: { query: string }) => string;
   insights?: AutocompleteOptions<InternalDocSearchHit>['insights'];
+  
+  // Field mapping for custom record schemas
+  fieldMapping?: FieldMapping;
+  recordMapperConfig?: RecordMapperConfig;
 }
 
-export function DocSearch({ ...props }: DocSearchProps): JSX.Element {
+export function DocSearch({
+  fieldMapping,
+  recordMapperConfig,
+  ...props
+}: DocSearchProps): JSX.Element {
+  // Validate field mapping on mount
+  React.useEffect(() => {
+    if (fieldMapping) {
+      const errors = validateFieldMapping(fieldMapping);
+      if (errors.length > 0) {
+        console.error('DocSearch field mapping validation errors:', errors);
+      }
+    }
+  }, [fieldMapping]);
+
   const searchButtonRef = React.useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState<string | undefined>(props?.initialQuery || undefined);
@@ -138,6 +158,8 @@ export function DocSearch({ ...props }: DocSearchProps): JSX.Element {
         createPortal(
           <DocSearchModal
             {...props}
+            fieldMapping={fieldMapping}
+            recordMapperConfig={recordMapperConfig}
             placeholder={currentPlaceholder}
             initialScrollY={window.scrollY}
             initialQuery={initialQuery}

--- a/packages/docsearch-react/src/utils/recordMapper.ts
+++ b/packages/docsearch-react/src/utils/recordMapper.ts
@@ -1,0 +1,324 @@
+import type { DocSearchHit } from '../types/DocSearchHit';
+
+// Configuration types
+export interface FieldMapping {
+  content?: string | ((record: any) => string);
+  url?: string | ((record: any) => string);
+  hierarchy?: {
+    lvl0?: string | ((record: any) => string);
+    lvl1?: string | ((record: any) => string);
+    lvl2?: string | ((record: any) => string | null);
+    lvl3?: string | ((record: any) => string | null);
+    lvl4?: string | ((record: any) => string | null);
+    lvl5?: string | ((record: any) => string | null);
+    lvl6?: string | ((record: any) => string | null);
+  };
+  type?: string | ((record: any) => string);
+  anchor?: string | ((record: any) => string | null);
+  metadata?: Record<string, string | ((record: any) => any)>;
+}
+
+export interface RecordMapperConfig {
+  fieldMapping?: FieldMapping;
+  preserveOriginal?: boolean;
+  fallbackValues?: {
+    content?: string;
+    hierarchy?: {
+      lvl0?: string;
+      lvl1?: string;
+    };
+  };
+  maxContentLength?: number;
+}
+
+// Helper function to extract value from record using field mapping
+function extractValue(
+  record: any,
+  mapping: string | ((record: any) => any) | undefined,
+  fallback: any = null
+): any {
+  if (!mapping) return fallback;
+  
+  if (typeof mapping === 'function') {
+    try {
+      return mapping(record);
+    } catch (error) {
+      console.warn('Error in field mapping function:', error);
+      return fallback;
+    }
+  }
+  
+  // Handle dot notation (e.g., "metadata.title")
+  const value = mapping.split('.').reduce((obj, key) => obj?.[key], record);
+  return value !== undefined ? value : fallback;
+}
+
+// Helper function to truncate and clean content
+function cleanAndTruncateContent(content: string, maxLength: number = 200): string {
+  if (!content || typeof content !== 'string') {
+    return '';
+  }
+  
+  // Clean up content: remove extra whitespace, newlines, and normalize
+  let cleaned = content
+    .replace(/\s+/g, ' ') // Replace multiple whitespace with single space
+    .replace(/\n/g, ' ')  // Replace newlines with spaces
+    .trim();
+  
+  // Truncate if too long
+  if (cleaned.length > maxLength) {
+    // Try to truncate at a word boundary
+    const truncated = cleaned.substring(0, maxLength);
+    const lastSpace = truncated.lastIndexOf(' ');
+    
+    if (lastSpace > maxLength * 0.8) { // If we can find a space in the last 20%
+      cleaned = truncated.substring(0, lastSpace) + '…';
+    } else {
+      cleaned = truncated + '…';
+    }
+  }
+  
+  return cleaned;
+}
+
+// Main mapping function
+export function mapRecordToDocSearchHit(
+  record: any,
+  config: RecordMapperConfig = {}
+): DocSearchHit {
+  const { fieldMapping = {}, preserveOriginal = true, fallbackValues = {}, maxContentLength = 200 } = config;
+
+  // Extract basic fields
+  const objectID = record.objectID || record.id || String(Math.random());
+  const rawContent = extractValue(
+    record, 
+    fieldMapping.content, 
+    fallbackValues.content || record.content || ''
+  );
+  const content = cleanAndTruncateContent(rawContent, maxContentLength);
+  const url = extractValue(record, fieldMapping.url, record.url || '');
+  const type = extractValue(record, fieldMapping.type, 'content');
+  const anchor = extractValue(record, fieldMapping.anchor, record.anchor || null);
+
+  // Build hierarchy
+  const hierarchy = {
+    lvl0: extractValue(
+      record, 
+      fieldMapping.hierarchy?.lvl0, 
+      fallbackValues.hierarchy?.lvl0 || record.title || ''
+    ),
+    lvl1: extractValue(
+      record, 
+      fieldMapping.hierarchy?.lvl1, 
+      fallbackValues.hierarchy?.lvl1 || ''
+    ),
+    lvl2: extractValue(record, fieldMapping.hierarchy?.lvl2, null),
+    lvl3: extractValue(record, fieldMapping.hierarchy?.lvl3, null),
+    lvl4: extractValue(record, fieldMapping.hierarchy?.lvl4, null),
+    lvl5: extractValue(record, fieldMapping.hierarchy?.lvl5, null),
+    lvl6: extractValue(record, fieldMapping.hierarchy?.lvl6, null),
+  };
+
+  // Generate URL without anchor
+  const url_without_anchor = url.split('#')[0];
+
+  // Preserve original highlight results if they exist, otherwise create basic ones
+  const originalHighlight = record._highlightResult || {};
+  const originalSnippet = record._snippetResult || {};
+
+  // Helper function to get highlight data for a field
+  const getHighlightForField = (fieldMapping: any, fallbackValue: string) => {
+    if (typeof fieldMapping === 'string') {
+      // Try to find the highlight in the original record
+      return originalHighlight[fieldMapping] || { value: fallbackValue, matchLevel: 'none', matchedWords: [] };
+    }
+    // For function mappings, we can't preserve highlights easily
+    return { value: fallbackValue, matchLevel: 'none', matchedWords: [] };
+  };
+
+  const getSnippetForField = (fieldMapping: any, fallbackValue: string) => {
+    if (typeof fieldMapping === 'string') {
+      // Try to find the snippet in the original record
+      return originalSnippet[fieldMapping] || { value: fallbackValue, matchLevel: 'none' };
+    }
+    // For function mappings, we can't preserve snippets easily
+    return { value: fallbackValue, matchLevel: 'none' };
+  };
+
+  // Create base DocSearch hit
+  const docSearchHit: DocSearchHit = {
+    objectID,
+    content,
+    url,
+    url_without_anchor,
+    type,
+    anchor,
+    hierarchy,
+    // Preserve original highlighting if available, otherwise create basic highlighting
+    _highlightResult: {
+      content: getHighlightForField(fieldMapping.content, content),
+      hierarchy: {
+        lvl0: getHighlightForField(fieldMapping.hierarchy?.lvl0, hierarchy.lvl0),
+        lvl1: getHighlightForField(fieldMapping.hierarchy?.lvl1, hierarchy.lvl1),
+        lvl2: getHighlightForField(fieldMapping.hierarchy?.lvl2, hierarchy.lvl2 || ''),
+        lvl3: getHighlightForField(fieldMapping.hierarchy?.lvl3, hierarchy.lvl3 || ''),
+        lvl4: getHighlightForField(fieldMapping.hierarchy?.lvl4, hierarchy.lvl4 || ''),
+        lvl5: getHighlightForField(fieldMapping.hierarchy?.lvl5, hierarchy.lvl5 || ''),
+        lvl6: getHighlightForField(fieldMapping.hierarchy?.lvl6, hierarchy.lvl6 || ''),
+      },
+      hierarchy_camel: originalHighlight.hierarchy_camel || [],
+    },
+    _snippetResult: {
+      content: getSnippetForField(fieldMapping.content, content),
+      hierarchy: {
+        lvl0: getSnippetForField(fieldMapping.hierarchy?.lvl0, hierarchy.lvl0),
+        lvl1: getSnippetForField(fieldMapping.hierarchy?.lvl1, hierarchy.lvl1),
+        lvl2: getSnippetForField(fieldMapping.hierarchy?.lvl2, hierarchy.lvl2 || ''),
+        lvl3: getSnippetForField(fieldMapping.hierarchy?.lvl3, hierarchy.lvl3 || ''),
+        lvl4: getSnippetForField(fieldMapping.hierarchy?.lvl4, hierarchy.lvl4 || ''),
+        lvl5: getSnippetForField(fieldMapping.hierarchy?.lvl5, hierarchy.lvl5 || ''),
+        lvl6: getSnippetForField(fieldMapping.hierarchy?.lvl6, hierarchy.lvl6 || ''),
+      },
+      hierarchy_camel: originalSnippet.hierarchy_camel || [],
+    },
+  };
+
+  // Add original record if requested
+  if (preserveOriginal) {
+    (docSearchHit as any)._original = record;
+  }
+
+  // Add custom metadata fields
+  if (fieldMapping.metadata) {
+    const metadata: Record<string, any> = {};
+    for (const [key, mapping] of Object.entries(fieldMapping.metadata)) {
+      metadata[key] = extractValue(record, mapping);
+    }
+    (docSearchHit as any)._metadata = metadata;
+  }
+
+  return docSearchHit;
+}
+
+// Batch mapping function for multiple records
+export function mapRecordsToDocSearchHits(
+  records: any[],
+  config: RecordMapperConfig = {}
+): DocSearchHit[] {
+  return records.map(record => mapRecordToDocSearchHit(record, config));
+}
+
+// Validation function to check if mapping config is valid
+export function validateFieldMapping(mapping: FieldMapping): string[] {
+  const errors: string[] = [];
+
+  // Check required mappings
+  if (!mapping.content && !mapping.hierarchy?.lvl0) {
+    errors.push('Either content or hierarchy.lvl0 mapping is required');
+  }
+
+  if (!mapping.url) {
+    errors.push('URL mapping is required');
+  }
+
+  return errors;
+}
+
+// Utility function to generate mapping config from sample record
+export function generateMappingFromSample(
+  sampleRecord: any,
+  options: {
+    contentFields?: string[];
+    urlFields?: string[];
+    hierarchyFields?: string[];
+  } = {}
+): FieldMapping {
+  const {
+    contentFields = ['content', 'description', 'body', 'text'],
+    urlFields = ['url', 'link', 'permalink', 'href'],
+    hierarchyFields = ['category', 'section', 'title', 'name']
+  } = options;
+
+  const mapping: FieldMapping = {
+    hierarchy: {}
+  };
+
+  // Auto-detect content field
+  const contentField = contentFields.find(field => sampleRecord[field]);
+  if (contentField) {
+    mapping.content = contentField;
+  }
+
+  // Auto-detect URL field
+  const urlField = urlFields.find(field => sampleRecord[field]);
+  if (urlField) {
+    mapping.url = urlField;
+  }
+
+  // Auto-detect hierarchy fields
+  const availableHierarchyFields = hierarchyFields.filter(field => sampleRecord[field]);
+  availableHierarchyFields.slice(0, 7).forEach((field, index) => {
+    const level = `lvl${index}` as keyof NonNullable<FieldMapping['hierarchy']>;
+    mapping.hierarchy![level] = field;
+  });
+
+  return mapping;
+}
+
+// Presets for common use cases
+export const MAPPING_PRESETS = {
+  ecommerce: {
+    content: 'description',
+    url: 'product_url',
+    hierarchy: {
+      lvl0: 'department',
+      lvl1: 'category', 
+      lvl2: 'brand',
+      lvl3: 'title'
+    },
+    metadata: {
+      price: 'price',
+      rating: 'rating',
+      availability: 'in_stock'
+    }
+  },
+  
+  blog: {
+    content: 'excerpt',
+    url: 'permalink',
+    hierarchy: {
+      lvl0: 'category',
+      lvl1: 'title',
+      lvl2: 'author'
+    },
+    metadata: {
+      publishDate: 'published_at',
+      tags: 'tags'
+    }
+  },
+  
+  documentation: {
+    content: 'content',
+    url: 'url',
+    hierarchy: {
+      lvl0: 'section',
+      lvl1: 'page',
+      lvl2: 'heading'
+    }
+  },
+  
+  knowledgeBase: {
+    content: 'body',
+    url: 'article_url',
+    hierarchy: {
+      lvl0: 'section',
+      lvl1: 'subsection',
+      lvl2: 'title'
+    },
+    metadata: {
+      helpfulness: 'helpful_votes',
+      lastUpdated: 'updated_at'
+    }
+  }
+} as const;
+


### PR DESCRIPTION
Playing with field mapping
For the most part it works well. Got it working on a random index.

<img width="1698" height="1274" alt="Screenshot 2025-07-25 at 3 52 49 PM" src="https://github.com/user-attachments/assets/299b1ac1-85a3-4b46-a08d-3169cc0f01cc" />

Some things that need to be checked:
- Make sure it's not breaking any styling or UI/UX
- Regular DocSearch indexes still work as expected. Integrations not tested. Don't think we will try to support them with this field mapping
- Highlighting is not working. Might be something to look into.
- Some time the content length might be too long, so had to add a custom trimmer. I think there is a better way to do this.
- Tried to test AskAI but since the index was in another app, it didn't let me. Backend error


Mapping I used:
```js
     <DocSearch
        indexName="INDEX_NAME"
        appId="APP_ID"
        apiKey="KEY"
        askAi={{
          assistantId: 'askAIDemo',
          searchParameters: {
            facetFilters: ['language:en'],
          },
        }}
        insights={true}
        fieldMapping={{
          content: 'body_safe',
          url: (record) => `/help/articles/${record.objectID}`,
          hierarchy: {
            lvl0: 'category.title',          // Uses dot notation - simpler
            lvl1: 'section.title',           // Access nested properties directly
            lvl2: 'title'
          },
          metadata: {
            locale: 'locale.locale',         // "en-gb"
            language: 'locale.name',         // "British English"
            fullPath: 'section.full_path',   // "In-store FAQs > Technical advice and support"
            voteSum: 'vote_sum',
            promoted: 'promoted'
          }
        }}
        recordMapperConfig={{
          maxContentLength: 180
        }}
      />
 ```
