### PR TITLE
feat: expose `portalContainer` and bundle types in js esm builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rollup": "4.31.0",
-    "rollup-plugin-dts": "6.1.1",
     "rollup-plugin-filesize": "10.0.0",
     "shipjs": "0.27.0",
     "start-server-and-test": "2.0.10",

--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -36,6 +36,7 @@
     "@docsearch/react": "4.0.0-beta.6",
     "@rollup/plugin-replace": "6.0.2",
     "nodemon": "^3.1.9",
-    "preact": "^10.0.0"
+    "preact": "^10.0.0",
+    "rollup-plugin-dts": "^6.2.1"
   }
 }

--- a/packages/docsearch-js/rollup.config.js
+++ b/packages/docsearch-js/rollup.config.js
@@ -1,6 +1,7 @@
 import replace from '@rollup/plugin-replace';
+import { dts } from 'rollup-plugin-dts';
 
-import { plugins, typesConfig } from '../../rollup.base.config';
+import { plugins } from '../../rollup.base.config';
 import { getBundleBanner } from '../../scripts/getBundleBanner';
 
 import pkg from './package.json';
@@ -14,7 +15,6 @@ export default [
         format: 'es',
         sourcemap: true,
         banner: getBundleBanner(pkg),
-        plugins: [...plugins],
       },
     ],
     plugins: [
@@ -44,5 +44,14 @@ export default [
       }),
     ],
   },
-  typesConfig,
+  {
+    input: 'dist/esm/types/index.d.ts',
+    output: [{ file: 'dist/esm/index.d.ts', format: 'es' }],
+    external: (id) => /^(react|react-dom|@types\/react|@ai-sdk\/react)/.test(id),
+    plugins: [
+      dts({
+        respectExternal: true,
+      }),
+    ],
+  },
 ];

--- a/packages/docsearch-js/src/docsearch.tsx
+++ b/packages/docsearch-js/src/docsearch.tsx
@@ -21,7 +21,6 @@ export function docsearch(props: DocSearchProps): void {
       {...props}
       transformSearchClient={(searchClient) => {
         searchClient.addAlgoliaAgent('docsearch.js', version);
-
         return props.transformSearchClient ? props.transformSearchClient(searchClient) : searchClient;
       }}
     />,

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -47,6 +47,7 @@
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",
     "nodemon": "^3.1.0",
+    "rollup-plugin-dts": "^6.2.1",
     "vitest": "3.0.2",
     "zod": "^3.25.67"
   },

--- a/packages/docsearch-react/rollup.config.js
+++ b/packages/docsearch-react/rollup.config.js
@@ -1,8 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
+import { dts } from 'rollup-plugin-dts';
 
-import { plugins, typesConfig } from '../../rollup.base.config';
+import { plugins } from '../../rollup.base.config';
 import { getBundleBanner } from '../../scripts/getBundleBanner';
 
 import pkg from './package.json';
@@ -34,5 +35,9 @@ export default [
       }),
     ],
   },
-  typesConfig,
+  {
+    input: 'dist/esm/types/index.d.ts',
+    output: [{ file: 'dist/esm/index.d.ts', format: 'es' }],
+    plugins: [dts()],
+  },
 ];

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -52,32 +52,90 @@ export type DocSearchAskAi = {
 };
 
 export interface DocSearchProps {
+  /**
+   * Algolia application id used by the search client.
+   */
   appId: string;
+  /**
+   * Public api key with search permissions for the index.
+   */
   apiKey: string;
+  /**
+   * Name of the algolia index to query.
+   */
   indexName: string;
+  /**
+   * Configuration or assistant id to enable ask ai mode. Pass a string assistant id or a full config object.
+   */
   askAi?: DocSearchAskAi | string;
+  /**
+   * Theme overrides applied to the modal and related components.
+   */
   theme?: DocSearchTheme;
+  /**
+   * Placeholder text for the search input.
+   */
   placeholder?: string;
+  /**
+   * Additional algolia search parameters to merge into each query.
+   */
   searchParameters?: SearchParamsObject;
+  /**
+   * Maximum number of hits to display per source/group.
+   */
   maxResultsPerGroup?: number;
+  /**
+   * Hook to post-process hits before rendering.
+   */
   transformItems?: (items: DocSearchHit[]) => DocSearchHit[];
+  /**
+   * Custom component to render an individual hit.
+   */
   hitComponent?: (props: { hit: InternalDocSearchHit | StoredDocSearchHit; children: React.ReactNode }) => JSX.Element;
+  /**
+   * Custom component rendered at the bottom of the results panel.
+   */
   resultsFooterComponent?: (props: { state: AutocompleteState<InternalDocSearchHit> }) => JSX.Element | null;
+  /**
+   * Hook to wrap or modify the algolia search client.
+   */
   transformSearchClient?: (searchClient: DocSearchTransformClient) => DocSearchTransformClient;
+  /**
+   * Disable storage and usage of recent and favorite searches.
+   */
   disableUserPersonalization?: boolean;
+  /**
+   * Query string to prefill when opening the modal.
+   */
   initialQuery?: string;
+  /**
+   * Custom navigator for controlling link navigation.
+   */
   navigator?: AutocompleteOptions<InternalDocSearchHit>['navigator'];
+  /**
+   * Localized strings for the button and modal ui.
+   */
   translations?: DocSearchTranslations;
+  /**
+   * Builds a url to report missing results for a given query.
+   */
   getMissingResultsUrl?: ({ query }: { query: string }) => string;
+  /**
+   * Insights client integration options to send analytics events.
+   */
   insights?: AutocompleteOptions<InternalDocSearchHit>['insights'];
   /**
-   * Limit of how many recent searches that should be saved/displayed.
+   * The container element where the modal should be portaled to. Defaults to document.body.
+   */
+  portalContainer?: DocumentFragment | Element;
+  /**
+   * Limit of how many recent searches should be saved/displayed..
    *
    * @default 7
    */
   recentSearchesLimit?: number;
   /**
-   * Limit of how many recent searches that should be saved/displayed when there are favorited searches.
+   * Limit of how many recent searches should be saved/displayed when there are favorited searches..
    *
    * @default 4
    */
@@ -159,7 +217,7 @@ export function DocSearch({ ...props }: DocSearchProps): JSX.Element {
             onAskAiToggle={onAskAiToggle}
             onClose={onClose}
           />,
-          document.body,
+          props.portalContainer ?? document.body,
         )}
     </>
   );

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -305,6 +305,40 @@ describe('api', () => {
     });
   });
 
+  describe('portalContainer', () => {
+    it('renders the modal inside document.body by default', async () => {
+      render(<DocSearch />);
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      const portal = document.querySelector('.DocSearch-Container');
+
+      expect(portal).toBeInTheDocument();
+      expect(portal?.parentElement).toBe(document.body);
+    });
+
+    it('renders the modal inside the provided portal container', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      render(<DocSearch portalContainer={container} />);
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      const portal = container.querySelector('.DocSearch-Container');
+
+      expect(portal).toBeInTheDocument();
+      expect(portal?.parentElement).toBe(container);
+
+      // clean up manually created container
+      container.remove();
+    });
+  });
+
   describe('Theme', () => {
     const html = document.documentElement;
     it('light theme', () => {

--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -536,6 +536,58 @@ docsearch({
 </TabItem>
 </Tabs>
 
+## `portalContainer` (React-only)
+
+> `type: Element | DocumentFragment` | `default: document.body` | **optional**
+
+The element where the DocSearch modal will be portaled. Use this when you need the overlay to render in a custom DOM node—for example when working inside a shadow root, a specific layout container, or a modal manager. When omitted, the modal portals to `document.body`.
+
+:::warning
+
+This prop only exists in `@docsearch/react`. If you are using **`@docsearch/js`**, use the [`container`](#container) option instead—the value you pass there is both the **mount point** of the search button *and* the portal target for the modal.
+
+:::
+
+<Tabs
+  groupId="language"
+  defaultValue="react"
+  values={[{ label: 'React', value: 'react' }, { label: 'JavaScript', value: 'js' }]}
+>
+<TabItem value="react">
+
+```jsx
+// assume you have a dedicated modal root in your html
+<div id="modal-root" />
+
+const portalEl = document.getElementById('modal-root');
+
+<DocSearch
+  appId="YOUR_APP_ID"
+  apiKey="YOUR_SEARCH_API_KEY"
+  indexName="YOUR_INDEX_NAME"
+  // render the modal inside #modal-root instead of document.body
+  portalContainer={portalEl}
+/>;
+```
+
+</TabItem>
+
+<TabItem value="js">
+
+```js
+docsearch({
+  // the element that will **contain the button** and **host the modal portal**
+  container: '#modal-root',
+  appId: 'YOUR_APP_ID',
+  apiKey: 'YOUR_SEARCH_API_KEY',
+  indexName: 'YOUR_INDEX_NAME',
+});
+```
+
+</TabItem>
+</Tabs>
+
+
 [1]: https://www.algolia.com/doc/ui-libraries/autocomplete/introduction/what-is-autocomplete/
 [2]: https://github.com/algolia/docsearch/
 [3]: https://github.com/algolia/docsearch/tree/master

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -3,7 +3,6 @@ import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
-import { dts } from 'rollup-plugin-dts';
 import filesize from 'rollup-plugin-filesize';
 
 export const plugins = [
@@ -28,9 +27,3 @@ export const plugins = [
     showGzippedSize: true,
   }),
 ];
-
-export const typesConfig = {
-  input: 'dist/esm/types/index.d.ts',
-  output: [{ file: 'dist/esm/index.d.ts', format: 'es' }],
-  plugins: [dts()],
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2343,6 +2343,7 @@ __metadata:
     "@rollup/plugin-replace": "npm:6.0.2"
     nodemon: "npm:^3.1.9"
     preact: "npm:^10.0.0"
+    rollup-plugin-dts: "npm:^6.2.1"
   languageName: unknown
   linkType: soft
 
@@ -2431,6 +2432,7 @@ __metadata:
     algoliasearch: "npm:^5.28.0"
     marked: "npm:^15.0.12"
     nodemon: "npm:^3.1.0"
+    rollup-plugin-dts: "npm:^6.2.1"
     vitest: "npm:3.0.2"
     zod: "npm:^3.25.67"
   peerDependencies:
@@ -22577,6 +22579,22 @@ __metadata:
     "@babel/code-frame":
       optional: true
   checksum: 10c0/2b042198ff00fb10c9c70087bbac9013f748dc34be0dbfcca82c6353884ead1467b4a8a37bafe9a8b9356479d43715c7cbc591eeb8e4112c583452431c1cb0a0
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-dts@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "rollup-plugin-dts@npm:6.2.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.26.2"
+    magic-string: "npm:^0.30.17"
+  peerDependencies:
+    rollup: ^3.29.4 || ^4
+    typescript: ^4.5 || ^5.0
+  dependenciesMeta:
+    "@babel/code-frame":
+      optional: true
+  checksum: 10c0/f21c8726470851a40e6ca68ae580261cee8bc6275775291b9c0fdf93b868ed54f12b11c8c0dddce2c14f5691d6032b6647d094835ab9b6789226efa60e1aa71e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,7 +417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.24.2, @babel/code-frame@npm:^7.25.9, @babel/code-frame@npm:^7.26.0, @babel/code-frame@npm:^7.26.2":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.25.9, @babel/code-frame@npm:^7.26.0, @babel/code-frame@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/code-frame@npm:7.26.2"
   dependencies:
@@ -2389,7 +2389,6 @@ __metadata:
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     rollup: "npm:4.31.0"
-    rollup-plugin-dts: "npm:6.1.1"
     rollup-plugin-filesize: "npm:10.0.0"
     shipjs: "npm:0.27.0"
     start-server-and-test: "npm:2.0.10"
@@ -16729,7 +16728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.10, magic-string@npm:^0.30.17, magic-string@npm:^0.30.3":
+"magic-string@npm:^0.30.17, magic-string@npm:^0.30.3":
   version: 0.30.17
   resolution: "magic-string@npm:0.30.17"
   dependencies:
@@ -22563,22 +22562,6 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 10c0/7da4fd0e15118ee05b918359462cfa1e7fe4b1228c7765195a45b55576e8c15b95db513b8466ec89129666f4af45ad978a3057a02139afba1a63512a2d9644cc
-  languageName: node
-  linkType: hard
-
-"rollup-plugin-dts@npm:6.1.1":
-  version: 6.1.1
-  resolution: "rollup-plugin-dts@npm:6.1.1"
-  dependencies:
-    "@babel/code-frame": "npm:^7.24.2"
-    magic-string: "npm:^0.30.10"
-  peerDependencies:
-    rollup: ^3.29.4 || ^4
-    typescript: ^4.5 || ^5.0
-  dependenciesMeta:
-    "@babel/code-frame":
-      optional: true
-  checksum: 10c0/2b042198ff00fb10c9c70087bbac9013f748dc34be0dbfcca82c6353884ead1467b4a8a37bafe9a8b9356479d43715c7cbc591eeb8e4112c583452431c1cb0a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed

- Exposing `portalContainer` to help select on what node the react component portals to.
- Bundling relevant external types in the JS component.

Fixes: #2695 and #2693