### PR TITLE
fix(docsearch): use correct index name for Ask AI localStorage keys

### DIFF
--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -307,6 +307,13 @@ export function DocSearchModal({
     typeof window !== 'undefined' ? window.getSelection()!.toString().slice(0, MAX_QUERY_SIZE) : '',
   ).current;
   const initialQuery = React.useRef(initialQueryFromProp || initialQueryFromSelection).current;
+
+  const searchClient = useSearchClient(appId, apiKey, transformSearchClient);
+
+  const askAiConfig = typeof askAi === 'object' ? askAi : null;
+  const askAiConfigurationId = typeof askAi === 'string' ? askAi : askAiConfig?.assistantId || null;
+  const askAiSearchParameters = askAiConfig?.searchParameters;
+
   // storage
   const conversations = React.useRef(
     createStoredConversations<StoredAskAiState>({
@@ -326,12 +333,6 @@ export function DocSearchModal({
       limit: favoriteSearches.getAll().length === 0 ? recentSearchesLimit : recentSearchesWithFavoritesLimit,
     }),
   ).current;
-
-  const searchClient = useSearchClient(appId, apiKey, transformSearchClient);
-
-  const askAiConfig = typeof askAi === 'object' ? askAi : null;
-  const askAiConfigurationId = typeof askAi === 'string' ? askAi : askAiConfig?.assistantId || null;
-  const askAiSearchParameters = askAiConfig?.searchParameters;
 
   const [askAiStreamError, setAskAiStreamError] = React.useState<Error | null>(null);
 


### PR DESCRIPTION
## Summary
- Fix localStorage key generation for Ask AI conversations to use the correct index name
- Move searchClient and askAi configuration initialization before conversations storage setup
- Ensure askAiConfigurationId is available when creating localStorage keys

## Problem
Previously, localStorage keys for Ask AI conversations were incorrectly using the main documentation index name instead of the specific Ask AI index name.

Before: `__DOCSEARCH_ASKAI_CONVERSATIONS__Prerelease Docs`
After: `__DOCSEARCH_ASKAI_CONVERSATIONS__Prerelease Ask AI`

## Changes
- Moved `searchClient` and Ask AI configuration variables initialization before `conversations` storage setup
- This ensures the correct `askAiConfigurationId` is available when localStorage keys are generated

Fixes #2725

🤖 Generated with [Claude Code](https://claude.ai/code)