### PR TITLE
feat(v4): Add support for multi-index search

### DIFF
--- a/examples/demo-react/src/App.tsx
+++ b/examples/demo-react/src/App.tsx
@@ -7,6 +7,7 @@ import '@docsearch/css/dist/style.css';
 
 import Basic from './examples/basic';
 import BasicAskAI from './examples/basic-askai';
+import MultiIndex from './examples/multi-index';
 import WHitComponent from './examples/w-hit-component';
 import WTransformItems from './examples/w-hit-transformItems';
 
@@ -45,6 +46,13 @@ function App(): JSX.Element {
             <p className="section-description">transform items before rendering</p>
             <div className="search-wrapper">
               <WTransformItems />
+            </div>
+          </section>
+
+          <section className="demo-section">
+            <p className="section-description">multi index search</p>
+            <div className="search-wrapper">
+              <MultiIndex />
             </div>
           </section>
         </main>

--- a/examples/demo-react/src/examples/multi-index.tsx
+++ b/examples/demo-react/src/examples/multi-index.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable react/react-in-jsx-scope */
+import { DocSearch } from '@docsearch/react';
+import type { JSX } from 'react';
+
+export default function MultiIndex(): JSX.Element {
+  return (
+    <DocSearch
+      indices={[
+        {
+          name: 'docsearch',
+        },
+        {
+          name: 'tailwindcss',
+        },
+        {
+          name: 'kubernetes',
+        },
+      ]}
+      appId="PMZUYBQDAK"
+      apiKey="24b09689d5b4223813d9b8e48563c8f6"
+      translations={{ button: { buttonText: 'Multi index search' } }}
+      insights={true}
+    />
+  );
+}

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -72,7 +72,9 @@ export interface DocSearchProps {
    */
   indexName?: string;
   /**
-   * List of indices to be used for search.
+   * List of indices and _optional_ searchParameters to be used for search.
+   *
+   * @see {@link https://docsearch.algolia.com/docs/api#indices}
    */
   indices?: Array<DocSearchIndex | string>;
   /**

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -51,6 +51,11 @@ export type DocSearchAskAi = {
   };
 };
 
+export interface DocSearchIndex {
+  name: string;
+  searchParameters?: SearchParamsObject;
+}
+
 export interface DocSearchProps {
   /**
    * Algolia application id used by the search client.
@@ -62,8 +67,14 @@ export interface DocSearchProps {
   apiKey: string;
   /**
    * Name of the algolia index to query.
+   *
+   * @deprecated `indexName` will be removed in a future version. Please use `indices` property going forward.
    */
-  indexName: string;
+  indexName?: string;
+  /**
+   * List of indices to be used for search.
+   */
+  indices?: Array<DocSearchIndex | string>;
   /**
    * Configuration or assistant id to enable ask ai mode. Pass a string assistant id or a full config object.
    */
@@ -78,6 +89,8 @@ export interface DocSearchProps {
   placeholder?: string;
   /**
    * Additional algolia search parameters to merge into each query.
+   *
+   * @deprecated `searchParameters` will be removed in a future version. Please use `indices` property going forward.
    */
   searchParameters?: SearchParamsObject;
   /**
@@ -142,7 +155,7 @@ export interface DocSearchProps {
   recentSearchesWithFavoritesLimit?: number;
 }
 
-export function DocSearch({ ...props }: DocSearchProps): JSX.Element {
+export function DocSearch({ indexName, searchParameters, indices = [], ...props }: DocSearchProps): JSX.Element {
   const searchButtonRef = React.useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState<string | undefined>(props?.initialQuery || undefined);
@@ -200,6 +213,26 @@ export function DocSearch({ ...props }: DocSearchProps): JSX.Element {
   });
   useTheme({ theme: props.theme });
 
+  // Format the `indexes` to be used until `indexName` and `searchParameters` props are fully removed.
+  const indexes: DocSearchIndex[] = [];
+
+  if (indexName && indexName !== '') {
+    indexes.push({
+      name: indexName,
+      searchParameters,
+    });
+  }
+
+  if (indices.length > 0) {
+    indices.forEach((index) => {
+      indexes.push(typeof index === 'string' ? { name: index } : index);
+    });
+  }
+
+  if (indexes.length < 1) {
+    throw new Error('Must supply either `indexName` or `indices` for DocSearch to work');
+  }
+
   return (
     <>
       <DocSearchButton ref={searchButtonRef} translations={props?.translations?.button} onClick={onOpen} />
@@ -214,6 +247,7 @@ export function DocSearch({ ...props }: DocSearchProps): JSX.Element {
             translations={props?.translations?.modal}
             isAskAiActive={isAskAiActive}
             canHandleAskAi={canHandleAskAi}
+            indexes={indexes}
             onAskAiToggle={onAskAiToggle}
             onClose={onClose}
           />,

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -11,7 +11,7 @@ import React, { type JSX } from 'react';
 
 import { getValidToken, postFeedback } from './askai';
 import { ASK_AI_API_URL, MAX_QUERY_SIZE, USE_ASK_AI_TOKEN } from './constants';
-import type { DocSearchProps } from './DocSearch';
+import type { DocSearchIndex, DocSearchProps } from './DocSearch';
 import type { FooterTranslations } from './Footer';
 import { Footer } from './Footer';
 import { Hit } from './Hit';
@@ -42,6 +42,7 @@ export type DocSearchModalProps = DocSearchProps & {
   isAskAiActive?: boolean;
   canHandleAskAi?: boolean;
   translations?: ModalTranslations;
+  indexes: DocSearchIndex[];
 };
 
 /**
@@ -116,8 +117,7 @@ const buildQuerySources = async ({
   setContext,
   setStatus,
   searchClient,
-  indexName,
-  searchParameters,
+  indexes: indices,
   snippetLength,
   insights,
   appId,
@@ -132,8 +132,7 @@ const buildQuerySources = async ({
   setContext: (context: Partial<DocSearchState<InternalDocSearchHit>['context']>) => void;
   setStatus: (status: DocSearchState<InternalDocSearchHit>['status']) => void;
   searchClient: ReturnType<typeof useSearchClient>;
-  indexName: string;
-  searchParameters: DocSearchProps['searchParameters'];
+  indexes: DocSearchIndex[];
   snippetLength: React.MutableRefObject<number>;
   insights: boolean;
   appId?: string;
@@ -147,11 +146,14 @@ const buildQuerySources = async ({
 
   try {
     const { results } = await searchClient.search<DocSearchHit>({
-      requests: [
-        {
+      requests: indices.map((index) => {
+        const indexName = typeof index === 'string' ? index : index.name;
+        const searchParams = typeof index === 'string' ? {} : index.searchParameters;
+
+        return {
           query,
           indexName,
-          attributesToRetrieve: searchParameters?.attributesToRetrieve ?? [
+          attributesToRetrieve: searchParams?.attributesToRetrieve ?? [
             'hierarchy.lvl0',
             'hierarchy.lvl1',
             'hierarchy.lvl2',
@@ -163,7 +165,7 @@ const buildQuerySources = async ({
             'type',
             'url',
           ],
-          attributesToSnippet: searchParameters?.attributesToSnippet ?? [
+          attributesToSnippet: searchParams?.attributesToSnippet ?? [
             `hierarchy.lvl1:${snippetLength.current}`,
             `hierarchy.lvl2:${snippetLength.current}`,
             `hierarchy.lvl3:${snippetLength.current}`,
@@ -172,80 +174,90 @@ const buildQuerySources = async ({
             `hierarchy.lvl6:${snippetLength.current}`,
             `content:${snippetLength.current}`,
           ],
-          snippetEllipsisText: searchParameters?.snippetEllipsisText ?? '…',
-          highlightPreTag: searchParameters?.highlightPreTag ?? '<mark>',
-          highlightPostTag: searchParameters?.highlightPostTag ?? '</mark>',
-          hitsPerPage: searchParameters?.hitsPerPage ?? 20,
-          clickAnalytics: searchParameters?.clickAnalytics ?? insightsActive,
-          ...searchParameters,
-        },
-      ],
+          snippetEllipsisText: searchParams?.snippetEllipsisText ?? '…',
+          highlightPreTag: searchParams?.highlightPreTag ?? '<mark>',
+          highlightPostTag: searchParams?.highlightPostTag ?? '</mark>',
+          hitsPerPage: searchParams?.hitsPerPage ?? 20,
+          clickAnalytics: searchParams?.clickAnalytics ?? insightsActive,
+          ...(searchParams ?? {}),
+        };
+      }),
     });
 
-    const firstResult = results[0] as SearchResponse<DocSearchHit>;
-    const { hits, nbHits } = firstResult;
-    const transformedHits = transformItems(hits);
-    const sources = groupBy<DocSearchHit>(transformedHits, (hit) => removeHighlightTags(hit), maxResultsPerGroup);
+    return results.flatMap((res) => {
+      const result = res as SearchResponse<DocSearchHit>;
+      const { hits, nbHits } = result;
+      const transformedHits = transformItems(hits);
+      const sources = groupBy<DocSearchHit>(transformedHits, (hit) => removeHighlightTags(hit), maxResultsPerGroup);
 
-    // We store the `lvl0`s to display them as search suggestions
-    // in the "no results" screen.
-    if ((sourcesState.context.searchSuggestions as any[]).length < Object.keys(sources).length) {
-      setContext({
-        searchSuggestions: Object.keys(sources),
+      // We store the `lvl0`s to display them as search suggestions
+      // in the "no results" screen.
+      if ((sourcesState.context.searchSuggestions as any[]).length < Object.keys(sources).length) {
+        setContext({
+          searchSuggestions: {
+            ...(sourcesState.context.searchSuggestions ?? []),
+            ...Object.keys(sources),
+          },
+        });
+      }
+
+      if (nbHits) {
+        const currentNbHits = sourcesState.context.nbHits as number | undefined;
+        setContext({
+          nbHits: (currentNbHits ?? 0) + nbHits,
+        });
+      }
+
+      let insightsParams = {};
+
+      if (insightsActive) {
+        insightsParams = {
+          __autocomplete_indexName: result.index,
+          __autocomplete_queryID: result.queryID,
+          __autocomplete_algoliaCredentials: {
+            appId,
+            apiKey,
+          },
+        };
+      }
+
+      return Object.values<DocSearchHit[]>(sources).map((items, index) => {
+        return {
+          sourceId: `hits_${result.index}_${index}`,
+          onSelect({ item, event }): void {
+            saveRecentSearch(item);
+            if (!isModifierEvent(event)) {
+              onClose();
+            }
+          },
+          getItemUrl({ item }): string {
+            return item.url;
+          },
+          getItems(): InternalDocSearchHit[] {
+            return Object.values(groupBy(items, (item) => item.hierarchy.lvl1, maxResultsPerGroup))
+              .map((groupedHits) =>
+                groupedHits.map((item) => {
+                  let parent: InternalDocSearchHit | null = null;
+
+                  const potentialParent = groupedHits.find(
+                    (siblingItem) => siblingItem.type === 'lvl1' && siblingItem.hierarchy.lvl1 === item.hierarchy.lvl1,
+                  ) as InternalDocSearchHit | undefined;
+
+                  if (item.type !== 'lvl1' && potentialParent) {
+                    parent = potentialParent;
+                  }
+
+                  return {
+                    ...item,
+                    __docsearch_parent: parent,
+                    ...insightsParams,
+                  };
+                }),
+              )
+              .flat();
+          },
+        };
       });
-    }
-
-    setContext({ nbHits });
-
-    let insightsParams = {};
-
-    if (insightsActive) {
-      insightsParams = {
-        __autocomplete_indexName: indexName,
-        __autocomplete_queryID: firstResult.queryID,
-        __autocomplete_algoliaCredentials: {
-          appId,
-          apiKey,
-        },
-      };
-    }
-
-    return Object.values<DocSearchHit[]>(sources).map((items, index) => {
-      return {
-        sourceId: `hits${index}`,
-        onSelect({ item, event }): void {
-          saveRecentSearch(item);
-          if (!isModifierEvent(event)) {
-            onClose();
-          }
-        },
-        getItemUrl({ item }): string {
-          return item.url;
-        },
-        getItems(): InternalDocSearchHit[] {
-          return Object.values(groupBy(items, (item) => item.hierarchy.lvl1, maxResultsPerGroup))
-            .map((groupedHits) =>
-              groupedHits.map((item) => {
-                let parent: InternalDocSearchHit | null = null;
-
-                const potentialParent = groupedHits.find(
-                  (siblingItem) => siblingItem.type === 'lvl1' && siblingItem.hierarchy.lvl1 === item.hierarchy.lvl1,
-                ) as InternalDocSearchHit | undefined;
-
-                if (item.type !== 'lvl1' && potentialParent) {
-                  parent = potentialParent;
-                }
-
-                return {
-                  ...item,
-                  __docsearch_parent: parent,
-                  ...insightsParams,
-                };
-              }),
-            )
-            .flat();
-        },
-      };
     });
   } catch (error) {
     // The Algolia `RetryError` happens when all the servers have
@@ -262,10 +274,8 @@ const buildQuerySources = async ({
 export function DocSearchModal({
   appId,
   apiKey,
-  indexName,
   placeholder,
   askAi,
-  searchParameters,
   maxResultsPerGroup,
   theme,
   onClose = noop,
@@ -285,6 +295,7 @@ export function DocSearchModal({
   canHandleAskAi = false,
   recentSearchesLimit = 7,
   recentSearchesWithFavoritesLimit = 4,
+  indexes,
 }: DocSearchModalProps): JSX.Element {
   const { footer: footerTranslations, searchBox: searchBoxTranslations, ...screenStateTranslations } = translations;
   const [state, setState] = React.useState<DocSearchState<InternalDocSearchHit>>({
@@ -314,22 +325,24 @@ export function DocSearchModal({
   const askAiConfigurationId = typeof askAi === 'string' ? askAi : askAiConfig?.assistantId || null;
   const askAiSearchParameters = askAiConfig?.searchParameters;
 
+  const defaultIndexName = indexes[0].name;
+
   // storage
   const conversations = React.useRef(
     createStoredConversations<StoredAskAiState>({
-      key: `__DOCSEARCH_ASKAI_CONVERSATIONS__${askAiConfig?.indexName || indexName}`,
+      key: `__DOCSEARCH_ASKAI_CONVERSATIONS__${askAiConfig?.indexName || defaultIndexName}`,
       limit: 10,
     }),
   ).current;
   const favoriteSearches = React.useRef(
     createStoredSearches<StoredDocSearchHit>({
-      key: `__DOCSEARCH_FAVORITE_SEARCHES__${indexName}`,
+      key: `__DOCSEARCH_FAVORITE_SEARCHES__${defaultIndexName}`,
       limit: 10,
     }),
   ).current;
   const recentSearches = React.useRef(
     createStoredSearches<StoredDocSearchHit>({
-      key: `__DOCSEARCH_RECENT_SEARCHES__${indexName}`,
+      key: `__DOCSEARCH_RECENT_SEARCHES__${defaultIndexName}`,
       limit: favoriteSearches.getAll().length === 0 ? recentSearchesLimit : recentSearchesWithFavoritesLimit,
     }),
   ).current;
@@ -363,7 +376,7 @@ export function DocSearchModal({
       'Content-Type': 'application/json',
       'X-Algolia-API-Key': askAiConfig?.apiKey || apiKey,
       'X-Algolia-Application-Id': askAiConfig?.appId || appId,
-      'X-Algolia-Index-Name': askAiConfig?.indexName || indexName,
+      'X-Algolia-Index-Name': askAiConfig?.indexName || defaultIndexName,
       'X-Algolia-Assistant-Id': askAiConfigurationId || '',
     },
     body: askAiSearchParameters ? { searchParameters: askAiSearchParameters } : {},
@@ -529,15 +542,13 @@ export function DocSearchModal({
           context: sourcesState.context,
         };
 
-        // Algolia sources
         const algoliaSourcesPromise = buildQuerySources({
           query,
           state: querySourcesState,
           setContext,
           setStatus,
           searchClient,
-          indexName,
-          searchParameters,
+          indexes,
           snippetLength,
           insights: Boolean(insights),
           appId,
@@ -587,7 +598,6 @@ export function DocSearchModal({
               },
             ]
           : [];
-
         // Combine Algolia results (once resolved) with the Ask AI source
         return algoliaSourcesPromise.then((algoliaSources) => {
           return [...askAiSource, ...algoliaSources];
@@ -748,7 +758,7 @@ export function DocSearchModal({
           <div className="DocSearch-Dropdown" ref={dropdownRef}>
             <ScreenState
               {...autocomplete}
-              indexName={indexName}
+              indexName={defaultIndexName}
               state={state}
               hitComponent={hitComponent}
               resultsFooterComponent={resultsFooterComponent}

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -350,4 +350,18 @@ describe('api', () => {
       expect(html.getAttribute('data-theme')).toBe('dark');
     });
   });
+
+  describe('Indexes', () => {
+    it('renders with deprecated indexName prop', () => {
+      expect(() => <DocSearch indexName="My test Index" />).not.toThrowError();
+    });
+
+    it('renders with new indices prop', () => {
+      expect(() => render(<DocSearch indexName={undefined} indices={[{ name: 'testing' }]} />)).not.toThrowError();
+    });
+
+    it('throws an error if indexName or indices are not provided', () => {
+      expect(() => render(<DocSearch indexName={undefined} indices={[]} />)).toThrowError();
+    });
+  });
 });

--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -51,11 +51,105 @@ Your Algolia application ID.
 
 Your Algolia Search API key.
 
+## `indices`
+
+> `type: Array<string | DocSearchIndex>`
+
+The list of indices and their _optional_ `searchParameters` to be used for keyword search.
+
+[Algolia Search Parameters][7]
+
+:::tip
+
+The ordering matters in the list, as results are ordered based on `indices` order.
+
+:::
+
+> While `indexName` is in deprecation, it is required to pass either `indices` or `indexName`. Not passing either will result in an `Error` being thrown.
+
+<Tabs
+  groupId="language"
+  defaultValue="js"
+  values={[
+    { label: 'JavaScript', value: 'js', },
+    { label: 'React', value: 'react', }
+  ]
+}>
+<TabItem value="js">
+
+```js
+docsearch({
+  // ...
+  indices: ['YOUR_ALGOLIA_INDEX'],
+  // ...
+});
+```
+
+in case you want to use custom `searchParameters` for the index
+
+```js
+docsearch({
+  // ...
+  indices: [
+    {
+      name: 'YOUR_ALGOLIA_INDEX',
+      searchParameters: {
+        facetFilters: ['language:en'],
+        // ...
+      }
+    }
+  ],
+  // ...
+});
+```
+
+</TabItem>
+
+<TabItem value="react">
+
+```jsx
+<DocSearch
+  // ...
+  indices={['YOUR_ALGOLIA_INDEX']}
+  // ...
+/>
+```
+
+in case you want to use custom `searchParameters` for the index
+
+
+```jsx
+<DocSearch
+  // ...
+  indices={[
+    {
+      name: 'YOUR_ALGOLIA_INDEX',
+      searchParameters: {
+        facetFilters: ['language:en'],
+        // ...
+      }
+    }
+  ]}
+  // ...
+/>
+```
+
+</TabItem>
+</Tabs>
+
 ## `indexName`
 
-> `type: string` | **required**
+> `type: string` | **deprecated**
+
+:::warning[Deprecation warning]
+
+`indexName` is currently being planned for deprecation. The new recommended property to use is `indices`.
+
+:::
 
 Your Algolia index name.
+
+> While `indexName` is in deprecation, it is required to pass either `indices` or `indexName`. Not passing either will result in an `Error` being thrown.
 
 ## `placeholder`
 
@@ -139,7 +233,13 @@ You can use `facetFilters: ['type:content']` to ensure AskAI only uses records w
 
 ## `searchParameters`
 
-> `type: SearchParameters` | **optional**
+> `type: SearchParameters` | **optional** | **deprecated**
+
+:::warning[Deprecation warning]
+
+`searchParameters` is currently being planned for deprecation. The new recommended property to use is `indices`.
+
+:::
 
 The [Algolia Search Parameters][7].
 

--- a/packages/website/docusaurus.config.mjs
+++ b/packages/website/docusaurus.config.mjs
@@ -133,7 +133,7 @@ export default {
       colorMode: {
         defaultMode: 'light',
         disableSwitch: false,
-        respectPrefersColorScheme: false,
+        respectPrefersColorScheme: true,
       },
       footer: {
         links: [


### PR DESCRIPTION
## What
Adds support for multi-index search during keyword search. This does not impact AskAI in any way.

- Add new `indices` property to accept a list of indexes for search
- Add deprecation messaging to `indexName` and `searchParameters` properties
- Manage backwards compatibility for now until `indexName` and `searchParameters` are fully removed
- Add another example of multi-index search

## Docs
- Adds documentation for `indices` and deprecation warnings for `indexName` and `searchParameters`
- Enables `respectPrefersColorScheme` within Docusaurus config

<img width="1022" height="1024" alt="indices_js_docs" src="https://github.com/user-attachments/assets/95c56d08-e9c9-4bc7-a0ad-5b70efda0f4e" />

<img width="1025" height="1004" alt="indices_react_docs" src="https://github.com/user-attachments/assets/0906a0ee-8e4a-4ccc-8a7e-ba107e2a2140" />

<img width="1018" height="364" alt="index_name_deprecation" src="https://github.com/user-attachments/assets/de9e3252-1813-44cb-aada-7f2e716d54ac" />

<img width="1024" height="275" alt="search_parameters_deprecation" src="https://github.com/user-attachments/assets/fd5e3457-10ce-4585-a368-9205a199d3df" />

## Dependencies
- [x] Add documentation around new and deprecated properties