### PR TITLE
feat(askai): Display number of search results from tool call

### DIFF
--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -191,7 +191,7 @@ function AskAiExchangeCard({
                       <div key={index} className="DocSearch-AskAiScreen-MessageContent-Tool Tool--Call shimmer">
                         <LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />
                         <span>
-                          {`${translations.duringToolCallText || 'Searching for '} "${part.input || ''}" ...`}
+                          {`${translations.duringToolCallText || 'Searching for '} "${part.input.query || ''}" ...`}
                         </span>
                       </div>
                     );
@@ -215,7 +215,8 @@ function AskAiExchangeCard({
                           >
                             {' '}
                             &quot;{part.output.query || ''}&quot;
-                          </span>
+                          </span>{' '}
+                          found {part.output.hits?.length || 0} results
                         </span>
                       </div>
                     );

--- a/packages/docsearch-react/src/__tests__/utils.test.ts
+++ b/packages/docsearch-react/src/__tests__/utils.test.ts
@@ -106,10 +106,13 @@ describe('utils', () => {
           },
           {
             type: 'tool-searchIndex',
-            input: 'What is DocSearch',
+            input: {
+              query: 'What is DocSearch',
+            },
             state: 'output-available',
             output: {
               query: 'DocSearch',
+              hits: [],
             },
             toolCallId: 'searchIndex-testing',
           },

--- a/packages/docsearch-react/src/types/AskiAi.ts
+++ b/packages/docsearch-react/src/types/AskiAi.ts
@@ -2,9 +2,12 @@ import type { UIMessage } from '@ai-sdk/react';
 import type { UIDataTypes, UIMessagePart } from 'ai';
 
 export interface SearchIndexTool {
-  input: string;
-  output: {
+  input: {
     query: string;
+  };
+  output: {
+    query?: string;
+    hits?: any[];
   };
 }
 


### PR DESCRIPTION
## What
- Display number of results from the tool call output
- Fix issue with "[Object object]" showing during tool streaming

## Preview
<img width="766" height="180" alt="Screenshot 2025-09-11 at 1 05 16 PM" src="https://github.com/user-attachments/assets/172357a3-c898-4e59-a955-ca9a88223aeb" />
