### PR TITLE
fix(deps): Adds zod to dependency list

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,11 +6,11 @@
     },
     {
       "path": "packages/docsearch-react/dist/umd/index.js",
-      "maxSize": "108 kB"
+      "maxSize": "109 kB"
     },
     {
       "path": "packages/docsearch-js/dist/umd/index.js",
-      "maxSize": "121 kB"
+      "maxSize": "123 kB"
     }
   ]
 }

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -41,7 +41,8 @@
     "@docsearch/css": "4.0.0",
     "ai": "^5.0.30",
     "algoliasearch": "^5.28.0",
-    "marked": "^15.0.12"
+    "marked": "^15.0.12",
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "6.0.2",
@@ -49,8 +50,7 @@
     "@testing-library/react": "16.2.0",
     "nodemon": "^3.1.0",
     "rollup-plugin-dts": "^6.2.1",
-    "vitest": "3.0.2",
-    "zod": "^3.25.67"
+    "vitest": "3.0.2"
   },
   "peerDependencies": {
     "@types/react": ">= 16.8.0 < 20.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,7 +2486,7 @@ __metadata:
     nodemon: "npm:^3.1.0"
     rollup-plugin-dts: "npm:^6.2.1"
     vitest: "npm:3.0.2"
-    zod: "npm:^3.25.67"
+    zod: "npm:^4.1.8"
   peerDependencies:
     "@types/react": ">= 16.8.0 < 20.0.0"
     react: ">= 16.8.0 < 20.0.0"
@@ -26628,10 +26628,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25.67":
-  version: 3.25.67
-  resolution: "zod@npm:3.25.67"
-  checksum: 10c0/80a0cab3033272c4ab9312198081f0c4ea88e9673c059aa36dc32024906363729db54bdb78f3dc9d5529bd1601f74974d5a56c0a23e40c6f04a9270c9ff22336
+"zod@npm:^4.1.8":
+  version: 4.1.8
+  resolution: "zod@npm:4.1.8"
+  checksum: 10c0/5eae39da09d7bd0564a30dfd2348811e4e2e7dd15955d8f3444f8e196f35e5422b1482eda234b722fafb0738f4a8b718adb042b860936bfdd2cc19cdbdac8a9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Both newer versions of `ai` and `@ai-sdk/react` have a `peerDependency` set for `zod`. This adds `zod` to our main `dependencies` so that it is just installed along with DocSearch itself.

Fixes #2758 