### PR TITLE
fix(modal): Fixes issue with index typings on DocSearchModal

### DIFF
--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -167,7 +167,7 @@ export interface DocSearchProps {
   keyboardShortcuts?: KeyboardShortcuts;
 }
 
-export function DocSearch({ indexName, searchParameters, indices = [], ...props }: DocSearchProps): JSX.Element {
+export function DocSearch(props: DocSearchProps): JSX.Element {
   const searchButtonRef = React.useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState<string | undefined>(props?.initialQuery || undefined);
@@ -226,26 +226,6 @@ export function DocSearch({ indexName, searchParameters, indices = [], ...props 
   });
   useTheme({ theme: props.theme });
 
-  // Format the `indexes` to be used until `indexName` and `searchParameters` props are fully removed.
-  const indexes: DocSearchIndex[] = [];
-
-  if (indexName && indexName !== '') {
-    indexes.push({
-      name: indexName,
-      searchParameters,
-    });
-  }
-
-  if (indices.length > 0) {
-    indices.forEach((index) => {
-      indexes.push(typeof index === 'string' ? { name: index } : index);
-    });
-  }
-
-  if (indexes.length < 1) {
-    throw new Error('Must supply either `indexName` or `indices` for DocSearch to work');
-  }
-
   return (
     <>
       <DocSearchButton
@@ -265,7 +245,6 @@ export function DocSearch({ indexName, searchParameters, indices = [], ...props 
             translations={props?.translations?.modal}
             isAskAiActive={isAskAiActive}
             canHandleAskAi={canHandleAskAi}
-            indexes={indexes}
             onAskAiToggle={onAskAiToggle}
             onClose={onClose}
           />,

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -43,7 +43,6 @@ export type DocSearchModalProps = DocSearchProps & {
   isAskAiActive?: boolean;
   canHandleAskAi?: boolean;
   translations?: ModalTranslations;
-  indexes: DocSearchIndex[];
 };
 
 /**
@@ -296,7 +295,9 @@ export function DocSearchModal({
   canHandleAskAi = false,
   recentSearchesLimit = 7,
   recentSearchesWithFavoritesLimit = 4,
-  indexes,
+  indices = [],
+  indexName,
+  searchParameters,
 }: DocSearchModalProps): JSX.Element {
   const { footer: footerTranslations, searchBox: searchBoxTranslations, ...screenStateTranslations } = translations;
   const [state, setState] = React.useState<DocSearchState<InternalDocSearchHit>>({
@@ -325,6 +326,26 @@ export function DocSearchModal({
   const askAiConfig = typeof askAi === 'object' ? askAi : null;
   const askAiConfigurationId = typeof askAi === 'string' ? askAi : askAiConfig?.assistantId || null;
   const askAiSearchParameters = askAiConfig?.searchParameters;
+
+  // Format the `indexes` to be used until `indexName` and `searchParameters` props are fully removed.
+  const indexes: DocSearchIndex[] = [];
+
+  if (indexName && indexName !== '') {
+    indexes.push({
+      name: indexName,
+      searchParameters,
+    });
+  }
+
+  if (indices.length > 0) {
+    indices.forEach((index) => {
+      indexes.push(typeof index === 'string' ? { name: index } : index);
+    });
+  }
+
+  if (indexes.length < 1) {
+    throw new Error('Must supply either `indexName` or `indices` for DocSearch to work');
+  }
 
   const defaultIndexName = indexes[0].name;
 

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -350,18 +350,4 @@ describe('api', () => {
       expect(html.getAttribute('data-theme')).toBe('dark');
     });
   });
-
-  describe('Indexes', () => {
-    it('renders with deprecated indexName prop', () => {
-      expect(() => <DocSearch indexName="My test Index" />).not.toThrowError();
-    });
-
-    it('renders with new indices prop', () => {
-      expect(() => render(<DocSearch indexName={undefined} indices={[{ name: 'testing' }]} />)).not.toThrowError();
-    });
-
-    it('throws an error if indexName or indices are not provided', () => {
-      expect(() => render(<DocSearch indexName={undefined} indices={[]} />)).toThrowError();
-    });
-  });
 });


### PR DESCRIPTION
Fixes a TS/runtime issue when rendering the `<DocSearchModal />` directly after the recent `indexName` deprecation. This moves the fallback safeguard within the modal itself to allow the index props to be passed directly to it.