### PR TITLE
Example of multiple entrypoints

### DIFF
--- a/packages/docsearch-react/button.js
+++ b/packages/docsearch-react/button.js
@@ -1,1 +1,1 @@
-export { DocSearchButton } from './dist/esm';
+export { DocSearchButton } from './dist/esm/button.js';

--- a/packages/docsearch-react/rollup.config.js
+++ b/packages/docsearch-react/rollup.config.js
@@ -36,6 +36,32 @@ export default [
     ],
   },
   {
+    input: 'src/button.ts',
+    external: ['react', 'react-dom'],
+    output: [
+      {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
+        file: 'dist/umd/index.js',
+        format: 'umd',
+        sourcemap: true,
+        name: pkg.name,
+        banner: getBundleBanner(pkg),
+      },
+      { dir: 'dist/esm', format: 'es' },
+    ],
+    plugins: [
+      commonjs(),
+      ...plugins,
+      replace({
+        preventAssignment: true,
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      }),
+    ],
+  },
+  {
     input: 'dist/esm/types/index.d.ts',
     output: [{ file: 'dist/esm/index.d.ts', format: 'es' }],
     plugins: [dts()],

--- a/packages/docsearch-react/src/button.ts
+++ b/packages/docsearch-react/src/button.ts
@@ -1,0 +1,1 @@
+export * from './DocSearchButton';


### PR DESCRIPTION
Doing such a thing can help library consumers to better code-split the code.

I tested on Docusaurus, and we could significantly minimize the impact of the modal + askAi on bundle size (saving 400kb) if you exposed 3 entrypoints:
- `/button` 
- `/version` 
- `/useDocSearchKeyboardEvents` 

Before:
> -rw-r--r--@ 1 sebastienlorber  staff  1167928 Sep 18 18:33 website/build/assets/js/main.2c9e14df.js


After: 
> -rw-r--r--@ 1 sebastienlorber  staff  735434 Sep 18 18:34 website/build/assets/js/main.029ed3dc.js


Note: it could be beneficial to expose a `/modal` entrypoint too, otherwise we'd load all the button/useDocSearchKeyboardEvents twice, but the most important is to be able to use the button with lightweight code, and code-split/lazy-load the heavy modal

