### PR TITLE
fix(suggested-questions): Fixes Suggested Questions on dark theme

### DIFF
--- a/examples/demo-react/src/examples/basic-askai.tsx
+++ b/examples/demo-react/src/examples/basic-askai.tsx
@@ -13,6 +13,7 @@ export default function BasicAskAI(): JSX.Element {
         searchParameters: {
           facetFilters: ['language:en'],
         },
+        suggestedQuestions: true,
       }}
       insights={true}
       translations={{ button: { buttonText: 'Search with Ask AI' } }}

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -1419,12 +1419,12 @@ assistive tech users */
 .DocSearch-NewConversationScreen-SuggestedQuestion {
   border-radius: var(--docsearch-border-radius);
   padding: 12px;
-  border: 1px solid #D6D6E7;
+  border: 1px solid var(--docsearch-subtle-color);
   height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: #fff;
+  background-color: var(--docsearch-searchbox-background);
   color: var(--docsearch-text-color);
   cursor: pointer;
 }


### PR DESCRIPTION
## What
Fixes coloring of Suggested Questions on dark theme.

Before:
<img width="865" height="689" alt="before" src="https://github.com/user-attachments/assets/9df7f0eb-3781-473a-a233-93578fd23746" />

After:
<img width="846" height="681" alt="after" src="https://github.com/user-attachments/assets/15b23520-d3bb-4ff0-8cc7-7e47aea96333" />
