### PR TITLE
feat(sidepanel): Sidepanel UI/UX tweaks

### DIFF
--- a/packages/docsearch-css/src/sidepanel.css
+++ b/packages/docsearch-css/src/sidepanel.css
@@ -498,12 +498,6 @@ html[data-theme="dark"] .DocSearch-Sidepanel-Prompt--stop:hover {
   margin-bottom: 1.5rem;
 }
 
-@media screen and (min-width: 769px) {
-  .DocSearch-Sidepanel-Screen--introduction {
-    max-width: 50ch;
-  }
-}
-
 .DocSearch-Sidepanel-List {
   list-style-type: none;
   display: flex;
@@ -523,16 +517,25 @@ html[data-theme="dark"] .DocSearch-Sidepanel-Prompt--stop:hover {
   scroll-margin-top: 2.5rem;
   background-color: var(--docsearch-hit-background);
   color: var(--docsearch-sidepanel-text-base);
-  padding: 0 0.75rem;
+  padding: 0;
   width: 100%;
   margin-bottom: 0.25rem;
   cursor: pointer;
 }
 
-.DocSearch-Sidepanel-RecentConversation:hover {
+.DocSearch-Sidepanel-RecentConversation a {
+  width: 100%;
+  display: block;
+  padding: 0 0.75rem;
+}
+
+.DocSearch-Sidepanel-RecentConversation:hover,
+.DocSearch-Sidepanel-RecentConversation:focus-within {
   background-color: var(--docsearch-hit-highlight-color);
 }
 
+.DocSearch-Sidepanel-RecentConversation:focus-within .DocSearch-Sidepanel-RecentConversation-icon,
+.DocSearch-Sidepanel-RecentConversation:focus-within .DocSearch-Hit-action,
 .DocSearch-Sidepanel-RecentConversation:hover .DocSearch-Sidepanel-RecentConversation-icon,
 .DocSearch-Sidepanel-RecentConversation:hover .DocSearch-Hit-action {
   color: var(--docsearch-sidepanel-accent);
@@ -544,6 +547,7 @@ html[data-theme="dark"] .DocSearch-Sidepanel-Prompt--stop:hover {
   flex-direction: row;
   height: 3.5rem;
   width: 100%;
+  color: var(--docsearch-text-color);
 }
 
 .DocSearch-Sidepanel-RecentConversation-icon {

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -441,7 +441,7 @@ function RelatedSourceIcon(): JSX.Element {
   );
 }
 
-function CopyButton({
+export function CopyButton({
   onClick,
   translations,
 }: {
@@ -513,8 +513,7 @@ function CopyButton({
   );
 }
 
-function LikeButton({ title, onClick }: { title: string; onClick: () => void }): JSX.Element {
-  // @todo: implement like button
+export function LikeButton({ title, onClick }: { title: string; onClick: () => void }): JSX.Element {
   return (
     <button
       type="button"
@@ -541,8 +540,7 @@ function LikeButton({ title, onClick }: { title: string; onClick: () => void }):
   );
 }
 
-function DislikeButton({ title, onClick }: { title: string; onClick: () => void }): JSX.Element {
-  // @todo: implement dislike button
+export function DislikeButton({ title, onClick }: { title: string; onClick: () => void }): JSX.Element {
   return (
     <button
       type="button"

--- a/packages/docsearch-react/src/Sidepanel/ConversationActions.tsx
+++ b/packages/docsearch-react/src/Sidepanel/ConversationActions.tsx
@@ -1,0 +1,87 @@
+import type { JSX } from 'react';
+import React from 'react';
+
+import { CopyButton, DislikeButton, LikeButton, type AskAiScreenTranslations } from '../AskAiScreen';
+import { LoadingIcon } from '../icons';
+import type { StoredSearchPlugin } from '../stored-searches';
+import type { StoredAskAiState } from '../types';
+
+interface ConversationActionsProps {
+  id: string;
+  showActions: boolean;
+  latestAssistantMessageContent: string | null;
+  translations: AskAiScreenTranslations;
+  conversations: StoredSearchPlugin<StoredAskAiState>;
+  onFeedback?: (messageId: string, thumbs: 0 | 1) => Promise<void>;
+  isSidepanel?: boolean;
+}
+
+export function ConversationActions({
+  translations,
+  conversations,
+  id,
+  onFeedback,
+  latestAssistantMessageContent,
+  showActions,
+}: ConversationActionsProps): JSX.Element | null {
+  const initialFeedback = React.useMemo(() => {
+    const message = conversations.getOne?.(id);
+    return message?.feedback ?? null;
+  }, [conversations, id]);
+
+  const [feedback, setFeedback] = React.useState<'dislike' | 'like' | null>(initialFeedback);
+  const [saving, setSaving] = React.useState(false);
+  const [savingError, setSavingError] = React.useState<Error | null>(null);
+
+  const handleFeedback = async (value: 'dislike' | 'like'): Promise<void> => {
+    if (saving) return;
+    setSavingError(null);
+    setSaving(true);
+    try {
+      await onFeedback?.(id, value === 'like' ? 1 : 0);
+      setFeedback(value);
+    } catch (error) {
+      setSavingError(error as Error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const {
+    likeButtonTitle = 'Like',
+    dislikeButtonTitle = 'Dislike',
+    thanksForFeedbackText = 'Thanks for your feedback!',
+  } = translations;
+
+  if (!showActions || !latestAssistantMessageContent) {
+    return null;
+  }
+
+  return (
+    <div className="DocSearch-AskAiScreen-Actions">
+      <CopyButton
+        translations={translations}
+        onClick={() => navigator.clipboard.writeText(latestAssistantMessageContent)}
+      />
+      {feedback === null ? (
+        <>
+          {saving ? (
+            <LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />
+          ) : (
+            <>
+              <LikeButton title={likeButtonTitle} onClick={() => handleFeedback('like')} />
+              <DislikeButton title={dislikeButtonTitle} onClick={() => handleFeedback('dislike')} />
+            </>
+          )}
+          {savingError && (
+            <p className="DocSearch-AskAiScreen-FeedbackText">{savingError.message || 'An error occured'}</p>
+          )}
+        </>
+      ) : (
+        <p className="DocSearch-AskAiScreen-FeedbackText DocSearch-AskAiScreen-FeedbackText--visible">
+          {thanksForFeedbackText}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/docsearch-react/src/Sidepanel/ConversationHistoryScreen.tsx
+++ b/packages/docsearch-react/src/Sidepanel/ConversationHistoryScreen.tsx
@@ -26,38 +26,41 @@ export const ConversationHistoryScreen = ({
     <div className="DocSearch-Sidepanel-ConversationHistoryScreen">
       <ul>
         {items.map((item) => (
-          <li
-            role="button"
-            key={item.objectID}
-            className="DocSearch-Sidepanel-RecentConversation"
-            onClick={() => {
-              selectConversation(item);
-            }}
-          >
-            <div className="DocSearch-Sidepanel-RecentConversation-container">
-              <div className="DocSearch-Sidepanel-RecentConversation-icon">
-                <RecentIcon />
-              </div>
+          <li key={item.objectID} className="DocSearch-Sidepanel-RecentConversation">
+            <a
+              href={item.url}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
 
-              <div className="DocSearch-Sidepanel-RecentConversation-content">
-                <span className="DocSearch-Sidepanel-RecentConversation-title">{item.hierarchy.lvl1}</span>
-              </div>
+                selectConversation(item);
+              }}
+            >
+              <div className="DocSearch-Sidepanel-RecentConversation-container">
+                <div className="DocSearch-Sidepanel-RecentConversation-icon">
+                  <RecentIcon />
+                </div>
 
-              <div className="DocSearch-Hit-action">
-                <button
-                  className="DocSearch-Hit-action-button"
-                  type="button"
-                  title="Remove conversation from history"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    handleRemoveConversation(item);
-                  }}
-                >
-                  <CloseIcon />
-                </button>
+                <div className="DocSearch-Sidepanel-RecentConversation-content">
+                  <span className="DocSearch-Sidepanel-RecentConversation-title">{item.hierarchy.lvl1}</span>
+                </div>
+
+                <div className="DocSearch-Hit-action">
+                  <button
+                    className="DocSearch-Hit-action-button"
+                    type="button"
+                    title="Remove conversation from history"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleRemoveConversation(item);
+                    }}
+                  >
+                    <CloseIcon />
+                  </button>
+                </div>
               </div>
-            </div>
+            </a>
           </li>
         ))}
       </ul>

--- a/packages/docsearch-react/src/Sidepanel/ConversationScreen.tsx
+++ b/packages/docsearch-react/src/Sidepanel/ConversationScreen.tsx
@@ -2,7 +2,7 @@ import type { UseChatHelpers } from '@ai-sdk/react';
 import type { JSX } from 'react';
 import React, { memo, useMemo } from 'react';
 
-import { AskAiScreenFooterActions, AskAiSourcesPanel, type Exchange } from '../AskAiScreen';
+import { AskAiSourcesPanel, type Exchange } from '../AskAiScreen';
 import { AlertIcon, LoadingIcon, SearchIcon } from '../icons';
 import { MemoizedMarkdown } from '../MemoizedMarkdown';
 import type { StoredSearchPlugin } from '../stored-searches';
@@ -12,6 +12,7 @@ import { extractLinksFromMessage, getMessageContent } from '../utils/ai';
 import { groupConsecutiveToolResults } from '../utils/groupConsecutiveToolResults';
 
 import { AggregatedSearchBlock } from './AggregatedSearchBlock';
+import { ConversationActions } from './ConversationActions';
 
 export type ConversationScreenTranslations = Partial<{
   /**
@@ -234,7 +235,7 @@ const ConversationExchange = React.forwardRef<HTMLDivElement, ConversationnExcha
           </div>
 
           <div className="DocSearch-AskAiScreen-Answer-Footer">
-            <AskAiScreenFooterActions
+            <ConversationActions
               id={userMessage?.id || exchange.id}
               showActions={showActions}
               latestAssistantMessageContent={assistantContent?.text || null}

--- a/packages/docsearch-react/src/Sidepanel/Sidepanel.tsx
+++ b/packages/docsearch-react/src/Sidepanel/Sidepanel.tsx
@@ -325,6 +325,7 @@ export const Sidepanel = ({
           sidepanelState={sidepanelState}
           exchanges={exchanges}
           setSidepanelState={setSidepanelState}
+          hasConversations={conversations.getAll().length > 0}
           onNewConversation={handleStartNewConversation}
           onToggleExpanded={toggleIsExpanded}
           onClose={onClose}

--- a/packages/docsearch-react/src/Sidepanel/SidepanelHeader.tsx
+++ b/packages/docsearch-react/src/Sidepanel/SidepanelHeader.tsx
@@ -63,6 +63,7 @@ type SidepanelHeaderProps = {
   onToggleExpanded: () => void;
   onClose: () => void;
   translations?: HeaderTranslations;
+  hasConversations: boolean;
 };
 
 export const SidepanelHeader = React.memo(
@@ -74,6 +75,7 @@ export const SidepanelHeader = React.memo(
     onToggleExpanded,
     onClose,
     translations = {},
+    hasConversations,
   }: SidepanelHeaderProps): JSX.Element => {
     const {
       title = 'Ask AI',
@@ -95,6 +97,8 @@ export const SidepanelHeader = React.memo(
         setSidepanelState('new-conversation');
       }
     }, [exchanges, setSidepanelState]);
+
+    const newConversationDisabled = sidepanelState === 'new-conversation' && exchanges.length < 1;
 
     let header = title;
 
@@ -140,14 +144,18 @@ export const SidepanelHeader = React.memo(
                 <MoreVerticalIcon />
               </Menu.Trigger>
               <Menu.Content>
-                <Menu.Item onClick={onNewConversation}>
-                  <NewConversationIcon />
-                  {newConversationText}
-                </Menu.Item>
-                <Menu.Item onClick={goToConversationHistory}>
-                  <ConversationHistoryIcon />
-                  {viewConversationHistoryText}
-                </Menu.Item>
+                {!newConversationDisabled && (
+                  <Menu.Item onClick={onNewConversation}>
+                    <NewConversationIcon />
+                    {newConversationText}
+                  </Menu.Item>
+                )}
+                {hasConversations && (
+                  <Menu.Item onClick={goToConversationHistory}>
+                    <ConversationHistoryIcon />
+                    {viewConversationHistoryText}
+                  </Menu.Item>
+                )}
               </Menu.Content>
             </Menu>
           )}


### PR DESCRIPTION
## What

- "The description on the empty state doesn't fully expand to the edge of the panel. But once the questions/answers are logged, the text fills the whole panel space properly." Intro text now takes up full width.
- "Starting a new conversation should be disabled when you are in a empty new conversation" Removed new conversation option in this case.
- "When navigating using the keyboard, up and down vote actions are highlighted before the copy, which is not the order on screen. Can it go copy, up vote and down vote." Tab order now matches visual order.
- "Can’t select conversation history items using keyboard commands." Now allows for `tab` key navigation.