### PR TITLE
fix: call onClose when askAi is active

### DIFF
--- a/packages/docsearch-core/src/useDocSearchKeyboardEvents.ts
+++ b/packages/docsearch-core/src/useDocSearchKeyboardEvents.ts
@@ -34,6 +34,7 @@ export function useDocSearchKeyboardEvents({
     function onKeyDown(event: KeyboardEvent): void {
       if (isOpen && event.code === 'Escape' && isAskAiActive) {
         onAskAiToggle(false);
+        onClose();
         return;
       }
 

--- a/packages/docsearch-react/src/useDocSearchKeyboardEvents.ts
+++ b/packages/docsearch-react/src/useDocSearchKeyboardEvents.ts
@@ -37,6 +37,7 @@ export function useDocSearchKeyboardEvents({
     function onKeyDown(event: KeyboardEvent): void {
       if (isOpen && event.code === 'Escape' && isAskAiActive) {
         onAskAiToggle(false);
+        onClose();
         return;
       }
 


### PR DESCRIPTION
Calls `onClose` when closing the modal via `Escape` and `isAskAiActive` is true. This follows the behavior of an `Escape` keypress when `isAskAiActive` is false.

Fixes https://github.com/algolia/docsearch/issues/2809.

(this is a guess, I still need to figure out testing this)