### PR TITLE
fix(button): Fixes default button styling accessibility

### DIFF
--- a/examples/demo-react/src/App.css
+++ b/examples/demo-react/src/App.css
@@ -80,7 +80,8 @@ main {
 }
 
 /* search component wrapper */
-.search-wrapper {
+.search-wrapper,
+.default-wrapper {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -114,7 +115,7 @@ main {
 }
 
 /* docsearch button customization */
-.DocSearch-Button {
+.search-wrapper .DocSearch-Button {
   margin: 0 !important;
   background: #f7fafc !important;
   border: 2px solid #e2e8f0 !important;
@@ -125,13 +126,13 @@ main {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05) !important;
 }
 
-.DocSearch-Button:hover {
+.search-wrapper .DocSearch-Button:hover {
   border-color: #667eea !important;
   box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15) !important;
   transform: translateY(-1px) !important;
 }
 
-.DocSearch-Button-Placeholder {
+.search-wrapper .DocSearch-Button-Placeholder {
   color: #718096 !important;
 }
 

--- a/examples/demo-react/src/App.tsx
+++ b/examples/demo-react/src/App.tsx
@@ -8,6 +8,7 @@ import '@docsearch/css/dist/style.css';
 import Basic from './examples/basic';
 import BasicAskAI from './examples/basic-askai';
 import Composable from './examples/composable';
+import Default from './examples/default';
 import DynamicImportModal from './examples/dynamic-import-modal';
 import MultiIndex from './examples/multi-index';
 import WHitComponent from './examples/w-hit-component';
@@ -24,6 +25,13 @@ function App(): JSX.Element {
         </header>
 
         <main>
+          <section className="demo-section">
+            <p className="section-description">default</p>
+            <div className="default-wrapper">
+              <Default />
+            </div>
+          </section>
+
           <section className="demo-section">
             <p className="section-description">basic search functionality</p>
             <div className="search-wrapper">

--- a/examples/demo-react/src/examples/default.tsx
+++ b/examples/demo-react/src/examples/default.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+import { DocSearch } from '@docsearch/react';
+import type { JSX } from 'react';
+
+export default function DefaultExperience(): JSX.Element {
+  return <DocSearch indexName="docsearch" appId="PMZUYBQDAK" apiKey="24b09689d5b4223813d9b8e48563c8f6" />;
+}

--- a/packages/docsearch-css/src/_variables.css
+++ b/packages/docsearch-css/src/_variables.css
@@ -20,6 +20,10 @@
   --docsearch-logo-color: rgba(0, 61, 255, 1);
   --docsearch-border-radius: 4px;
 
+  /* button */
+  --docsearch-search-button-background: #fff;
+  --docsearch-search-button-text-color: var(--docsearch-secondary-text-color);
+
   /* modal */
   --docsearch-modal-width: 800px;
   --docsearch-modal-height: 600px;
@@ -111,4 +115,6 @@ html[data-theme='dark'] {
   );
   --docsearch-dropdown-menu-background: var(--docsearch-hit-background);
   --docsearch-dropdown-menu-item-hover-background: var(--docsearch-modal-background);
+  --docsearch-search-button-background: var(--docsearch-modal-background);
+  --docsearch-search-button-text-color: var(--docsearch-text-color);
 }

--- a/packages/docsearch-css/src/button.css
+++ b/packages/docsearch-css/src/button.css
@@ -2,8 +2,8 @@
   align-items: center;
   border: 1px solid var(--docsearch-subtle-color);
   border-radius: 4px;
-  background-color: var(--docsearch-searchbox-background);
-  color: var(--docsearch-muted-color);
+  background-color: var(--docsearch-search-button-background);
+  color: var(--docsearch-search-button-text-color);
   cursor: pointer;
   display: flex;
   all: unset;
@@ -20,7 +20,7 @@
 }
 
 .DocSearch-Button-Container svg {
-  color: var(--docsearch-muted-color);
+  color: currentColor;
 }
 
 .DocSearch-Search-Icon {
@@ -37,7 +37,7 @@
   font-size: 1rem;
   padding-block: 0;
   padding-inline: 8px 12px;
-  color: var(--docsearch-muted-color);
+  color: currentColor;
   display: inline-block;
   line-height: normal;
 }


### PR DESCRIPTION
## What
Fixes #2804 

Fixes some accessibility issues for default search button styling in light/dark mode.

## Previews

Light before
<img width="168" height="42" alt="light_before" src="https://github.com/user-attachments/assets/ef7e59c7-a440-42c7-b8ae-6f4383713aac" />

Light after
<img width="166" height="42" alt="light_after" src="https://github.com/user-attachments/assets/08fa06fd-14af-4cf6-9c28-4d8d85486c3f" />

Dark before
<img width="166" height="39" alt="dark_before" src="https://github.com/user-attachments/assets/a94f349a-e1d9-4551-914c-554f7627625b" />

Dark after
<img width="166" height="41" alt="dark_after" src="https://github.com/user-attachments/assets/640d096a-d825-4a29-8fc7-6440ea1a8e22" />
