### PR TITLE
fix: make @docsearch/core a real dependency.

### DIFF
--- a/packages/docsearch-modal/package.json
+++ b/packages/docsearch-modal/package.json
@@ -42,9 +42,11 @@
     "on:change": "yarn build",
     "watch": "nodemon --watch src --ext ts,tsx,js,jsx,json --ignore dist/ --ignore node_modules/ --verbose --delay 250ms --exec \"yarn on:change\""
   },
-  "devDependencies": {
+  "dependencies": {
     "@docsearch/core": "4.5.2",
-    "@docsearch/react": "4.5.2",
+    "@docsearch/react": "4.5.2"
+  },
+  "devDependencies": {
     "@rollup/plugin-replace": "6.0.2",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -53,12 +53,12 @@
     "watch": "nodemon --watch src --ext ts,tsx,js,jsx,json --ignore dist/ --ignore node_modules/ --verbose --delay 250ms --exec \"yarn on:change\""
   },
   "dependencies": {
+    "@docsearch/core": "4.5.2",
     "@docsearch/css": "4.5.2"
   },
   "devDependencies": {
     "@ai-sdk/react": "^2.0.30",
     "@algolia/autocomplete-core": "1.19.2",
-    "@docsearch/core": "4.5.2",
     "@rollup/plugin-replace": "6.0.2",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",

--- a/packages/docsearch-sidepanel/package.json
+++ b/packages/docsearch-sidepanel/package.json
@@ -48,11 +48,11 @@
     "watch": "nodemon --watch src --ext ts,tsx,js,jsx,json --ignore dist/ --ignore node_modules/ --verbose --delay 250ms --exec \"yarn on:change\""
   },
   "dependencies": {
-    "@docsearch/css": "4.5.2"
+    "@docsearch/core": "4.5.2",
+    "@docsearch/css": "4.5.2",
+    "@docsearch/react": "4.5.2"
   },
   "devDependencies": {
-    "@docsearch/core": "4.5.2",
-    "@docsearch/react": "4.5.2",
     "@rollup/plugin-replace": "6.0.2",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",


### PR DESCRIPTION
## Summary
- Move `@docsearch/core` (and `@docsearch/react` where needed) from `devDependencies` to `dependencies` in `@docsearch/react`, `@docsearch/modal`, and `@docsearch/sidepanel`
- Ensure runtime externals are correctly declared so consumers don’t need manual installs

## Test Plan
- `yarn lint`
- `yarn test:types`