### PR TITLE
fix: Missing result title would trigger an error

### DIFF
--- a/packages/docsearch-react/src/Results.tsx
+++ b/packages/docsearch-react/src/Results.tsx
@@ -13,7 +13,7 @@ export type ResultsTranslations = Partial<{
 }>;
 interface ResultsProps<TItem extends BaseItem>
   extends AutocompleteApi<TItem, React.FormEvent, React.MouseEvent, React.KeyboardEvent> {
-  title: string;
+  title?: string | null;
   translations?: ResultsTranslations;
   collection: AutocompleteState<TItem>['collections'][0];
   renderIcon: (props: { item: TItem; index: number }) => React.ReactNode;
@@ -25,7 +25,12 @@ interface ResultsProps<TItem extends BaseItem>
 
 export function Results<TItem extends StoredDocSearchHit>(props: ResultsProps<TItem>): JSX.Element | null {
   // The collection title, decoded to handle encoded HTML entities
+  // If there is not a title, return null to not render anything
   const decodedTitle = React.useMemo(() => {
+    if (!props.title) {
+      return null;
+    }
+
     return props.title
       .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')


### PR DESCRIPTION
https://github.com/algolia/docsearch/pull/2780/changes#r2713174214

There was an error occurring if a result did not have a title, this is due to us trying to decode encoded HTML entities.