### PR TITLE
chore(composable): add DocSearchButton + DocSearchModal example

### DIFF
--- a/packages/website/docs/examples.mdx
+++ b/packages/website/docs/examples.mdx
@@ -114,11 +114,14 @@ import '@docsearch/css/style.css';
   <DocSearchButton translations={{ buttonText: 'Composable search (demo)' }} />
   <DocSearchModal
     appId="PMZUYBQDAK"
-    apiKey="24b09689d5b4223813d9b8e48563c8f6"
     indexName="docsearch"
-    askAi={{ assistantId: 'askAIDemo' }}
+    apiKey="a00716d83c64f6c61905c078b7d5ab66"
+    askAi={{
+      assistantId: 'ccdec697-e3fe-465b-a1c3-657e7bf18aef',
+      agentStudio: true,
+    }}
   />
-</DocSearch>
+</DocSearch>;
 ```
 
 <BrowserOnly>
@@ -129,9 +132,12 @@ import '@docsearch/css/style.css';
       />
       <DocSearchModal
         appId="PMZUYBQDAK"
-        apiKey="24b09689d5b4223813d9b8e48563c8f6"
         indexName="docsearch"
-        askAi={{ assistantId: 'askAIDemo' }}
+        apiKey="a00716d83c64f6c61905c078b7d5ab66"
+        askAi={{
+          assistantId: 'ccdec697-e3fe-465b-a1c3-657e7bf18aef',
+          agentStudio: true,
+        }}
       />
     </DocSearchProvider>
   )}

--- a/packages/website/docs/examples.mdx
+++ b/packages/website/docs/examples.mdx
@@ -5,6 +5,8 @@ description: live demos showing how to use and extend docsearch beyond documenta
 ---
 
 import { DocSearch } from '@docsearch/react';
+import { DocSearch as DocSearchProvider } from '@docsearch/core';
+import { DocSearchButton, DocSearchModal } from '@docsearch/modal';
 import { DocSearchSidepanel } from '@docsearch/react/sidepanel';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import '@docsearch/css/dist/style.css';
@@ -93,6 +95,45 @@ The sidepanel provides a persistent chat interface anchored to the side of the p
       indexName="docsearch"
       assistantId="askAIDemo"
     />
+  )}
+</BrowserOnly>
+
+---
+
+## Composable API: DocSearchButton + DocSearchModal
+
+Use the [Composable API](/docs/composable-api) to render the button and modal as separate components. This gives you explicit control over where each piece is rendered and when the modal code is loaded.
+
+```jsx
+import { DocSearch } from '@docsearch/core';
+import { DocSearchButton, DocSearchModal } from '@docsearch/modal';
+
+import '@docsearch/css/style.css';
+
+<DocSearch>
+  <DocSearchButton translations={{ buttonText: 'Composable search (demo)' }} />
+  <DocSearchModal
+    appId="PMZUYBQDAK"
+    apiKey="24b09689d5b4223813d9b8e48563c8f6"
+    indexName="docsearch"
+    askAi={{ assistantId: 'askAIDemo' }}
+  />
+</DocSearch>
+```
+
+<BrowserOnly>
+  {() => (
+    <DocSearchProvider>
+      <DocSearchButton
+        translations={{ buttonText: 'Composable search (demo)' }}
+      />
+      <DocSearchModal
+        appId="PMZUYBQDAK"
+        apiKey="24b09689d5b4223813d9b8e48563c8f6"
+        indexName="docsearch"
+        askAi={{ assistantId: 'askAIDemo' }}
+      />
+    </DocSearchProvider>
   )}
 </BrowserOnly>
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -19,6 +19,7 @@
     "@docsearch/core": "workspace:*",
     "@docsearch/css": "workspace:*",
     "@docsearch/docusaurus-adapter": "workspace:*",
+    "@docsearch/modal": "workspace:*",
     "@docsearch/react": "workspace:*",
     "@docsearch/sidepanel": "workspace:*",
     "@docusaurus/core": "3.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,6 +2669,7 @@ __metadata:
     "@docsearch/core": "workspace:*"
     "@docsearch/css": "workspace:*"
     "@docsearch/docusaurus-adapter": "workspace:*"
+    "@docsearch/modal": "workspace:*"
     "@docsearch/react": "workspace:*"
     "@docsearch/sidepanel": "workspace:*"
     "@docusaurus/core": "npm:3.9.2"


### PR DESCRIPTION
## Summary

- Since we're adding it in Agent Studio (Implementation tab), let's add it here too. 

<img width="1324" height="685" alt="Screenshot 2026-03-26 at 18 13 43" src="https://github.com/user-attachments/assets/596ac06b-756a-448b-9b30-3db042ef7229" />
