### PR TITLE
feat(askai): Ask AI deprecation warning

### DIFF
--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -130,6 +130,8 @@ export interface DocSearchProps {
   indices?: Array<DocSearchIndex | string>;
   /**
    * Configuration or assistant id to enable ask ai mode. Pass a string assistant id or a full config object.
+   *
+   * @deprecated Ask AI is being migrated from a standalone DocSearch feature into Algolia's Agent Studio. The `askAi` prop will be removed in DocSearch v5.
    */
   askAi?: DocSearchAskAi | string;
   /**

--- a/packages/website/docs/sidepanel/advanced-use-cases.mdx
+++ b/packages/website/docs/sidepanel/advanced-use-cases.mdx
@@ -4,6 +4,9 @@ title: Advanced use cases
 
 import Tabs from  '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
 
 ## Introduction
 

--- a/packages/website/docs/sidepanel/api-reference.mdx
+++ b/packages/website/docs/sidepanel/api-reference.mdx
@@ -4,6 +4,9 @@ title: Sidepanel API Reference
 
 import Tabs from  '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
 
 ## `appId`
 

--- a/packages/website/docs/sidepanel/getting-started.mdx
+++ b/packages/website/docs/sidepanel/getting-started.mdx
@@ -4,6 +4,9 @@ title: Get started with Sidepanel
 
 import Tabs from  '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
 
 :::info
 Sidepanel is available from version `>= 4.4`

--- a/packages/website/docs/sidepanel/hybrid.mdx
+++ b/packages/website/docs/sidepanel/hybrid.mdx
@@ -4,6 +4,9 @@ title: Hybrid Mode
 
 import Tabs from  '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
 
 :::info
 Currently Hybrid Mode is only available when using the React usage approach. Hybrid Mode is not available in the JavaScript-only (vanilla) integration.

--- a/packages/website/docs/v4/askai-api.mdx
+++ b/packages/website/docs/v4/askai-api.mdx
@@ -2,6 +2,10 @@
 title: Ask AI API Reference
 ---
 
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
+
 The Ask AI API enables developers to build custom chat interfaces powered by Algolia's AI assistant. Use these endpoints to create tailored conversational experiences that search your Algolia index and generate contextual responses using your own LLM provider.
 
 :::info

--- a/packages/website/docs/v4/askai-errors.mdx
+++ b/packages/website/docs/v4/askai-errors.mdx
@@ -2,6 +2,10 @@
 title: Ask AI Errors Reference
 ---
 
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
+
 These error codes correspond to issues encountered when using Ask AI. Each code includes a short description and possible resolutions.
 
 ## General API errors

--- a/packages/website/docs/v4/askai-markdown-indexing.mdx
+++ b/packages/website/docs/v4/askai-markdown-indexing.mdx
@@ -2,6 +2,10 @@
 title: Improving Answer Quality with Markdown Indexing
 ---
 
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
+
 To deliver more accurate, context-rich answers at scale, Ask AI benefits from cleanly structured content. One of the most effective ways to achieve this is by using a Markdown-based indexing helper in your Algolia Crawler configuration. This setup ensures Ask AI can access well-formed, content-focused records—especially important for larger documentation sites where metadata, navigation elements, or layout artifacts might otherwise dilute the quality of generative responses.
 
 :::info
@@ -39,7 +43,7 @@ The easiest way to set up markdown indexing is through the Crawler UI, which aut
    - **Content Tag**: Specify the HTML content selector (typically `main`)
    - **Template**: Choose the template that matches your documentation framework:
      - **Docusaurus** - For Docusaurus sites
-     - **VitePress** - For VitePress sites  
+     - **VitePress** - For VitePress sites
      - **Astro/Starlight** - For Astro/Starlight sites
      - **Non-DocSearch (Generic)** - For custom sites or other frameworks
 
@@ -245,7 +249,7 @@ class CustomAskAI {
 
   async sendMessage(conversationId, messages, searchParameters = {}) {
     const token = await this.getToken();
-    
+
     const response = await fetch(`${this.baseUrl}/chat`, {
       method: 'POST',
       headers: {
@@ -270,14 +274,14 @@ class CustomAskAI {
     // Handle streaming response
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
-    
+
     return {
       async *[Symbol.asyncIterator]() {
         try {
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
-            
+
             const chunk = decoder.decode(value, { stream: true });
             if (chunk.trim()) {
               yield chunk;

--- a/packages/website/docs/v4/askai-models.mdx
+++ b/packages/website/docs/v4/askai-models.mdx
@@ -2,7 +2,10 @@
 title: Bring Your Own LLM
 ---
 
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
 import { ProvidersTable } from '../../src/components/ProvidersTable'
+
+<AskAIDeprecationNotice />
 
 Ask AI currently supports a Bring Your Own LLM (BYOLLM) model selection, allowing you to connect your preferred provider.
 

--- a/packages/website/docs/v4/askai-prompts.mdx
+++ b/packages/website/docs/v4/askai-prompts.mdx
@@ -2,6 +2,10 @@
 title: Prompting
 ---
 
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
+
 Master the art of prompting to get the best results from Ask AI. This guide covers how prompts work in DocSearch v4, shares proven techniques from leading AI providers, and provides practical examples to help you create effective, on-brand AI responses for your documentation.
 
 **What you'll learn:**

--- a/packages/website/docs/v4/askai-whitelisted-domains.mdx
+++ b/packages/website/docs/v4/askai-whitelisted-domains.mdx
@@ -2,6 +2,10 @@
 title: Whitelisted domains
 ---
 
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
+
 DocSearch Ask AI can only run on domains or domain patterns explicitly allowed (whitelisted). Domains not listed here will not be permitted to use Ask AI, ensuring security and preventing unauthorized use. You can manage this list at any time.
 
 Use wildcards (`*`) to easily match multiple subdomains, for example:

--- a/packages/website/docs/v4/askai.mdx
+++ b/packages/website/docs/v4/askai.mdx
@@ -3,6 +3,9 @@ title: Get started with Ask AI
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import AskAIDeprecationNotice from '../../src/components/mdx/ask-ai-deprecation-notice.jsx'
+
+<AskAIDeprecationNotice />
 
 ## Overview
 

--- a/packages/website/src/components/mdx/ask-ai-deprecation-notice.jsx
+++ b/packages/website/src/components/mdx/ask-ai-deprecation-notice.jsx
@@ -1,0 +1,15 @@
+import Admonition from '@theme/Admonition';
+import React from 'react';
+
+export default function AskAIDeprecationNotice() {
+  return (
+    <Admonition type="warning">
+      Ask AI is being migrated from a standalone DocSearch feature into Algolia's{' '}
+      <a href="https://www.algolia.com/doc/guides/algolia-ai/agent-studio" target="_blank" rel="noreferrer">
+        Agent Studio
+      </a>
+      . DocSearch v5 will fully support Agent Studio and transition to using it. A more detailed migration guide will be
+      published before the DocSearch v5 release.
+    </Admonition>
+  );
+}


### PR DESCRIPTION
Ask AI as a DocSearch product is being migrated to Agent Studio. This just adds a deprecation message to Ask AI related docs pages for the upcoming changes.

<img width="1039" height="488" alt="Screenshot 2026-05-18 at 2 50 55 PM" src="https://github.com/user-attachments/assets/fff9fb10-f156-4068-849e-11adbb66d225" />
