### PR TITLE
feat(askai): Agent Studio core tools

### DIFF
--- a/examples/demo-react/src/examples/agent-studio-sidepanel.tsx
+++ b/examples/demo-react/src/examples/agent-studio-sidepanel.tsx
@@ -19,6 +19,22 @@ export default function AgentStudioSidepanel(): JSX.Element {
         apiKey="a00716d83c64f6c61905c078b7d5ab66"
         assistantId="ccdec697-e3fe-465b-a1c3-657e7bf18aef"
         agentStudio={true}
+        tools={{
+          printConsoleMessage: {
+            render({ message: { output } }) {
+              if (!output) return '';
+
+              return output as string;
+            },
+            async onToolCall({ input, addToolOutput }) {
+              console.log(input.message);
+
+              await addToolOutput({
+                output: 'Check your console for a nice message :)',
+              });
+            },
+          },
+        }}
       />
     </DocSearch>
   );

--- a/examples/demo-react/src/examples/agent-studio-sidepanel.tsx
+++ b/examples/demo-react/src/examples/agent-studio-sidepanel.tsx
@@ -27,7 +27,8 @@ export default function AgentStudioSidepanel(): JSX.Element {
               return output as string;
             },
             async onToolCall({ input, addToolOutput }) {
-              console.log(input.message);
+              // eslint-disable-next-line no-console
+              console.log((input as any).message);
 
               await addToolOutput({
                 output: 'Check your console for a nice message :)',

--- a/examples/demo-react/src/examples/agent-studio.tsx
+++ b/examples/demo-react/src/examples/agent-studio.tsx
@@ -27,7 +27,8 @@ export default function AgentStudio(): JSX.Element {
               return output as string;
             },
             async onToolCall({ input, addToolOutput }) {
-              console.log(input.message);
+              // eslint-disable-next-line no-console
+              console.log((input as any).message);
 
               await addToolOutput({
                 output: 'Check your console for a nice message :)',

--- a/examples/demo-react/src/examples/agent-studio.tsx
+++ b/examples/demo-react/src/examples/agent-studio.tsx
@@ -19,6 +19,22 @@ export default function AgentStudio(): JSX.Element {
           assistantId: 'ccdec697-e3fe-465b-a1c3-657e7bf18aef',
           agentStudio: true,
         }}
+        tools={{
+          printConsoleMessage: {
+            render({ message: { output } }) {
+              if (!output) return '';
+
+              return output as string;
+            },
+            async onToolCall({ input, addToolOutput }) {
+              console.log(input.message);
+
+              await addToolOutput({
+                output: 'Check your console for a nice message :)',
+              });
+            },
+          },
+        }}
       />
     </DocSearch>
   );

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -3,10 +3,10 @@ import React, { type JSX, useMemo, useState, useEffect } from 'react';
 
 import { AggregatedSearchBlock } from './AggregatedSearchBlock';
 import type { AskAiScreenStateProps } from './AskAiScreenState';
+import { ToolCall } from './components/ui/ToolCall';
 import { AlertIcon, LoadingIcon } from './icons';
 import { MemoizedMarkdown } from './MemoizedMarkdown';
 import type { StoredSearchPlugin } from './stored-searches';
-import { ToolCall } from './ToolCall';
 import type { InternalDocSearchHit, StoredAskAiState } from './types';
 import { type AIMessage, type ToolCalls } from './types/AskiAi';
 import { extractLinksFromMessage, getMessageContent, isThreadDepthError, isAIToolPart } from './utils/ai';

--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -8,8 +8,8 @@ import { MemoizedMarkdown } from './MemoizedMarkdown';
 import type { StoredSearchPlugin } from './stored-searches';
 import { ToolCall } from './ToolCall';
 import type { InternalDocSearchHit, StoredAskAiState } from './types';
-import type { AIMessage } from './types/AskiAi';
-import { extractLinksFromMessage, getMessageContent, isThreadDepthError } from './utils/ai';
+import { type AIMessage, type ToolCalls } from './types/AskiAi';
+import { extractLinksFromMessage, getMessageContent, isThreadDepthError, isAIToolPart } from './utils/ai';
 import { groupConsecutiveToolResults } from './utils/groupConsecutiveToolResults';
 
 export type AskAiScreenTranslations = Partial<{
@@ -65,6 +65,7 @@ export type AskAiScreenTranslations = Partial<{
 
 type AskAiScreenProps = Omit<AskAiScreenStateProps<InternalDocSearchHit>, 'translations'> & {
   messages: AIMessage[];
+  tools: ToolCalls;
   status: UseChatHelpers<AIMessage>['status'];
   askAiError?: Error;
   translations?: AskAiScreenTranslations;
@@ -93,6 +94,7 @@ interface AskAiExchangeCardProps {
   loadingStatus: UseChatHelpers<AIMessage>['status'];
   onSearchQueryClick: (query: string) => void;
   translations: AskAiScreenTranslations;
+  tools: ToolCalls;
   conversations: StoredSearchPlugin<StoredAskAiState>;
   onFeedback?: (messageId: string, thumbs: 0 | 1) => Promise<void>;
   agentStudio?: boolean;
@@ -105,6 +107,7 @@ function AskAiExchangeCard({
   loadingStatus,
   onSearchQueryClick,
   translations,
+  tools,
   conversations,
   onFeedback,
   agentStudio,
@@ -184,6 +187,22 @@ function AskAiExchangeCard({
                 );
               }
 
+              if (isAIToolPart(part)) {
+                return (
+                  <ToolCall
+                    key={index}
+                    translations={{
+                      preToolCallText,
+                      searchingText: duringToolCallText,
+                      toolCallResultText: afterToolCallText,
+                    }}
+                    part={part}
+                    tools={tools}
+                    onSearchQueryClick={onSearchQueryClick}
+                  />
+                );
+              }
+
               if (part.type === 'aggregated-tool-call') {
                 return (
                   <AggregatedSearchBlock
@@ -215,20 +234,7 @@ function AskAiExchangeCard({
                   />
                 );
               }
-              if (part.type === 'tool-searchIndex' || part.type === 'tool-algolia_search_index') {
-                return (
-                  <ToolCall
-                    key={index}
-                    translations={{
-                      preToolCallText,
-                      searchingText: duringToolCallText,
-                      toolCallResultText: afterToolCallText,
-                    }}
-                    part={part}
-                    onSearchQueryClick={onSearchQueryClick}
-                  />
-                );
-              }
+
               // fallback for unknown part type
               return null;
             })}
@@ -371,7 +377,7 @@ export function AskAiScreen({ translations = {}, ...props }: AskAiScreenProps): 
     startNewConversationButtonText = 'Start a new conversation',
   } = translations;
 
-  const { messages, askAiError, status, agentStudio } = props;
+  const { messages, tools, askAiError, status, agentStudio } = props;
 
   // Check if there's a thread depth error
   const hasThreadDepthError = useMemo(() => {
@@ -445,6 +451,7 @@ export function AskAiScreen({ translations = {}, ...props }: AskAiScreenProps): 
                 isLastExchange={index === 0}
                 loadingStatus={props.status}
                 translations={translations}
+                tools={tools}
                 conversations={props.conversations}
                 agentStudio={agentStudio}
                 onSearchQueryClick={handleSearchQueryClick}

--- a/packages/docsearch-react/src/AskAiScreenState.tsx
+++ b/packages/docsearch-react/src/AskAiScreenState.tsx
@@ -18,7 +18,7 @@ import type { ResultsScreenTranslations } from './ResultsScreen';
 import { ResultsScreen } from './ResultsScreen';
 import type { StoredSearchPlugin } from './stored-searches';
 import type { InternalDocSearchHit, StoredAskAiState, StoredDocSearchHit, SuggestedQuestionHit } from './types';
-import type { AIMessage, AskAiState } from './types/AskiAi';
+import type { AIMessage, AskAiState, ToolCalls } from './types/AskiAi';
 
 export type AskAiScreenStateTranslations = Partial<{
   errorScreen: ErrorScreenTranslations;
@@ -43,6 +43,7 @@ export interface AskAiScreenStateProps<TItem extends BaseItem>
   hitComponent: DocSearchProps['hitComponent'];
   indexName: DocSearchProps['indexName'];
   messages: UseChatHelpers<AIMessage>['messages'];
+  tools: ToolCalls;
   status: UseChatHelpers<AIMessage>['status'];
   askAiError?: Error;
   disableUserPersonalization: boolean;
@@ -80,6 +81,7 @@ export const AskAiScreenState = React.memo(
         <AskAiScreen
           {...props}
           messages={props.messages}
+          tools={props.tools}
           status={props.status}
           askAiError={props.askAiError}
           translations={translations?.askAiScreen}

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -10,6 +10,7 @@ import type { ButtonTranslations } from './DocSearchButton';
 import { DocSearchModal } from './DocSearchModal';
 import type { ModalTranslations } from './DocSearchModal';
 import type { DocSearchHit, DocSearchTheme, InternalDocSearchHit, StoredDocSearchHit } from './types';
+import type { ToolCalls } from './types/AskiAi';
 
 export type { DocSearchRef } from '@docsearch/core';
 
@@ -245,6 +246,14 @@ export interface DocSearchAIProps extends DocSearchProps {
    * Useful to route Ask AI into a different UI (e.g. `@docsearch/sidepanel-js`) without flicker.
    */
   interceptAskAiEvent?: (initialMessage: InitialAskAiMessage) => boolean | void;
+  /**
+   * Use custom tools driven by Agent Studio.
+   *
+   * For best performance, memoize this object with `useMemo` or define it
+   * outside the component. Inline object literals will be recreated every
+   * render but will not affect correctness.
+   **/
+  tools?: ToolCalls;
 }
 
 function DocSearchComponent(props: DocSearchProps, ref: React.ForwardedRef<DocSearchRef>): JSX.Element {

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -21,12 +21,12 @@ import { useSaveRecentSearch } from './hooks/useSaveRecentSearch';
 import { useStoredDocSearches } from './hooks/useStoredDocSearches';
 import type { NewConversationTranslations } from './NewConversationScreen';
 import type { DocSearchState, InternalDocSearchHit, StoredAskAiMessage, SuggestedQuestionHit } from './types';
-import type { AskAiState } from './types/AskiAi';
+import { type AskAiState } from './types/AskiAi';
 import { useAskAi } from './useAskAi';
 import { useSearchClient } from './useSearchClient';
 import { useSuggestedQuestions } from './useSuggestedQuestions';
 import { identity, isModifierEvent, noop, scrollTo as scrollToUtils } from './utils';
-import { buildDummyAskAiHit, isThreadDepthError } from './utils/ai';
+import { buildDummyAskAiHit, isThreadDepthError, EMPTY_TOOLS } from './utils/ai';
 import { buildAskAiActionSources, buildRecentConversationSources } from './utils/createAskAiSources';
 import { buildNoQuerySources, buildQuerySources, type BuildQuerySourcesState } from './utils/createDocSearchSources';
 import { normalizeDocSearchIndexes } from './utils/normalizeDocSearchIndexes';
@@ -74,6 +74,7 @@ export function DocSearchAskAiModal({
   indexName,
   searchParameters,
   isHybridModeSupported = false,
+  tools = EMPTY_TOOLS,
   ...props
 }: DocSearchAskAiModalProps): JSX.Element {
   const { footer: footerTranslations, searchBox: searchBoxTranslations, ...screenStateTranslations } = translations;
@@ -141,6 +142,7 @@ export function DocSearchAskAiModal({
       searchParameters: askAiSearchParameters,
       useStagingEnv: askAiUseStagingEnv,
       agentStudio,
+      tools,
     });
 
   const prevStatus = React.useRef(status);
@@ -453,6 +455,7 @@ export function DocSearchAskAiModal({
           isAskAiActive={isAskAiActive}
           canHandleAskAi={canHandleAskAi}
           messages={messages}
+          tools={tools}
           askAiError={askAiError}
           status={status}
           hasCollections={hasCollections}

--- a/packages/docsearch-react/src/Sidepanel.tsx
+++ b/packages/docsearch-react/src/Sidepanel.tsx
@@ -7,6 +7,7 @@ import { createPortal } from 'react-dom';
 import type { AgentStudioSearchParameters, AskAiSearchParameters } from './DocSearch';
 import type { SidepanelButtonProps, SidepanelProps as SidepanelPanelProps } from './Sidepanel/index';
 import { SidepanelButton, Sidepanel } from './Sidepanel/index';
+import type { ToolCalls } from './types/AskiAi';
 
 export type { DocSearchRef, DocSearchCallbacks } from '@docsearch/core';
 
@@ -84,6 +85,14 @@ export type DocSearchSidepanelProps = DocSearchCallbacks & {
    * Props specific to the Sidepanel panel.
    */
   panel?: Omit<SidepanelPanelProps, 'keyboardShortcuts'>;
+  /**
+   * Use custom tools driven by Agent Studio.
+   *
+   * For best performance, memoize this object with `useMemo` or define it
+   * outside the component. Inline object literals will be recreated every
+   * render but will not affect correctness.
+   **/
+  tools?: ToolCalls;
 };
 
 type SidepanelProps = DocSearchSidepanelProps & SidepanelSearchParameters;

--- a/packages/docsearch-react/src/Sidepanel/ConversationScreen.tsx
+++ b/packages/docsearch-react/src/Sidepanel/ConversationScreen.tsx
@@ -3,10 +3,10 @@ import type { JSX } from 'react';
 import React, { memo, useMemo } from 'react';
 
 import { AskAiSourcesPanel, type Exchange } from '../AskAiScreen';
+import { ToolCall, type ToolCallTranslations } from '../components/ui/ToolCall';
 import { AlertIcon, LoadingIcon } from '../icons';
 import { MemoizedMarkdown } from '../MemoizedMarkdown';
 import type { StoredSearchPlugin } from '../stored-searches';
-import { ToolCall, type ToolCallTranslations } from '../ToolCall';
 import type { StoredAskAiState } from '../types';
 import { type AIMessage, type ToolCalls } from '../types/AskiAi';
 import { extractLinksFromMessage, getMessageContent, EMPTY_TOOLS, isAIToolPart } from '../utils/ai';

--- a/packages/docsearch-react/src/Sidepanel/ConversationScreen.tsx
+++ b/packages/docsearch-react/src/Sidepanel/ConversationScreen.tsx
@@ -8,8 +8,8 @@ import { MemoizedMarkdown } from '../MemoizedMarkdown';
 import type { StoredSearchPlugin } from '../stored-searches';
 import { ToolCall, type ToolCallTranslations } from '../ToolCall';
 import type { StoredAskAiState } from '../types';
-import { isAIToolPart, type AIMessage } from '../types/AskiAi';
-import { extractLinksFromMessage, getMessageContent } from '../utils/ai';
+import { type AIMessage, type ToolCalls } from '../types/AskiAi';
+import { extractLinksFromMessage, getMessageContent, EMPTY_TOOLS, isAIToolPart } from '../utils/ai';
 import { groupConsecutiveToolResults } from '../utils/groupConsecutiveToolResults';
 
 import { AggregatedSearchBlock } from './AggregatedSearchBlock';
@@ -72,6 +72,7 @@ export type ConversationScreenProps = {
   handleFeedback?: (messageId: string, thumbs: 0 | 1) => Promise<void>;
   streamError?: Error;
   agentStudio?: boolean;
+  tools?: ToolCalls;
 };
 
 type ConversationnExchangeProps = {
@@ -83,11 +84,12 @@ type ConversationnExchangeProps = {
   onFeedback?: ConversationScreenProps['handleFeedback'];
   streamError?: ConversationScreenProps['streamError'];
   agentStudio?: boolean;
+  tools: ToolCalls;
 };
 
 const ConversationExchange = React.forwardRef<HTMLDivElement, ConversationnExchangeProps>(
   (
-    { exchange, translations = {}, isLastExchange, conversations, onFeedback, status, streamError, agentStudio },
+    { exchange, translations = {}, isLastExchange, conversations, onFeedback, status, streamError, agentStudio, tools },
     conversationRef,
   ): JSX.Element => {
     const { userMessage, assistantMessage } = exchange;
@@ -171,6 +173,7 @@ const ConversationExchange = React.forwardRef<HTMLDivElement, ConversationnExcha
                         searchingText,
                         toolCallResultText,
                       }}
+                      tools={tools}
                     />
                   );
                 }
@@ -233,7 +236,13 @@ const ConversationExchange = React.forwardRef<HTMLDivElement, ConversationnExcha
 );
 
 export const ConversationScreen = memo(
-  ({ exchanges, translations = {}, handleFeedback, ...props }: ConversationScreenProps): JSX.Element => {
+  ({
+    exchanges,
+    translations = {},
+    handleFeedback,
+    tools = EMPTY_TOOLS,
+    ...props
+  }: ConversationScreenProps): JSX.Element => {
     const { conversationDisclaimer = 'Answers are generated with AI which can make mistakes. Verify responses.' } =
       translations;
 
@@ -263,6 +272,7 @@ export const ConversationScreen = memo(
               translations={translations}
               isLastExchange={isLastExchange}
               ref={isLastExchange ? mostRecentExchangeRef : null}
+              tools={tools}
               onFeedback={handleFeedback}
               {...props}
             />

--- a/packages/docsearch-react/src/Sidepanel/Sidepanel.tsx
+++ b/packages/docsearch-react/src/Sidepanel/Sidepanel.tsx
@@ -9,7 +9,7 @@ import { useAskAi } from '../useAskAi';
 import { useIsMobile } from '../useIsMobile';
 import { useSearchClient } from '../useSearchClient';
 import { useSuggestedQuestions } from '../useSuggestedQuestions';
-import { buildDummyAskAiHit } from '../utils/ai';
+import { EMPTY_TOOLS, buildDummyAskAiHit } from '../utils/ai';
 
 import { ConversationHistoryScreen } from './ConversationHistoryScreen';
 import type { ConversationScreenTranslations } from './ConversationScreen';
@@ -152,6 +152,7 @@ function SidepanelInner(
     initialMessage,
     useStagingEnv = false,
     agentStudio = false,
+    tools = EMPTY_TOOLS,
   }: Props,
   ref: React.ForwardedRef<SidepanelRef>,
 ): JSX.Element {
@@ -195,6 +196,7 @@ function SidepanelInner(
     searchParameters,
     useStagingEnv,
     agentStudio,
+    tools,
   });
 
   const suggestedQuestions = useSuggestedQuestions({
@@ -398,6 +400,7 @@ function SidepanelInner(
               translations={translations.conversationScreen}
               streamError={askAiError}
               agentStudio={agentStudio}
+              tools={tools}
             />
           )}
           {sidepanelState === 'conversation-history' && (

--- a/packages/docsearch-react/src/ToolCall.tsx
+++ b/packages/docsearch-react/src/ToolCall.tsx
@@ -1,8 +1,8 @@
 import type { JSX } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 
-import { LoadingIcon, SearchIcon } from './icons';
-import type { AIToolPart } from './types/AskiAi';
+import { LoadingIcon, SearchIcon, ToolIcon } from './icons';
+import type { AIToolPart, SearchToolPart, ToolCalls, ToolDefinition } from './types/AskiAi';
 
 export type ToolCallTranslations = {
   /**
@@ -22,36 +22,66 @@ export type ToolCallTranslations = {
 interface ToolCallProps {
   part: AIToolPart;
   translations: ToolCallTranslations;
+  tools: ToolCalls;
   onSearchQueryClick?: (query: string) => void;
 }
 
-export function ToolCall({ part, translations, onSearchQueryClick }: ToolCallProps): JSX.Element | null {
+interface ToolStateProps {
+  variant: 'Call' | 'PartialCall' | 'Result';
+  icon: React.ReactNode;
+  shimmer?: boolean;
+  children: React.ReactNode;
+}
+
+function ToolState({ icon, shimmer = false, children, variant }: ToolStateProps) {
+  const className = `DocSearch-AskAiScreen-MessageContent-Tool Tool--${variant}${shimmer ? ' shimmer' : ''}`;
+
+  return (
+    <div className={className}>
+      {icon}
+      {children}
+    </div>
+  );
+}
+
+interface SearchToolProps {
+  part: SearchToolPart;
+  translations: ToolCallTranslations;
+  onSearchQueryClick?: (query: string) => void;
+}
+
+function SearchTool({ part, translations, onSearchQueryClick }: SearchToolProps) {
   const { searchingText, preToolCallText, toolCallResultText } = translations;
 
   switch (part.state) {
     case 'input-streaming':
       return (
-        <div className="DocSearch-AskAiScreen-MessageContent-Tool Tool--PartialCall shimmer">
-          <LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />
+        <ToolState
+          shimmer={true}
+          icon={<LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />}
+          variant="PartialCall"
+        >
           <span>{searchingText}</span>
-        </div>
+        </ToolState>
       );
     case 'input-available':
       return (
-        <div className="DocSearch-AskAiScreen-MessageContent-Tool Tool--Call shimmer">
-          <LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />
+        <ToolState
+          shimmer={true}
+          icon={<LoadingIcon className="DocSearch-AskAiScreen-SmallerLoadingIcon" />}
+          variant="Call"
+        >
           <span>
             {preToolCallText} {`"${part.input.query || ''}" ...`}
           </span>
-        </div>
+        </ToolState>
       );
     case 'output-available': {
       const query = part.type === 'tool-searchIndex' ? part.output.query : part.input.query;
       const numberOfHits = part.output.hits?.length ?? 0;
 
       return (
-        <div className="DocSearch-AskAiScreen-MessageContent-Tool Tool--Result">
-          <SearchIcon />
+        <ToolState icon={<SearchIcon />} variant="Result">
           <span>
             {toolCallResultText}{' '}
             {onSearchQueryClick ? (
@@ -75,10 +105,64 @@ export function ToolCall({ part, translations, onSearchQueryClick }: ToolCallPro
             )}{' '}
             found {numberOfHits} results
           </span>
-        </div>
+        </ToolState>
       );
     }
     default:
       return null;
   }
+}
+
+interface DynamicToolProps {
+  tool: ToolDefinition;
+  part: AIToolPart;
+}
+
+function DynamicTool({ tool, part }: DynamicToolProps) {
+  const toolOutput = useMemo(() => {
+    if (part.state !== 'output-available') return null;
+
+    return tool.render({ message: { input: part.input, output: part.output } });
+  }, [part.input, part.output, tool, part.state]);
+
+  if (part.state === 'output-error') {
+    return null;
+  }
+
+  if (part.state !== 'output-available') {
+    const { callingToolText = 'Loading tool' } = tool.translations || {};
+
+    return (
+      <ToolState shimmer={true} variant="PartialCall" icon={<ToolIcon />}>
+        <span>{callingToolText}</span>
+      </ToolState>
+    );
+  }
+
+  if (!toolOutput) return null;
+
+  return (
+    <ToolState icon={<ToolIcon />} variant="Result">
+      <span>{toolOutput}</span>
+    </ToolState>
+  );
+}
+
+function isSearchToolPart(part: AIToolPart): part is SearchToolPart {
+  return part.type === 'tool-searchIndex' || part.type.startsWith('tool-algolia_search_index');
+}
+
+export function ToolCall({ part, translations, tools, onSearchQueryClick }: ToolCallProps): JSX.Element | null {
+  const normalizedToolName = part.type.replace('tool-', '');
+  const dynamicTool = tools[normalizedToolName];
+
+  if (dynamicTool) {
+    return <DynamicTool tool={dynamicTool} part={part} />;
+  }
+
+  if (!isSearchToolPart(part)) {
+    return null;
+  }
+
+  return <SearchTool part={part} translations={translations} onSearchQueryClick={onSearchQueryClick} />;
 }

--- a/packages/docsearch-react/src/__tests__/ToolCall.test.tsx
+++ b/packages/docsearch-react/src/__tests__/ToolCall.test.tsx
@@ -62,7 +62,7 @@ describe('ToolCall', () => {
     ] satisfies Array<{ description: string; part: AIToolPart; expectedHits: number }>)(
       'displays $expectedHits results for $description',
       ({ part, expectedHits }) => {
-        render(<ToolCall part={part} translations={TRANSLATIONS} />);
+        render(<ToolCall part={part} translations={TRANSLATIONS} tools={{}} />);
 
         expect(screen.getByText(`found ${expectedHits} results`, { exact: false })).toBeInTheDocument();
       },

--- a/packages/docsearch-react/src/__tests__/ToolCall.test.tsx
+++ b/packages/docsearch-react/src/__tests__/ToolCall.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 
-import { ToolCall, type ToolCallTranslations } from '../ToolCall';
+import { ToolCall, type ToolCallTranslations } from '../components/ui/ToolCall';
 import type { AIToolPart } from '../types/AskiAi';
 
 const TRANSLATIONS: ToolCallTranslations = {
@@ -43,7 +43,12 @@ describe('ToolCall', () => {
           type: 'tool-algolia_search_index',
           toolCallId: 'id-3',
           state: 'output-available',
-          input: { index: 'docs', query: 'test', number_of_results: 10, facet_filters: null },
+          input: {
+            index: 'docs',
+            query: 'test',
+            number_of_results: 10,
+            facet_filters: null,
+          },
           output: { hits: [{}, {}] },
         },
         expectedHits: 2,
@@ -59,13 +64,14 @@ describe('ToolCall', () => {
         },
         expectedHits: 1,
       },
-    ] satisfies Array<{ description: string; part: AIToolPart; expectedHits: number }>)(
-      'displays $expectedHits results for $description',
-      ({ part, expectedHits }) => {
-        render(<ToolCall part={part} translations={TRANSLATIONS} tools={{}} />);
+    ] satisfies Array<{
+      description: string;
+      part: AIToolPart;
+      expectedHits: number;
+    }>)('displays $expectedHits results for $description', ({ part, expectedHits }) => {
+      render(<ToolCall part={part} translations={TRANSLATIONS} tools={{}} />);
 
-        expect(screen.getByText(`found ${expectedHits} results`, { exact: false })).toBeInTheDocument();
-      },
-    );
+      expect(screen.getByText(`found ${expectedHits} results`, { exact: false })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/docsearch-react/src/__tests__/ToolCall.test.tsx
+++ b/packages/docsearch-react/src/__tests__/ToolCall.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { ToolCall, type ToolCallTranslations } from '../components/ui/ToolCall';
-import type { AIToolPart } from '../types/AskiAi';
+import type { AIToolPart, ToolCalls } from '../types/AskiAi';
 
 const TRANSLATIONS: ToolCallTranslations = {
   preToolCallText: 'Searching for',
@@ -72,6 +72,72 @@ describe('ToolCall', () => {
       render(<ToolCall part={part} translations={TRANSLATIONS} tools={{}} />);
 
       expect(screen.getByText(`found ${expectedHits} results`, { exact: false })).toBeInTheDocument();
+    });
+  });
+
+  describe('custom tools', () => {
+    it('renders the custom loading text while output is unavailable', () => {
+      const part: AIToolPart = {
+        type: 'tool-customAction',
+        toolCallId: 'custom-tool-1',
+        state: 'input-available',
+        input: { value: 'test' },
+      };
+      const tools: ToolCalls = {
+        customAction: {
+          render: () => 'Custom tool finished',
+          translations: { callingToolText: 'Running custom action' },
+        },
+      };
+
+      render(<ToolCall part={part} translations={TRANSLATIONS} tools={tools} />);
+
+      expect(screen.getByText('Running custom action')).toBeInTheDocument();
+    });
+
+    it('renders custom tool output with input and output', () => {
+      const part: AIToolPart = {
+        type: 'tool-customAction',
+        toolCallId: 'custom-tool-2',
+        state: 'output-available',
+        input: { value: 'input value' },
+        output: { result: 'output value' },
+      };
+      const renderToolOutput = vi.fn(() => 'Custom tool finished');
+      const tools: ToolCalls = {
+        customAction: {
+          render: renderToolOutput,
+        },
+      };
+
+      render(<ToolCall part={part} translations={TRANSLATIONS} tools={tools} />);
+
+      expect(renderToolOutput).toHaveBeenCalledWith({
+        message: {
+          input: { value: 'input value' },
+          output: { result: 'output value' },
+        },
+      });
+      expect(screen.getByText('Custom tool finished')).toBeInTheDocument();
+    });
+
+    it('renders nothing for custom tool output errors', () => {
+      const part: AIToolPart = {
+        type: 'tool-customAction',
+        toolCallId: 'custom-tool-3',
+        state: 'output-error',
+        input: { value: 'test' },
+        errorText: 'Custom tool failed',
+      };
+      const tools: ToolCalls = {
+        customAction: {
+          render: () => 'Custom tool finished',
+        },
+      };
+
+      const { container } = render(<ToolCall part={part} translations={TRANSLATIONS} tools={tools} />);
+
+      expect(container).toBeEmptyDOMElement();
     });
   });
 });

--- a/packages/docsearch-react/src/__tests__/useAskAi.test.tsx
+++ b/packages/docsearch-react/src/__tests__/useAskAi.test.tsx
@@ -1,0 +1,152 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAskAi } from '../useAskAi';
+
+type ToolCall = {
+  input: unknown;
+  toolCallId: string;
+  toolName: string;
+};
+
+type ChatOptions = {
+  onToolCall: (params: { toolCall: ToolCall }) => unknown;
+};
+
+type CustomOnToolCallParams = ToolCall & {
+  addToolOutput: (props: { output: unknown }) => Promise<void>;
+};
+
+const mocks = vi.hoisted(() => ({
+  addToolOutput: vi.fn(),
+  useChat: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: mocks.useChat,
+}));
+
+vi.mock('ai', () => ({
+  DefaultChatTransport: class DefaultChatTransport {
+    options: unknown;
+
+    constructor(options: unknown) {
+      this.options = options;
+    }
+  },
+  lastAssistantMessageIsCompleteWithToolCalls: vi.fn(() => false),
+}));
+
+describe('useAskAi', () => {
+  let chatOptions: ChatOptions | undefined;
+
+  function getOnToolCall(): ChatOptions['onToolCall'] {
+    if (!chatOptions) {
+      throw new Error('useChat was not initialized');
+    }
+
+    return chatOptions.onToolCall;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    chatOptions = undefined;
+    mocks.useChat.mockImplementation((options: ChatOptions) => {
+      chatOptions = options;
+
+      return {
+        addToolOutput: mocks.addToolOutput,
+        error: undefined,
+        messages: [],
+        sendMessage: vi.fn(),
+        setMessages: vi.fn(),
+        status: 'ready',
+        stop: vi.fn(),
+      };
+    });
+  });
+
+  it('forwards custom tool output to useChat addToolOutput', async () => {
+    let addToolOutput: CustomOnToolCallParams['addToolOutput'] | undefined;
+    const onToolCall = vi.fn((params: CustomOnToolCallParams) => {
+      addToolOutput = params.addToolOutput;
+    });
+
+    renderHook(() =>
+      useAskAi({
+        agentStudio: false,
+        apiKey: 'api-key',
+        appId: 'app-id',
+        assistantId: 'assistant-id',
+        indexName: 'index-name',
+        tools: {
+          customAction: {
+            onToolCall,
+            render: () => 'Custom action complete',
+          },
+        },
+      }),
+    );
+
+    getOnToolCall()({
+      toolCall: {
+        input: { value: 'input value' },
+        toolCallId: 'tool-call-id',
+        toolName: 'customAction',
+      },
+    });
+
+    expect(onToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: { value: 'input value' },
+        toolCallId: 'tool-call-id',
+        toolName: 'customAction',
+      }),
+    );
+
+    if (!addToolOutput) {
+      throw new Error('addToolOutput was not provided to the custom tool');
+    }
+
+    await addToolOutput({ output: { result: 'output value' } });
+
+    expect(mocks.addToolOutput).toHaveBeenCalledWith({
+      output: { result: 'output value' },
+      tool: 'customAction',
+      toolCallId: 'tool-call-id',
+    });
+  });
+
+  it('does not wait for custom onToolCall to finish', () => {
+    const pendingToolCall = new Promise<void>(() => {});
+    const onToolCall = vi.fn(() => pendingToolCall);
+
+    renderHook(() =>
+      useAskAi({
+        agentStudio: false,
+        apiKey: 'api-key',
+        appId: 'app-id',
+        assistantId: 'assistant-id',
+        indexName: 'index-name',
+        tools: {
+          customAction: {
+            onToolCall,
+            render: () => 'Custom action complete',
+          },
+        },
+      }),
+    );
+
+    const result = getOnToolCall()({
+      toolCall: {
+        input: { value: 'input value' },
+        toolCallId: 'tool-call-id',
+        toolName: 'customAction',
+      },
+    });
+
+    expect(onToolCall).toHaveBeenCalledTimes(1);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/docsearch-react/src/components/ui/ToolCall.tsx
+++ b/packages/docsearch-react/src/components/ui/ToolCall.tsx
@@ -1,8 +1,8 @@
 import type { JSX } from 'react';
 import React, { useMemo } from 'react';
 
-import { LoadingIcon, SearchIcon, ToolIcon } from './icons';
-import type { AIToolPart, SearchToolPart, ToolCalls, ToolDefinition } from './types/AskiAi';
+import { LoadingIcon, SearchIcon, ToolIcon } from '../../icons';
+import type { AIToolPart, SearchToolPart, ToolCalls, ToolDefinition } from '../../types/AskiAi';
 
 export type ToolCallTranslations = {
   /**

--- a/packages/docsearch-react/src/components/ui/ToolCall.tsx
+++ b/packages/docsearch-react/src/components/ui/ToolCall.tsx
@@ -113,12 +113,12 @@ function SearchTool({ part, translations, onSearchQueryClick }: SearchToolProps)
   }
 }
 
-interface DynamicToolProps {
+interface CustomToolProps {
   tool: ToolDefinition;
   part: AIToolPart;
 }
 
-function DynamicTool({ tool, part }: DynamicToolProps) {
+function CustomTool({ tool, part }: CustomToolProps) {
   const toolOutput = useMemo(() => {
     if (part.state !== 'output-available') return null;
 
@@ -157,7 +157,7 @@ export function ToolCall({ part, translations, tools, onSearchQueryClick }: Tool
   const dynamicTool = tools[normalizedToolName];
 
   if (dynamicTool) {
-    return <DynamicTool tool={dynamicTool} part={part} />;
+    return <CustomTool tool={dynamicTool} part={part} />;
   }
 
   if (!isSearchToolPart(part)) {

--- a/packages/docsearch-react/src/icons/ToolIcon.tsx
+++ b/packages/docsearch-react/src/icons/ToolIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export function ToolIcon({ size = 20 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="DocSearch-Search-Icon"
+    >
+      <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+    </svg>
+  );
+}

--- a/packages/docsearch-react/src/icons/index.ts
+++ b/packages/docsearch-react/src/icons/index.ts
@@ -18,3 +18,4 @@ export * from './SendIcon';
 export * from './ExpandIcon';
 export * from './FolderIcon';
 export * from './EditIcon';
+export * from './ToolIcon';

--- a/packages/docsearch-react/src/types/AskiAi.ts
+++ b/packages/docsearch-react/src/types/AskiAi.ts
@@ -3,7 +3,7 @@ import { type ToolUIPart, type UIDataTypes, type UIMessagePart } from 'ai';
 
 export type AskAiState = 'conversation-history' | 'conversation' | 'initial' | 'new-conversation';
 
-export interface DynamicTool {
+export interface CustomTool {
   input: unknown;
   output: unknown;
 }
@@ -18,27 +18,17 @@ export interface SearchIndexTool {
   };
 }
 
-export interface AgentStudioSearchTool {
-  input: {
-    index: string;
-    query: string;
-    number_of_results: number;
-    facet_filters: any | null;
-  };
-  output: {
-    hits?: any[];
-    nbHits?: number;
-    queryID?: string;
-  };
-}
-
 export interface AlgoliaMCPSearchTool {
   input: {
     query: string;
+    index: string;
+    number_of_results?: number;
+    facet_filters?: string[];
   };
   output: {
     hits?: any[];
     nbHits?: number;
+    queryId?: string;
   };
 }
 
@@ -70,13 +60,13 @@ export type ToolCalls = Record<string, ToolDefinition>;
 type SearchTools = {
   [K in `algolia_search_index_${string}`]: AlgoliaMCPSearchTool;
 } & {
+  algolia_search_index: AlgoliaMCPSearchTool;
   searchIndex: SearchIndexTool;
-  algolia_search_index: AgentStudioSearchTool;
 };
-type DynamicTools = {
-  [K in string as K extends keyof SearchTools | `algolia_search_index_${string}` ? never : K]: DynamicTool;
+type CustomTools = {
+  [K in string as K extends keyof SearchTools | `algolia_search_index_${string}` ? never : K]: CustomTool;
 };
-type Tools = DynamicTools & SearchTools;
+type Tools = CustomTools & SearchTools;
 
 export type AIMessage = UIMessage<{ stopped?: boolean }, UIDataTypes, Tools>;
 

--- a/packages/docsearch-react/src/types/AskiAi.ts
+++ b/packages/docsearch-react/src/types/AskiAi.ts
@@ -1,7 +1,12 @@
 import type { UIMessage } from '@ai-sdk/react';
-import type { ToolUIPart, UIDataTypes, UIMessagePart } from 'ai';
+import { type ToolUIPart, type UIDataTypes, type UIMessagePart } from 'ai';
 
 export type AskAiState = 'conversation-history' | 'conversation' | 'initial' | 'new-conversation';
+
+export interface DynamicTool {
+  input: unknown;
+  output: unknown;
+}
 
 export interface SearchIndexTool {
   input: {
@@ -37,19 +42,50 @@ export interface AlgoliaMCPSearchTool {
   };
 }
 
-type Tools = {
+export type ToolDefinition = {
+  /**
+   * Use the tool's input and output to build a string output for the tool result.
+   */
+  render: (params: { message: { input: unknown; output: unknown } }) => string;
+  /**
+   * Optional callback function that is invoked when a tool call is received. You must call addToolOutput to provide the tool result.
+   */
+  onToolCall?: (params: {
+    input: unknown;
+    addToolOutput: (props: { output: unknown }) => Promise<void>;
+    toolCallId: string;
+    toolName: string;
+    dynamic?: boolean;
+  }) => Promise<void> | void;
+  translations?: Partial<{
+    /**
+     * The text displayed before tool call output is available.
+     */
+    callingToolText: string;
+  }>;
+};
+
+export type ToolCalls = Record<string, ToolDefinition>;
+
+type SearchTools = {
   [K in `algolia_search_index_${string}`]: AlgoliaMCPSearchTool;
 } & {
   searchIndex: SearchIndexTool;
   algolia_search_index: AgentStudioSearchTool;
 };
+type DynamicTools = {
+  [K in string as K extends keyof SearchTools | `algolia_search_index_${string}` ? never : K]: DynamicTool;
+};
+type Tools = DynamicTools & SearchTools;
 
 export type AIMessage = UIMessage<{ stopped?: boolean }, UIDataTypes, Tools>;
 
 export type AIMessagePart = UIMessagePart<UIDataTypes, Tools>;
 
+export type SearchToolPart = ToolUIPart<SearchTools>;
 export type AIToolPart = ToolUIPart<Tools>;
 
-export function isAIToolPart(part: AIMessagePart): part is AIToolPart {
-  return part.type.startsWith('tool-');
+export interface AggregatedToolCallPart {
+  type: 'aggregated-tool-call';
+  queries: string[];
 }

--- a/packages/docsearch-react/src/types/__tests__/AskiAi.test.ts
+++ b/packages/docsearch-react/src/types/__tests__/AskiAi.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
+import { isAIToolPart } from '../../utils/ai';
 import type { AIMessagePart } from '../AskiAi';
-import { isAIToolPart } from '../AskiAi';
 
 describe('isAIToolPart', () => {
   it.each([

--- a/packages/docsearch-react/src/useAskAi.ts
+++ b/packages/docsearch-react/src/useAskAi.ts
@@ -1,7 +1,8 @@
 import type { UseChatHelpers } from '@ai-sdk/react';
 import { useChat } from '@ai-sdk/react';
+import type { ChatOnToolCallCallback } from 'ai';
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import {
   agentStudioBaseUrl,
@@ -14,7 +15,8 @@ import type { Exchange } from './AskAiScreen';
 import { ASK_AI_API_URL, BETA_ASK_AI_API_URL } from './constants';
 import type { StoredSearchPlugin } from './stored-searches';
 import { createStoredConversations } from './stored-searches';
-import type { AIMessage } from './types/AskiAi';
+import { type AIMessage, type ToolCalls } from './types/AskiAi';
+import { EMPTY_TOOLS } from './utils/ai';
 
 import type { AgentStudioSearchParameters, AskAiSearchParameters, StoredAskAiState } from '.';
 
@@ -27,6 +29,7 @@ type UseAskAiParams = {
   indexName: string;
   useStagingEnv?: boolean;
   searchParameters?: AskAiSearchParameters;
+  tools: ToolCalls;
   agentStudio: boolean;
 } & (
   | {
@@ -111,34 +114,76 @@ const getAskAiTransport = ({
   });
 };
 
-export const useAskAi: UseAskAi = ({ assistantId, apiKey, appId, indexName, useStagingEnv = false, ...params }) => {
+export const useAskAi: UseAskAi = ({
+  assistantId,
+  apiKey,
+  appId,
+  indexName,
+  useStagingEnv = false,
+  tools = EMPTY_TOOLS,
+  agentStudio,
+  searchParameters,
+}) => {
   const abortControllerRef = useRef(new AbortController());
 
   const askAiTransport = useMemo(
     () =>
-      params.agentStudio
+      agentStudio
         ? getAgentStudioTransport({
             apiKey,
             appId,
             assistantId: assistantId ?? '',
-            searchParameters: params.searchParameters,
+            searchParameters,
           })
         : getAskAiTransport({
             assistantId: assistantId ?? '',
             apiKey,
             appId,
             indexName,
-            searchParameters: params.searchParameters,
+            searchParameters,
             abortController: abortControllerRef.current,
             useStagingEnv,
           }),
-    [apiKey, appId, assistantId, indexName, useStagingEnv, params],
+    [apiKey, appId, assistantId, indexName, useStagingEnv, agentStudio, searchParameters],
   );
 
-  const { messages, sendMessage, status, setMessages, error, stop } = useChat({
+  // Sync ref during render so the stable `handleToolCall` (registered once
+  // by useChat) always sees the latest `tools` without re-creating itself.
+  // Safe because tool calls only fire after a commit, and writes are idempotent.
+  const toolsRef = useRef(tools);
+  toolsRef.current = tools;
+
+  const addToolOutputRef = useRef<UseChat['addToolOutput'] | null>(null);
+
+  const handleToolCall: ChatOnToolCallCallback<AIMessage> = useCallback(async ({ toolCall }) => {
+    const tool = toolsRef.current[toolCall.toolName];
+    if (!tool?.onToolCall) {
+      return;
+    }
+
+    await tool.onToolCall({
+      ...toolCall,
+      addToolOutput: async ({ output }) => {
+        if (!addToolOutputRef.current) return;
+
+        await addToolOutputRef.current({
+          output,
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+        });
+      },
+    });
+  }, []);
+
+  const { messages, sendMessage, status, setMessages, error, stop, addToolOutput } = useChat({
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     transport: askAiTransport,
+    onToolCall: handleToolCall,
   });
+
+  useEffect(() => {
+    addToolOutputRef.current = addToolOutput;
+  }, [addToolOutput]);
 
   const conversations = useRef(
     createStoredConversations<StoredAskAiState>({
@@ -151,7 +196,7 @@ export const useAskAi: UseAskAi = ({ assistantId, apiKey, appId, indexName, useS
     async (messageId: string, thumbs: 0 | 1): Promise<void> => {
       if (!assistantId) return;
 
-      const res = await (params.agentStudio
+      const res = await (agentStudio
         ? postAgentStudioFeedback({
             agentId: assistantId,
             vote: thumbs,
@@ -172,7 +217,7 @@ export const useAskAi: UseAskAi = ({ assistantId, apiKey, appId, indexName, useS
       if (res.status >= 300) throw new Error('Failed, try again later.');
       conversations.addFeedback?.(messageId, thumbs === 1 ? 'like' : 'dislike');
     },
-    [assistantId, params.agentStudio, appId, apiKey, useStagingEnv, conversations],
+    [assistantId, agentStudio, appId, apiKey, useStagingEnv, conversations],
   );
 
   const onStopStreaming = async (): Promise<void> => {
@@ -202,10 +247,10 @@ export const useAskAi: UseAskAi = ({ assistantId, apiKey, appId, indexName, useS
   const askAiError = useMemo((): Error | undefined => {
     if (!error) return undefined;
 
-    if (!params.agentStudio) return error;
+    if (!agentStudio) return error;
 
     return getAgentStudioErrorMessage(error);
-  }, [error, params.agentStudio]);
+  }, [error, agentStudio]);
 
   return {
     messages,

--- a/packages/docsearch-react/src/useAskAi.ts
+++ b/packages/docsearch-react/src/useAskAi.ts
@@ -155,13 +155,13 @@ export const useAskAi: UseAskAi = ({
 
   const addToolOutputRef = useRef<UseChat['addToolOutput'] | null>(null);
 
-  const handleToolCall: ChatOnToolCallCallback<AIMessage> = useCallback(async ({ toolCall }) => {
+  const handleToolCall: ChatOnToolCallCallback<AIMessage> = useCallback(({ toolCall }) => {
     const tool = toolsRef.current[toolCall.toolName];
     if (!tool?.onToolCall) {
       return;
     }
 
-    await tool.onToolCall({
+    tool.onToolCall({
       ...toolCall,
       addToolOutput: async ({ output }) => {
         if (!addToolOutputRef.current) return;

--- a/packages/docsearch-react/src/utils/__tests__/ai.test.ts
+++ b/packages/docsearch-react/src/utils/__tests__/ai.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
-import { isAIToolPart } from '../../utils/ai';
-import type { AIMessagePart } from '../AskiAi';
+import type { AIMessagePart } from '../../types/AskiAi';
+import { isAIToolPart } from '../ai';
 
 describe('isAIToolPart', () => {
   it.each([

--- a/packages/docsearch-react/src/utils/ai.ts
+++ b/packages/docsearch-react/src/utils/ai.ts
@@ -1,7 +1,7 @@
 import type { TextUIPart } from 'ai';
 
 import type { StoredAskAiState } from '../types';
-import type { AIMessage } from '../types/AskiAi';
+import type { AggregatedToolCallPart, AIMessage, AIMessagePart, AIToolPart, ToolCalls } from '../types/AskiAi';
 
 import { sanitizeUserInput } from './sanitize';
 
@@ -106,4 +106,10 @@ export function isThreadDepthError(error?: Error): boolean {
   if (!error) return false;
 
   return error.message?.includes('AI-217') || false;
+}
+
+export const EMPTY_TOOLS: Readonly<ToolCalls> = Object.freeze({});
+
+export function isAIToolPart(part: AggregatedToolCallPart | AIMessagePart): part is AIToolPart {
+  return part.type.startsWith('tool-');
 }

--- a/packages/docsearch-react/src/utils/groupConsecutiveToolResults.ts
+++ b/packages/docsearch-react/src/utils/groupConsecutiveToolResults.ts
@@ -1,8 +1,9 @@
-import type { AIMessagePart } from '../types/AskiAi';
+import type { ToolUIPart } from 'ai';
 
-export interface AggregatedToolCallPart {
-  type: 'aggregated-tool-call';
-  queries: string[];
+import type { AIMessagePart, SearchIndexTool, AggregatedToolCallPart } from '../types/AskiAi';
+
+function isSearchIndexOutputPart(part: AIMessagePart): part is ToolUIPart<{ searchIndex: SearchIndexTool }> {
+  return part.type === 'tool-searchIndex' && part.state === 'output-available';
 }
 
 /**
@@ -15,13 +16,13 @@ export function groupConsecutiveToolResults(parts: AIMessagePart[]): Array<Aggre
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i];
 
-    if (part.type === 'tool-searchIndex' && part.state === 'output-available') {
+    if (isSearchIndexOutputPart(part)) {
       // build list of consecutive result queries
       const queries: string[] = [];
       let j = i;
       while (j < parts.length) {
         const candidate = parts[j];
-        if (candidate.type === 'tool-searchIndex' && candidate.state === 'output-available') {
+        if (isSearchIndexOutputPart(candidate)) {
           const q = (candidate.output?.query ?? '').trim();
 
           // eslint-disable-next-line max-depth


### PR DESCRIPTION
## Summary

Adds support for dynamic, user-defined tool calls (custom tools) in the Ask AI experience, powered by Agent Studio. Consumers can now pass a `tools` map to `DocSearch` and `Sidepanel` to register custom tool handlers and render their results in the conversation UI. This PR also converges the various Agent Studio search tool definitions into a single shape and fixes a client-side issue where unknown tools could break the UI state.

## Motivation

Agent Studio agents can invoke arbitrary tools beyond the built-in `searchIndex` / `algolia_search_index`. Previously, the UI only knew how to render the two hardcoded search tools and would silently drop or mis-handle anything else. This change lets integrators:

- Define their own tools that the agent can call from the host application
- Stream a custom loading state and a final rendered result for each tool
- Reuse a single, consistent search tool type across DocSearch + Agent Studio

## Changes

**Public API**
- New `tools?: ToolCalls` prop on `DocSearchAIProps` (`packages/docsearch-react/src/DocSearch.tsx:249`) and `DocSearchSidepanelProps` (`packages/docsearch-react/src/Sidepanel.tsx:88`).
- New `ToolDefinition` / `ToolCalls` types exported from `types/AskiAi.ts`, including:
  - `render({ message: { input, output } }) => string` to render the final tool result.
  - Optional `onToolCall({ input, addToolOutput, toolCallId, toolName })` to handle the call client-side and push output back into the chat.
  - Optional `translations.callingToolText` for the in-progress state.
- JSDoc recommends memoizing `tools` (or defining it outside the component) for best performance.

**Tool rendering**
- Moved `ToolCall` to `src/components/ui/ToolCall.tsx` and split it into:
  - `SearchTool` — existing search rendering (input-streaming / input-available / output-available).
  - `CustomTool` — renders dynamic tools using `ToolDefinition.render`, with a shimmer loading state using a new `ToolIcon`, and renders nothing on `output-error`.
- `ToolCall` dispatches based on whether the part's tool name matches a registered dynamic tool, falling back to the search renderer.
- New `ToolIcon` added to `src/icons/`.

**Hook wiring (`useAskAi`)**
- `useAskAi` accepts `tools` and wires `useChat`'s `onToolCall`:
  - Uses a `toolsRef` synced during render so a stable `handleToolCall` always sees the latest `tools` without re-subscribing.
  - Exposes `addToolOutput` to the user-provided `onToolCall` via a ref, so custom handlers can push results asynchronously.
  - Does not await the user's `onToolCall`, so a long-running handler doesn't block streaming.
- Destructured params (`agentStudio`, `searchParameters`, …) for stable memo deps.

**Type cleanup**
- Collapsed `AgentStudioSearchTool` and `AlgoliaMCPSearchTool` into a single `AlgoliaMCPSearchTool` shape and introduced a `SearchTools` vs `CustomTools` split so arbitrary tool names are typed as `CustomTool` (`input/output: unknown`).
- Added `SearchToolPart` and moved `AggregatedToolCallPart` into `types/AskiAi.ts`.
- Moved `isAIToolPart` from `types/AskiAi.ts` to `utils/ai.ts` and added a frozen `EMPTY_TOOLS` constant used as a stable default to avoid re-renders.

**Propagation**
- `tools` is threaded through `DocSearchAskAiModal`, `AskAiScreenState`, `AskAiScreen`, `Sidepanel`, `Sidepanel/Sidepanel.tsx`, and `Sidepanel/ConversationScreen.tsx`, defaulting to `EMPTY_TOOLS`.

**Bug fix**
- `groupConsecutiveToolResults` now uses a proper type guard (`isSearchIndexOutputPart`) so non-search tool parts no longer get mis-typed/aggregated, preventing client-side tools from breaking the UI state.

## Tests

- New `__tests__/useAskAi.test.tsx` covers:
  - Forwarding custom tool output to `useChat.addToolOutput` with the correct `tool` / `toolCallId`.
  - Not awaiting custom `onToolCall` (non-blocking).
- Expanded `__tests__/ToolCall.test.tsx` with a `custom tools` suite covering loading text, render output with input/output, and `output-error` rendering nothing.
- Renamed `types/__tests__/AskiAi.test.ts` -> `utils/__tests__/ai.test.ts` to follow the moved `isAIToolPart`.

## Commits

- `feat(askai): Implement dynamic tool calls`
- `move ToolCall to components dir`
- `Converge Agent Studio search tools to same definition, fix client side tools breaking UI state`

## Notes / Follow-ups

- `ToolDefinition.render` returns a `string`; if richer UI is needed later, this can be widened to `ReactNode`.
- Custom tool errors render `null`; consider surfacing a user-visible fallback in a follow-up.
