### PR TITLE
chore: Specify free hosting for public technical documentation

### DIFF
--- a/packages/website/docs/who-can-apply.md
+++ b/packages/website/docs/who-can-apply.md
@@ -4,7 +4,7 @@ title: Who can apply?
 
 **Open for all developer documentation and technical blogs.**
 
-We built DocSearch from the ground up with the idea of improving search on large technical documentations. For this reason, we are offering a free hosting version to all online technical documentations and technical blogs.
+We built DocSearch from the ground up with the idea of improving search on large technical documentations. For this reason, we are offering a free hosting version to all public online technical documentations and technical blogs.
 
 We usually turn down applications when they are not production ready or have non-technical content on the website.
 


### PR DESCRIPTION
Clarified that the free hosting version is for public online technical documentations and blogs.