### PR TITLE
docs(mcp): add public MCP website docs

### DIFF
--- a/mcp/plugins/docsearch/claude/algolia-docsearch/README.md
+++ b/mcp/plugins/docsearch/claude/algolia-docsearch/README.md
@@ -24,9 +24,9 @@ mcp/plugins/docsearch/claude/algolia-docsearch/.mcp.json
 
 For Claude Code marketplace install from this repository:
 
-```bash
-claude plugin marketplace add algolia/docsearch
-claude plugin install algolia-docsearch@algolia-docsearch-marketplace
+```text
+/plugin marketplace add algolia/docsearch
+/plugin install algolia-docsearch@algolia-docsearch-marketplace
 ```
 
 ## Available Tools

--- a/packages/website/docs/mcp/installation.mdx
+++ b/packages/website/docs/mcp/installation.mdx
@@ -1,0 +1,142 @@
+---
+title: Install DocSearch MCP
+sidebar_label: Installation
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+DocSearch MCP is available at:
+
+```text
+https://mcp.algolia.com/1/docsearch/mcp
+```
+
+No authentication is required for the public endpoint.
+
+## Plugins
+
+Plugins install the MCP server config plus client-specific guidance, such as rules, skills, and commands.
+
+<Tabs groupId="mcp-plugin-client" defaultValue="cursor" values={[{ label: 'Cursor', value: 'cursor' }, { label: 'Claude Code', value: 'claude-code' }]}>
+<TabItem value="cursor">
+
+The Cursor plugin package lives in this repository:
+
+```text
+mcp/plugins/docsearch/cursor/algolia-docsearch
+```
+
+It includes:
+
+- `mcp.json` with the public DocSearch MCP endpoint.
+- A Cursor rule that asks the agent to use DocSearch MCP for public developer documentation questions.
+- A skill that explains the two-step `resolve_docset` then `query_docs` flow.
+
+</TabItem>
+<TabItem value="claude-code">
+
+The Claude Code plugin package lives in this repository:
+
+```text
+mcp/plugins/docsearch/claude/algolia-docsearch
+```
+
+It includes:
+
+- `.mcp.json` with the public DocSearch MCP endpoint.
+- A Claude Code skill that triggers for public developer documentation questions.
+- `/algolia-docsearch:docs` for manual documentation lookups.
+
+If you install from the Claude Code marketplace, add the marketplace and install the plugin from Claude Code:
+
+```text
+/plugin marketplace add algolia/docsearch
+/plugin install algolia-docsearch@algolia-docsearch-marketplace
+```
+
+</TabItem>
+</Tabs>
+
+## Manual installation
+
+Use manual installation when you only want the MCP tools, or when your client does not support DocSearch plugins yet.
+
+<Tabs groupId="mcp-manual-client" defaultValue="cursor" values={[{ label: 'Cursor', value: 'cursor' }, { label: 'Claude Code', value: 'claude-code' }, { label: 'Claude Desktop', value: 'claude-desktop' }, { label: 'Generic client', value: 'generic' }]}>
+<TabItem value="cursor">
+
+Go to `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`.
+
+You can also add it to `~/.cursor/mcp.json` for a global install, or `.cursor/mcp.json` for a project install:
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=algolia-docsearch&config=eyJ1cmwiOiJodHRwczovL21jcC5hbGdvbGlhLmNvbS8xL2RvY3NlYXJjaC9tY3AifQ%3D%3D)
+
+```json
+{
+  "mcpServers": {
+    "algolia-docsearch": {
+      "url": "https://mcp.algolia.com/1/docsearch/mcp"
+    }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="claude-code">
+
+Add the remote HTTP server with the Claude Code CLI:
+
+```bash
+claude mcp add --scope user --transport http algolia-docsearch https://mcp.algolia.com/1/docsearch/mcp
+```
+
+Use `--scope project` instead of `--scope user` if you want the configuration stored with a specific project.
+
+</TabItem>
+<TabItem value="claude-desktop">
+
+Open Claude Desktop, then go to `Settings` -> `Connectors` -> `Add Custom Connector`.
+
+Use:
+
+```text
+Name: Algolia DocSearch
+URL: https://mcp.algolia.com/1/docsearch/mcp
+```
+
+</TabItem>
+<TabItem value="generic">
+
+For clients that support remote HTTP MCP servers, configure a server named `algolia-docsearch` with this URL:
+
+```text
+https://mcp.algolia.com/1/docsearch/mcp
+```
+
+Many clients use a JSON shape similar to:
+
+```json
+{
+  "mcpServers": {
+    "algolia-docsearch": {
+      "type": "http",
+      "url": "https://mcp.algolia.com/1/docsearch/mcp"
+    }
+  }
+}
+```
+
+If your client uses a different MCP config format, keep the same server name and URL, and follow that client's remote HTTP MCP documentation.
+
+</TabItem>
+</Tabs>
+
+## Verify the install
+
+Ask your MCP client a public documentation question, for example:
+
+```text
+Use DocSearch MCP to find the current Next.js middleware matcher docs.
+```
+
+The client should call `algolia_docsearch_resolve_docset`, then `algolia_docsearch_query_docs`, and answer with content from the matching documentation.

--- a/packages/website/docs/mcp/overview.mdx
+++ b/packages/website/docs/mcp/overview.mdx
@@ -1,0 +1,58 @@
+---
+title: DocSearch MCP
+sidebar_label: Overview
+---
+
+DocSearch MCP lets AI clients search current public developer documentation from the DocSearch corpus.
+
+Use it when you want an assistant to answer questions from public docs instead of relying only on model training data. The public endpoint does not require authentication:
+
+```text
+https://mcp.algolia.com/1/docsearch/mcp
+```
+
+## What it does
+
+DocSearch MCP exposes documentation search through the [Model Context Protocol](https://modelcontextprotocol.io/). MCP-compatible clients can connect to the endpoint and call DocSearch tools while answering your questions.
+
+The endpoint is focused on public developer documentation. You do not need an Algolia application ID, search API key, or DocSearch application to use it.
+
+## How it works
+
+DocSearch MCP uses a two-step lookup flow:
+
+1. Resolve the documentation set that best matches the library, framework, API, or product you asked about.
+2. Query that documentation set for the specific topic.
+
+For example, if you ask about Next.js middleware, the client first resolves the Next.js docs, then searches those docs for middleware-specific pages.
+
+## Available tools
+
+### `algolia_docsearch_resolve_docset`
+
+Finds matching documentation sets. It returns candidates with a `docset_id` and `targetIndex`, plus ranking signals that help the client choose the best match.
+
+Good queries are short and keyword-based:
+
+```text
+Next.js middleware
+Stripe webhooks
+Algolia InstantSearch React
+```
+
+### `algolia_docsearch_query_docs`
+
+Searches inside one or more resolved documentation sets. The client passes the selected `docset_id` values and their matching `targetIndex` values.
+
+Good queries are specific to the docs content you want:
+
+```text
+middleware matcher config
+webhook signature verification
+configure search client
+```
+
+## Next steps
+
+- [Install DocSearch MCP](/docs/mcp/installation)
+- [Use DocSearch MCP](/docs/mcp/usage)

--- a/packages/website/docs/mcp/usage.mdx
+++ b/packages/website/docs/mcp/usage.mdx
@@ -97,7 +97,7 @@ The client then calls `algolia_docsearch_query_docs` with the selected docset an
 }
 ```
 
-The `docsetIds` and `targets` values should come from the resolve step. Do not guess them.
+The `docsetIds` and `targets` values should come from the resolve step.
 
 ## Tips
 

--- a/packages/website/docs/mcp/usage.mdx
+++ b/packages/website/docs/mcp/usage.mdx
@@ -1,0 +1,125 @@
+---
+title: Use DocSearch MCP
+sidebar_label: Usage
+---
+
+DocSearch MCP works best when your client knows to search public documentation before answering library, framework, API, or SDK questions.
+
+## Ask documentation questions
+
+After installation, ask your client about public developer docs:
+
+```text
+How do I configure middleware matchers in Next.js?
+```
+
+```text
+Show me the current Stripe webhook signature verification docs.
+```
+
+```text
+What is the current setup for Algolia InstantSearch React?
+```
+
+If your client does not automatically use MCP tools, mention DocSearch MCP explicitly:
+
+```text
+Use DocSearch MCP to look up React Server Components data fetching.
+```
+
+## Use the Claude Code command
+
+The Claude Code plugin includes a manual command:
+
+```text
+/algolia-docsearch:docs <library-or-product> [topic]
+```
+
+Examples:
+
+```text
+/algolia-docsearch:docs Next.js middleware matcher
+/algolia-docsearch:docs Stripe webhook signature verification
+/algolia-docsearch:docs Algolia InstantSearch React configure search client
+```
+
+## Query style
+
+DocSearch MCP tools work best with short keyword queries.
+
+Good tool queries:
+
+```text
+Next.js middleware
+middleware matcher config
+Stripe webhooks
+webhook signature verification
+```
+
+Avoid sending full conversational prompts as tool queries:
+
+```text
+Can you please explain how I should configure middleware in the latest version of Next.js?
+```
+
+Your MCP client can still answer conversationally. The keyword guidance only applies to the tool calls it makes behind the scenes.
+
+## Tool flow
+
+DocSearch MCP exposes two tools.
+
+### 1. Resolve a docset
+
+The client first calls `algolia_docsearch_resolve_docset` with a keyword query for the documentation source:
+
+```json
+{
+  "query": "Next.js middleware"
+}
+```
+
+The result includes candidates with `docset_id` and `targetIndex` values. The client should choose the candidate that best matches the requested public docs.
+
+### 2. Query the docs
+
+The client then calls `algolia_docsearch_query_docs` with the selected docset and a topic-specific query:
+
+```json
+{
+  "query": "middleware matcher config",
+  "docsetIds": ["nextjs"],
+  "targets": [
+    {
+      "docsetId": "nextjs",
+      "indexName": "nextjs_docs"
+    }
+  ]
+}
+```
+
+The `docsetIds` and `targets` values should come from the resolve step. Do not guess them.
+
+## Tips
+
+- Be specific about the product and topic you want.
+- Include a version when it matters.
+- Ask for source URLs if you want the client to show where the answer came from.
+- If the first result is too broad, ask for a narrower topic.
+
+## Troubleshooting
+
+### The client does not call DocSearch MCP
+
+Make sure the MCP server is enabled in your client and named `algolia-docsearch`. If you installed the plugin, check that the plugin is enabled too.
+
+### The result is about the wrong product
+
+Ask with more specific keywords. For example, use `Algolia InstantSearch React routing` instead of `routing`.
+
+### The client cannot connect
+
+Confirm that your client supports remote HTTP MCP servers and that the configured URL is:
+
+```text
+https://mcp.algolia.com/1/docsearch/mcp
+```

--- a/packages/website/sidebars.js
+++ b/packages/website/sidebars.js
@@ -23,6 +23,11 @@ export default {
     },
     {
       type: 'category',
+      label: 'MCP',
+      items: ['mcp/overview', 'mcp/installation', 'mcp/usage'],
+    },
+    {
+      type: 'category',
       label: 'Algolia Ask AI',
       items: [
         'v4/askai',


### PR DESCRIPTION
## Summary
- Add a new MCP section to the DocSearch website with overview, installation, and usage pages.
- Document plugin installs for Cursor and Claude Code, plus manual remote MCP setup for common clients.
- Fix the Claude plugin README to use Claude Code `/plugin` commands instead of shell commands.

## Test plan
- [x] `yarn workspace @docsearch/website build`
- [ ] Review `/docs/mcp/overview`, `/docs/mcp/installation`, and `/docs/mcp/usage` locally
