### PR TITLE
fix(askai): Fix new conversation causing thread depth errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ bun run pw:run:webkit
 
 ### Imports
 
-Imports must be ordered alphabetically with newlines between groups:
+Imported modules must be ordered alphabetically with newlines between groups:
 
 1. Built-in modules
 2. External dependencies

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -25,6 +25,7 @@ import type {
   InternalDocSearchHit,
   OnAskAiFeedback,
   StoredAskAiMessage,
+  StoredAskAiState,
   SuggestedQuestionHit,
 } from './types';
 import { type AskAiState } from './types/AskiAi';
@@ -138,17 +139,28 @@ export function DocSearchAskAiModal({
 
   const [stoppedStream, setStoppedStream] = React.useState(false);
 
-  const { messages, status, setMessages, sendMessage, stopAskAiStreaming, askAiError, sendFeedback, conversations } =
-    useAskAi({
-      assistantId: askAiConfigurationId,
-      apiKey: askAiConfig?.apiKey || apiKey,
-      appId: askAiConfig?.appId || appId,
-      indexName: askAiConfig?.indexName || defaultIndexName,
-      searchParameters: askAiSearchParameters,
-      tools,
-      memory: props.memory,
-      indices: askAiConfig?.indices,
-    });
+  const {
+    chatId,
+    messages,
+    status,
+    setMessages,
+    sendMessage,
+    stopAskAiStreaming,
+    askAiError,
+    sendFeedback,
+    conversations,
+    startNewConversation,
+    restoreConversation,
+  } = useAskAi({
+    assistantId: askAiConfigurationId,
+    apiKey: askAiConfig?.apiKey || apiKey,
+    appId: askAiConfig?.appId || appId,
+    indexName: askAiConfig?.indexName || defaultIndexName,
+    searchParameters: askAiSearchParameters,
+    tools,
+    memory: props.memory,
+    indices: askAiConfig?.indices,
+  });
 
   const prevStatus = React.useRef(status);
   React.useEffect(() => {
@@ -166,12 +178,12 @@ export function DocSearchAskAiModal({
 
       for (const part of messages[0].parts) {
         if (part.type === 'text') {
-          conversations.add(buildDummyAskAiHit(part.text, messages));
+          conversations.add(buildDummyAskAiHit(part.text, messages, chatId));
         }
       }
     }
     prevStatus.current = status;
-  }, [status, messages, conversations, disableUserPersonalization, stoppedStream]);
+  }, [status, messages, conversations, disableUserPersonalization, stoppedStream, chatId]);
 
   // Check if there's a thread depth error (AI-217)
   const hasThreadDepthError = React.useMemo(() => {
@@ -369,14 +381,19 @@ export function DocSearchAskAiModal({
 
   useRefreshOnInitialQuery({ initialQuery, inputRef, refresh });
 
+  const hasCurrentMessages = messages.length > 0;
+
   // Refresh the autocomplete results when ask ai is toggled off
   // helps return to the previous ac state and start screen
   React.useEffect(() => {
     if (!isAskAiActive) {
       autocomplete.refresh();
-      setMessages([]);
+
+      if (hasCurrentMessages) {
+        startNewConversation();
+      }
     }
-  }, [isAskAiActive, autocomplete, setMessages]);
+  }, [isAskAiActive, autocomplete, startNewConversation, hasCurrentMessages]);
 
   // Track external state in order to manage internal askAiState
   React.useEffect(() => {
@@ -390,7 +407,7 @@ export function DocSearchAskAiModal({
   };
 
   const handleNewConversation = (): void => {
-    setMessages([]);
+    startNewConversation();
     setAskAiState('new-conversation');
   };
 
@@ -474,10 +491,11 @@ export function DocSearchAskAiModal({
           onItemClick={(item, event) => {
             if (item.type === 'askAI' && item.query) {
               if (item.anchor === 'stored' && 'messages' in item) {
-                setMessages(item.messages as any);
+                const hitMessages = item.messages as StoredAskAiMessage[];
+                restoreConversation(hitMessages, (item as StoredAskAiState).chatId);
                 const initialMessage: InitialAskAiMessage = {
                   query: item.query,
-                  messageId: (item.messages as StoredAskAiMessage[])[0].id,
+                  messageId: hitMessages[0].id,
                 };
 
                 if (interceptAskAiEvent?.(initialMessage)) {

--- a/packages/docsearch-react/src/Sidepanel/Sidepanel.tsx
+++ b/packages/docsearch-react/src/Sidepanel/Sidepanel.tsx
@@ -176,16 +176,18 @@ function SidepanelInner(
   const searchClient = useSearchClient(appId, apiKey, setSidepanelSearchClient);
 
   const {
+    chatId,
     status,
     sendMessage,
     stopAskAiStreaming,
     isStreaming,
     exchanges,
-    setMessages,
     conversations,
     messages,
     sendFeedback,
     askAiError,
+    startNewConversation,
+    restoreConversation,
   } = useAskAi({
     appId,
     indexName,
@@ -213,13 +215,13 @@ function SidepanelInner(
   };
 
   const handleStartNewConversation = (): void => {
-    setMessages([]);
+    startNewConversation();
     setSidepanelState('new-conversation');
   };
 
   const handleSelectQuestion = (question: SuggestedQuestionHit): void => {
     setStoppedStreaming(false);
-    setMessages([]);
+    startNewConversation();
     sendMessage(
       { text: question.question },
       {
@@ -239,14 +241,14 @@ function SidepanelInner(
   const handleSelectConversation = React.useCallback(
     (conversation: StoredAskAiState): void => {
       if (conversation.messages) {
-        setMessages(conversation.messages);
+        restoreConversation(conversation.messages, conversation.chatId);
       } else if (conversation.query) {
         sendMessage({ text: conversation.query });
       }
 
       setSidepanelState('conversation');
     },
-    [sendMessage, setMessages],
+    [sendMessage, restoreConversation],
   );
 
   useManageSidepanelLayout({
@@ -290,13 +292,13 @@ function SidepanelInner(
 
       for (const part of messages[0].parts) {
         if (part.type === 'text') {
-          conversations.add(buildDummyAskAiHit(part.text, messages));
+          conversations.add(buildDummyAskAiHit(part.text, messages, chatId));
         }
       }
     }
 
     prevStatus.current = status;
-  }, [conversations, status, messages, stoppedStreaming]);
+  }, [conversations, status, messages, stoppedStreaming, chatId]);
 
   React.useEffect(() => {
     function setFullViewportHeight(): void {
@@ -327,7 +329,7 @@ function SidepanelInner(
     if (selectedConversation) {
       handleSelectConversation(selectedConversation);
     } else {
-      setMessages([]);
+      startNewConversation();
       sendMessage(
         {
           text: initialMessage.query,
@@ -342,7 +344,7 @@ function SidepanelInner(
       );
       setSidepanelState('conversation');
     }
-  }, [initialMessage, sendMessage, conversations, handleSelectConversation, setMessages]);
+  }, [initialMessage, sendMessage, conversations, handleSelectConversation, startNewConversation]);
 
   // Autofocus the prompt input when the sidepanel opens and blur it when
   // it closes. Disabled on mobile because focusing the textarea triggers the

--- a/packages/docsearch-react/src/__tests__/useAskAi.test.ts
+++ b/packages/docsearch-react/src/__tests__/useAskAi.test.ts
@@ -1,21 +1,22 @@
+/* eslint-disable max-classes-per-file */
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAskAi } from '../useAskAi';
 
-type ToolCall = {
+interface ToolCall {
   input: unknown;
   toolCallId: string;
   toolName: string;
-};
+}
 
-type ChatMessage = {
+interface ChatMessage {
   id: string;
   role: 'assistant' | 'user';
   parts: Array<{ type: 'text'; text: string }>;
-};
+}
 
-type ChatOptions = {
+interface ChatOptions {
   id?: string;
   messages?: ChatMessage[];
   onToolCall: (params: { toolCall: ToolCall }) => unknown;
@@ -25,7 +26,18 @@ type ChatOptions = {
       body?: Record<string, unknown>;
     };
   };
-};
+}
+
+interface ChatInstance {
+  id?: string;
+  messages?: ChatMessage[];
+  options: ChatOptions;
+  sendMessage: (message: unknown) => void;
+}
+
+interface UseChatOptions {
+  chat: ChatInstance;
+}
 
 type CustomOnToolCallParams = ToolCall & {
   addToolOutput: (props: { output: unknown }) => Promise<void>;
@@ -34,11 +46,27 @@ type CustomOnToolCallParams = ToolCall & {
 const mocks = vi.hoisted(() => ({
   addToolOutput: vi.fn(),
   setMessages: vi.fn(),
+  sendMessage: vi.fn(),
   useChat: vi.fn(),
   generateId: vi.fn(),
 }));
 
 vi.mock('@ai-sdk/react', () => ({
+  Chat: class Chat {
+    id?: string;
+    messages?: ChatMessage[];
+    options: ChatOptions;
+
+    constructor(options: ChatOptions) {
+      this.id = options.id;
+      this.messages = options.messages;
+      this.options = options;
+    }
+
+    sendMessage(message: unknown): void {
+      mocks.sendMessage({ chatId: this.id, message });
+    }
+  },
   useChat: mocks.useChat,
 }));
 
@@ -54,9 +82,15 @@ vi.mock('ai', () => ({
   generateId: mocks.generateId,
 }));
 
+interface SendMessageCall {
+  chatId?: string;
+  message: unknown;
+}
+
 describe('useAskAi', () => {
   let chatOptions: ChatOptions | undefined;
   let chatOptionsHistory: ChatOptions[] = [];
+  let sendMessageCalls: SendMessageCall[] = [];
 
   function getOnToolCall(): ChatOptions['onToolCall'] {
     if (!chatOptions) {
@@ -93,15 +127,19 @@ describe('useAskAi', () => {
 
     chatOptions = undefined;
     chatOptionsHistory = [];
-    mocks.useChat.mockImplementation((options: ChatOptions) => {
-      chatOptions = options;
-      chatOptionsHistory.push(options);
+    sendMessageCalls = [];
+    mocks.sendMessage.mockImplementation((call: SendMessageCall) => {
+      sendMessageCalls.push(call);
+    });
+    mocks.useChat.mockImplementation(({ chat }: UseChatOptions) => {
+      chatOptions = chat.options;
+      chatOptionsHistory.push(chat.options);
 
       return {
         addToolOutput: mocks.addToolOutput,
         error: undefined,
-        messages: [],
-        sendMessage: vi.fn(),
+        messages: chat.messages ?? [],
+        sendMessage: chat.sendMessage,
         setMessages: mocks.setMessages,
         status: 'ready',
         stop: vi.fn(),
@@ -494,6 +532,78 @@ describe('useAskAi', () => {
       // recreation does not re-hydrate the previous conversation.
       expect(chatOptions?.messages).toBeUndefined();
       expect(chatOptions?.id).toBe('generated-id-2');
+    });
+
+    it('sends the next message with the new chat id after startNewConversation', () => {
+      const { result } = renderHook(() =>
+        useAskAi({
+          apiKey: 'api-key',
+          appId: 'app-id',
+          assistantId: 'assistant-id',
+          indexName: 'index-name',
+          tools: {},
+        }),
+      );
+
+      const initialId = chatOptions?.id;
+      expect(initialId).toBe('generated-id-1');
+
+      // Capture `sendMessage` from the current render, mirroring how a consumer
+      // (e.g. the Sidepanel) grabs it before rotating the conversation.
+      const sendMessage = result.current.sendMessage;
+
+      act(() => {
+        result.current.startNewConversation();
+        sendMessage({
+          role: 'user',
+          parts: [{ type: 'text', text: 'new question' }],
+        });
+      });
+
+      // The rotated id is what every later request must target.
+      expect(chatOptions?.id).toBe('generated-id-2');
+      expect(chatOptions?.id).not.toBe(initialId);
+
+      // Regression: the request must NOT go out on the stale (pre-rotation) id.
+      expect(sendMessageCalls).toHaveLength(1);
+      expect(sendMessageCalls[0].chatId).toBe('generated-id-2');
+      expect(sendMessageCalls[0].chatId).not.toBe(initialId);
+    });
+
+    it('keeps conversation lifecycle callbacks stable when transport inputs change by reference', () => {
+      const { result, rerender } = renderHook(
+        ({ indices, searchParameters }) =>
+          useAskAi({
+            apiKey: 'api-key',
+            appId: 'app-id',
+            assistantId: 'assistant-id',
+            indexName: 'index-name',
+            searchParameters,
+            indices,
+            tools: {},
+          }),
+        {
+          initialProps: {
+            searchParameters: {
+              'index-name': { distinct: false },
+            },
+            indices: [{ index: 'index-name', description: 'Test index' }],
+          },
+        },
+      );
+
+      const startNewConversation = result.current.startNewConversation;
+      const restoreConversation = result.current.restoreConversation;
+
+      rerender({
+        searchParameters: {
+          'index-name': { distinct: false },
+        },
+        indices: [{ index: 'index-name', description: 'Test index' }],
+      });
+
+      expect(result.current.startNewConversation).toBe(startNewConversation);
+      expect(result.current.restoreConversation).toBe(restoreConversation);
     });
   });
 });

--- a/packages/docsearch-react/src/__tests__/useAskAi.test.ts
+++ b/packages/docsearch-react/src/__tests__/useAskAi.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAskAi } from '../useAskAi';
@@ -9,7 +9,15 @@ type ToolCall = {
   toolName: string;
 };
 
+type ChatMessage = {
+  id: string;
+  role: 'assistant' | 'user';
+  parts: Array<{ type: 'text'; text: string }>;
+};
+
 type ChatOptions = {
+  id?: string;
+  messages?: ChatMessage[];
   onToolCall: (params: { toolCall: ToolCall }) => unknown;
   transport: {
     options: {
@@ -25,7 +33,9 @@ type CustomOnToolCallParams = ToolCall & {
 
 const mocks = vi.hoisted(() => ({
   addToolOutput: vi.fn(),
+  setMessages: vi.fn(),
   useChat: vi.fn(),
+  generateId: vi.fn(),
 }));
 
 vi.mock('@ai-sdk/react', () => ({
@@ -41,10 +51,12 @@ vi.mock('ai', () => ({
     }
   },
   lastAssistantMessageIsCompleteWithToolCalls: vi.fn(() => false),
+  generateId: mocks.generateId,
 }));
 
 describe('useAskAi', () => {
   let chatOptions: ChatOptions | undefined;
+  let chatOptionsHistory: ChatOptions[] = [];
 
   function getOnToolCall(): ChatOptions['onToolCall'] {
     if (!chatOptions) {
@@ -73,16 +85,24 @@ describe('useAskAi', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    let idCounter = 0;
+    mocks.generateId.mockImplementation(() => {
+      idCounter += 1;
+      return `generated-id-${idCounter}`;
+    });
+
     chatOptions = undefined;
+    chatOptionsHistory = [];
     mocks.useChat.mockImplementation((options: ChatOptions) => {
       chatOptions = options;
+      chatOptionsHistory.push(options);
 
       return {
         addToolOutput: mocks.addToolOutput,
         error: undefined,
         messages: [],
         sendMessage: vi.fn(),
-        setMessages: vi.fn(),
+        setMessages: mocks.setMessages,
         status: 'ready',
         stop: vi.fn(),
       };
@@ -301,5 +321,179 @@ describe('useAskAi', () => {
     );
 
     expect(getTransportBody()).toEqual({ algolia: {} });
+  });
+
+  describe('conversation id rotation', () => {
+    it('passes a generated id to useChat on mount', () => {
+      renderHook(() =>
+        useAskAi({
+          apiKey: 'api-key',
+          appId: 'app-id',
+          assistantId: 'assistant-id',
+          indexName: 'index-name',
+          tools: {},
+        }),
+      );
+
+      expect(chatOptions?.id).toBe('generated-id-1');
+    });
+
+    it('rotates the chat id and clears messages on startNewConversation', () => {
+      const { result } = renderHook(() =>
+        useAskAi({
+          apiKey: 'api-key',
+          appId: 'app-id',
+          assistantId: 'assistant-id',
+          indexName: 'index-name',
+          tools: {},
+        }),
+      );
+
+      const initialId = chatOptions?.id;
+      expect(initialId).toBe('generated-id-1');
+
+      act(() => {
+        result.current.startNewConversation();
+      });
+
+      // Rotating the id recreates the `Chat` instance with no seeded messages,
+      // which is what clears the previous conversation.
+      expect(chatOptions?.messages).toBeUndefined();
+      expect(chatOptions?.id).toBe('generated-id-2');
+      expect(chatOptions?.id).not.toBe(initialId);
+    });
+
+    it('generates a fresh id for each new conversation', () => {
+      const { result } = renderHook(() =>
+        useAskAi({
+          apiKey: 'api-key',
+          appId: 'app-id',
+          assistantId: 'assistant-id',
+          indexName: 'index-name',
+          tools: {},
+        }),
+      );
+
+      act(() => {
+        result.current.startNewConversation();
+      });
+      const secondId = chatOptions?.id;
+
+      act(() => {
+        result.current.startNewConversation();
+      });
+      const thirdId = chatOptions?.id;
+
+      expect(secondId).toBe('generated-id-2');
+      expect(thirdId).toBe('generated-id-3');
+      expect(secondId).not.toBe(thirdId);
+    });
+
+    it('restores a stored conversation using its persisted chat id', () => {
+      const { result } = renderHook(() =>
+        useAskAi({
+          apiKey: 'api-key',
+          appId: 'app-id',
+          assistantId: 'assistant-id',
+          indexName: 'index-name',
+          tools: {},
+        }),
+      );
+
+      const storedMessages: ChatMessage[] = [
+        {
+          id: 'message-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'stored question' }],
+        },
+      ];
+
+      act(() => {
+        result.current.restoreConversation(storedMessages, 'stored-chat-id');
+      });
+
+      // Restored messages are seeded through the `messages` option so they
+      // survive the `Chat` instance being recreated when the id changes.
+      expect(chatOptions?.messages).toEqual(storedMessages);
+      expect(chatOptions?.id).toBe('stored-chat-id');
+    });
+
+    it('restores a stored conversation with a fresh id when no chat id is persisted', () => {
+      const { result } = renderHook(() =>
+        useAskAi({
+          apiKey: 'api-key',
+          appId: 'app-id',
+          assistantId: 'assistant-id',
+          indexName: 'index-name',
+          tools: {},
+        }),
+      );
+
+      const storedMessages: ChatMessage[] = [
+        {
+          id: 'message-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'stored question' }],
+        },
+      ];
+
+      act(() => {
+        result.current.restoreConversation(storedMessages);
+      });
+
+      // The messages must still be seeded even when a fresh id is generated,
+      // otherwise the recreated `Chat` instance would render an empty thread.
+      expect(chatOptions?.messages).toEqual(storedMessages);
+      expect(chatOptions?.id).toBe('generated-id-2');
+    });
+
+    it('does not seed initial messages on mount', () => {
+      renderHook(() =>
+        useAskAi({
+          apiKey: 'api-key',
+          appId: 'app-id',
+          assistantId: 'assistant-id',
+          indexName: 'index-name',
+          tools: {},
+        }),
+      );
+
+      expect(chatOptions?.messages).toBeUndefined();
+    });
+
+    it('clears seeded messages and rotates the id when starting a new conversation after a restore', () => {
+      const { result } = renderHook(() =>
+        useAskAi({
+          apiKey: 'api-key',
+          appId: 'app-id',
+          assistantId: 'assistant-id',
+          indexName: 'index-name',
+          tools: {},
+        }),
+      );
+
+      const storedMessages: ChatMessage[] = [
+        {
+          id: 'message-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'stored question' }],
+        },
+      ];
+
+      act(() => {
+        result.current.restoreConversation(storedMessages, 'stored-chat-id');
+      });
+
+      expect(chatOptions?.messages).toEqual(storedMessages);
+
+      act(() => {
+        result.current.startNewConversation();
+      });
+
+      // Starting a new conversation must drop the seeded messages so a later
+      // recreation does not re-hydrate the previous conversation.
+      expect(chatOptions?.messages).toBeUndefined();
+      expect(chatOptions?.id).toBe('generated-id-2');
+    });
   });
 });

--- a/packages/docsearch-react/src/types/StoredDocSearchHit.ts
+++ b/packages/docsearch-react/src/types/StoredDocSearchHit.ts
@@ -14,6 +14,7 @@ export type StoredAskAiMessage = AIMessage & {
 };
 
 export type StoredAskAiState = StoredDocSearchHit & {
+  chatId?: string;
   stopped?: boolean;
   messages?: StoredAskAiMessage[];
 };

--- a/packages/docsearch-react/src/useAskAi.ts
+++ b/packages/docsearch-react/src/useAskAi.ts
@@ -1,8 +1,8 @@
 import type { UseChatHelpers } from '@ai-sdk/react';
 import { useChat } from '@ai-sdk/react';
 import type { ChatOnToolCallCallback } from 'ai';
-import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls, generateId } from 'ai';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { agentStudioBaseUrl, getAgentStudioErrorMessage, postAgentStudioFeedback } from './askai';
 import type { Exchange } from './AskAiScreen';
@@ -28,6 +28,7 @@ type UseAskAiParams = {
 };
 
 type UseAskAiReturn = {
+  chatId: string;
   messages: AIMessage[];
   status: UseChat['status'];
   sendMessage: UseChat['sendMessage'];
@@ -38,6 +39,8 @@ type UseAskAiReturn = {
   exchanges: Exchange[];
   conversations: StoredSearchPlugin<StoredAskAiState>;
   sendFeedback: OnAskAiFeedback;
+  startNewConversation: () => void;
+  restoreConversation: (restored: AIMessage[], existingConversationId?: string) => void;
 };
 
 type UseAskAi = (params: UseAskAiParams) => UseAskAiReturn;
@@ -90,6 +93,8 @@ export const useAskAi: UseAskAi = ({
   memory,
   indices,
 }) => {
+  const [chatId, setChatId] = useState(generateId);
+  const [restoredMessages, setRestoredMessages] = useState<AIMessage[] | undefined>(undefined);
   const abortControllerRef = useRef(new AbortController());
 
   const askAiTransport = useMemo(
@@ -134,6 +139,8 @@ export const useAskAi: UseAskAi = ({
   }, []);
 
   const { messages, sendMessage, status, setMessages, error, stop, addToolOutput } = useChat({
+    id: chatId,
+    messages: restoredMessages,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     transport: askAiTransport,
     onToolCall: handleToolCall,
@@ -201,7 +208,18 @@ export const useAskAi: UseAskAi = ({
     return getAgentStudioErrorMessage(error);
   }, [error]);
 
+  const startNewConversation = useCallback(() => {
+    setRestoredMessages(undefined);
+    setChatId(generateId());
+  }, []);
+
+  const restoreConversation = useCallback((restored: AIMessage[], existingConversationId?: string) => {
+    setRestoredMessages(restored);
+    setChatId(existingConversationId ?? generateId());
+  }, []);
+
   return {
+    chatId,
     messages,
     sendMessage,
     status,
@@ -212,5 +230,7 @@ export const useAskAi: UseAskAi = ({
     exchanges,
     conversations,
     sendFeedback,
+    startNewConversation,
+    restoreConversation,
   };
 };

--- a/packages/docsearch-react/src/useAskAi.ts
+++ b/packages/docsearch-react/src/useAskAi.ts
@@ -1,5 +1,5 @@
 import type { UseChatHelpers } from '@ai-sdk/react';
-import { useChat } from '@ai-sdk/react';
+import { Chat, useChat } from '@ai-sdk/react';
 import type { ChatOnToolCallCallback } from 'ai';
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls, generateId } from 'ai';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -39,7 +39,13 @@ type UseAskAiReturn = {
   exchanges: Exchange[];
   conversations: StoredSearchPlugin<StoredAskAiState>;
   sendFeedback: OnAskAiFeedback;
+  /**
+   * Create's a new chat instance, clearing existing messages and generating a new conversation ID.
+   */
   startNewConversation: () => void;
+  /**
+   * Create's a new chat instance, seeded with an existing conversation's ID and its messages.
+   */
   restoreConversation: (restored: AIMessage[], existingConversationId?: string) => void;
 };
 
@@ -93,8 +99,6 @@ export const useAskAi: UseAskAi = ({
   memory,
   indices,
 }) => {
-  const [chatId, setChatId] = useState(generateId);
-  const [restoredMessages, setRestoredMessages] = useState<AIMessage[] | undefined>(undefined);
   const abortControllerRef = useRef(new AbortController());
 
   const askAiTransport = useMemo(
@@ -109,6 +113,12 @@ export const useAskAi: UseAskAi = ({
       }),
     [apiKey, appId, assistantId, searchParameters, memory?.userToken, indices],
   );
+
+  // Store transport in a ref since it is dependent on unstable dependencies:
+  // - searchParameters, an object whose changed values trigger a new transport
+  // - indices, an array whose changed values trigger a new transport
+  const askAiTransportRef = useRef(askAiTransport);
+  askAiTransportRef.current = askAiTransport;
 
   // Sync ref during render so the stable `handleToolCall` (registered once
   // by useChat) always sees the latest `tools` without re-creating itself.
@@ -138,12 +148,25 @@ export const useAskAi: UseAskAi = ({
     });
   }, []);
 
-  const { messages, sendMessage, status, setMessages, error, stop, addToolOutput } = useChat({
-    id: chatId,
-    messages: restoredMessages,
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-    transport: askAiTransport,
-    onToolCall: handleToolCall,
+  const createChatInstance = useCallback(
+    (messages?: AIMessage[], id = generateId()): Chat<AIMessage> =>
+      new Chat<AIMessage>({
+        id,
+        messages,
+        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+        transport: askAiTransportRef.current,
+        onToolCall: handleToolCall,
+      }),
+    [handleToolCall],
+  );
+
+  const [chatInstance, setChatInstance] = useState((): Chat<AIMessage> => createChatInstance());
+  // Keep a stable reference to the chat instance so reading messages are render safe
+  const chatInstanceRef = useRef<Chat<AIMessage>>(chatInstance);
+  chatInstanceRef.current = chatInstance;
+
+  const { messages, status, setMessages, error, stop, addToolOutput } = useChat({
+    chat: chatInstance,
   });
 
   useEffect(() => {
@@ -178,12 +201,12 @@ export const useAskAi: UseAskAi = ({
     [assistantId, appId, apiKey, conversations],
   );
 
-  const onStopStreaming = async (): Promise<void> => {
+  const onStopStreaming = useCallback(async (): Promise<void> => {
     abortControllerRef.current.abort();
     await stop();
-  };
+  }, [stop]);
 
-  const exchanges = useMemo(() => {
+  const exchanges = useMemo((): Exchange[] => {
     const grouped: Exchange[] = [];
 
     for (let i = 0; i < messages.length; i++) {
@@ -208,20 +231,36 @@ export const useAskAi: UseAskAi = ({
     return getAgentStudioErrorMessage(error);
   }, [error]);
 
-  const startNewConversation = useCallback(() => {
-    setRestoredMessages(undefined);
-    setChatId(generateId());
-  }, []);
+  const updateChatInstance = useCallback(
+    (restored?: AIMessage[], existingConversationId?: string): void => {
+      const newChatInstance = createChatInstance(restored, existingConversationId);
+      chatInstanceRef.current = newChatInstance;
+      setChatInstance(newChatInstance);
+    },
+    [createChatInstance],
+  );
 
-  const restoreConversation = useCallback((restored: AIMessage[], existingConversationId?: string) => {
-    setRestoredMessages(restored);
-    setChatId(existingConversationId ?? generateId());
-  }, []);
+  const startNewConversation = useCallback((): void => {
+    updateChatInstance();
+  }, [updateChatInstance]);
+
+  const restoreConversation = useCallback(
+    (restored: AIMessage[], existingConversationId?: string): void => {
+      updateChatInstance(restored, existingConversationId);
+    },
+    [updateChatInstance],
+  );
+
+  // This is so that the public `sendMessage` is always pointed to a stable reference of the chat instance
+  const sendMessageSafe = useCallback<UseChat['sendMessage']>(
+    (...args): Promise<void> => chatInstanceRef.current!.sendMessage(...args),
+    [],
+  );
 
   return {
-    chatId,
+    chatId: chatInstance.id,
     messages,
-    sendMessage,
+    sendMessage: sendMessageSafe,
     status,
     setMessages,
     askAiError,

--- a/packages/docsearch-react/src/utils/ai.ts
+++ b/packages/docsearch-react/src/utils/ai.ts
@@ -79,13 +79,14 @@ export function extractLinksFromMessage(message: AIMessage | null): ExtractedLin
   return links;
 }
 
-export const buildDummyAskAiHit = (query: string, messages: AIMessage[]): StoredAskAiState => {
+export const buildDummyAskAiHit = (query: string, messages: AIMessage[], chatId?: string): StoredAskAiState => {
   const textPart = messages[0].parts.find((part) => part.type === 'text');
   const sanitizedText = textPart?.text ? sanitizeUserInput(textPart.text) : '';
 
   return {
     query,
     objectID: sanitizedText,
+    chatId,
     messages,
     type: 'askAI',
     anchor: 'stored',


### PR DESCRIPTION
### Why

Starting a "new conversation" in Ask AI previously only cleared the rendered messages (`setMessages([])`) while keeping the same underlying chat session alive. Because the conversation id never rotated, the backend kept appending every "new" conversation onto the same thread, which eventually tripped the thread depth limit (AI-217).

This change ties each conversation to its own `chatId`:
- Starting a new conversation rotates the id, recreating the chat session with an empty thread.
- Restoring a stored conversation reuses its persisted `chatId` (or generates a fresh one if none exists) and seeds the prior messages so history is preserved across session recreation.
- The `chatId` is now persisted on stored conversation hits so restores stay anchored to the correct thread.

### What changed (high level)
- `useAskAi` now owns the `chatId` lifecycle and exposes `startNewConversation` / `restoreConversation`, replacing direct `setMessages([])` calls in the modal and sidepanel.
- `chatId` added to `StoredAskAiState` and threaded through `buildDummyAskAiHit`.

### Testing scenarios
1. Open Ask AI, ask a question, click "New conversation", ask several more questions in a row, confirm no thread depth error appears after repeated new conversations.
2. Have a conversation, close/toggle Ask AI off and back on, start a new question, confirm it starts a clean thread rather than appending to the old one.
3. From conversation history, restore a previous conversation, confirm prior messages render and follow-up questions continue the correct thread.
4. Restore an older stored conversation that predates this change (no persisted `chatId`), confirm it still loads and a fresh id is assigned.
5. Repeat the same flows in both the **modal** and the **sidepanel** (both call sites were updated).