### PR TITLE
docs(agents): document Cursor Cloud dev environment setup for v5 (Bun)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,3 +246,14 @@ packages/
 - `marked` - Markdown rendering
 - `rollup` - Build bundling
 - `vitest` - Test runner
+
+## Cursor Cloud specific instructions
+
+Toolchain is pinned in `.tool-versions`: Node `22.15.0` (managed via `fnm`) and Bun `1.3.10`. These are preinstalled in the Cloud VM and available on `PATH` in new shells; the startup update script only runs `bun install`.
+
+Non-obvious caveats:
+
+- The **Docusaurus website does not run under Bun on this branch**. Both `bun run website:build` and the dev server (`bun run website:start` / `website:test`) fail at plugin load with `ERR_PACKAGE_PATH_NOT_EXPORTED` (e.g. `entities/lib/decode.js`, from `docusaurus` → `cheerio`/`htmlparser2`) because of how Bun hoists transitive deps. Consequently, **`bun run build` (which ends with `website:build`) and Playwright E2E (`bun run pw:*`, which boots the website first) cannot complete as-is.** Build the libraries only with: `bun run --sequential build:stage:base build:stage:react build:stage:consumers build:stage:adapter`.
+- **To run/demo the widget, use the React playground:** `bun run playground:start` serves at `http://localhost:5173` (Vite). `bun run playground-js:start` serves the vanilla-JS demo. These connect to Algolia's hosted index using public credentials baked into the demo, so **outbound internet is required** for live search results.
+- Run unit tests non-interactively with `bun run test --run` (plain `bun run test` starts Vitest watch mode).
+- `bun run lint:css` reports many pre-existing CSS lint violations in the repo; these are not environment problems.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the Cloud dev environment for the **v5** branch (Bun-based) and records durable, non-obvious startup notes in `AGENTS.md` under `## Cursor Cloud specific instructions`.

The only code change is documentation (`AGENTS.md`). The startup **update script** is configured to `bun install`.

## Environment

- Node `22.15.0` via `fnm`, Bun `1.3.10` (pinned in `.tool-versions`).
- `bun install` links all workspaces.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Type check | `bun run test:types` | ✅ pass |
| Lint (ESLint) | `bun run lint` | ✅ pass |
| Lint (CSS) | `bun run lint:css` | ⚠️ runs; reports pre-existing repo violations |
| Unit tests | `bun run test --run` | ✅ 214 passed (24 files) |
| Build (libs) | `bun run --sequential build:stage:base build:stage:react build:stage:consumers build:stage:adapter` | ✅ pass |
| Build (full) | `bun run build` | ❌ fails at `website:build` (see caveat) |
| Run/demo | `bun run playground:start` → `http://localhost:5173` | ✅ live Algolia search working |

### Hello-world demo

Opened the React playground, opened the DocSearch modal, typed `getting started`, got live Algolia results, and navigated to a result.

[docsearch_v5_playground_search_demo.mp4](https://cursor.com/agents/bc-3a036fda-50e3-47a1-aa50-6c5357d05b0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocsearch_v5_playground_search_demo.mp4)

[Live search results for ](https://cursor.com/agents/bc-3a036fda-50e3-47a1-aa50-6c5357d05b0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocsearch_v5_search_results.webp)

## Known caveat (documented in AGENTS.md)

The Docusaurus **website does not run under Bun** on this branch: both `website:build` and the dev server fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` (`entities`/`cheerio` transitive deps under Bun's hoisting). This blocks full `bun run build` and Playwright E2E (`pw:*`), which boots the website first. Library builds and the playground demo are unaffected.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a036fda-50e3-47a1-aa50-6c5357d05b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a036fda-50e3-47a1-aa50-6c5357d05b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

