### PR TITLE
fix: increase line height to avoid overlap

### DIFF
--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -316,7 +316,7 @@
   color: var(--docsearch-text-color);
   vertical-align: middle;
   font-size: 1.1em;
-  line-height: 0.5em;
+  line-height: 1.5em;
   font-weight: 300;
 }
 


### PR DESCRIPTION
fixes #2883

before:

(on Docusaurus' website)

<img width="835" height="683" alt="image" src="https://github.com/user-attachments/assets/20255923-d5c6-463c-94ec-21f8f78a108a" /><br />

after:

<img width="872" height="692" alt="image" src="https://github.com/user-attachments/assets/d6cb217a-6c50-486b-8a5f-78743cc31630" /><br />