### PR TITLE
fix(core): support IME composition in search and prompt inputs

### DIFF
--- a/packages/docsearch-core/src/__tests__/DocSearch.test.tsx
+++ b/packages/docsearch-core/src/__tests__/DocSearch.test.tsx
@@ -393,6 +393,31 @@ describe('@docsearch/core', () => {
       expect(onClose).toHaveBeenCalled();
     });
 
+    it('does not close on escape key during IME composition', () => {
+      const onCloseSpy = vi.fn();
+
+      renderHook(() => {
+        const searchRef = useRef<HTMLButtonElement | null>(null);
+        return useDocSearchKeyboardEvents({
+          isOpen: true,
+          onOpen,
+          isAskAiActive: false,
+          onClose: onCloseSpy,
+          searchButtonRef: searchRef,
+          onAskAiToggle: () => {},
+        });
+      });
+
+      act(() => {
+        fireEvent.keyDown(document, {
+          code: 'Escape',
+          isComposing: true,
+        });
+      });
+
+      expect(onCloseSpy).not.toHaveBeenCalled();
+    });
+
     it('respects keyboard shortcuts', () => {
       renderHook(() => {
         const searchRef = useRef<HTMLButtonElement | null>(null);

--- a/packages/docsearch-core/src/useDocSearchKeyboardEvents.ts
+++ b/packages/docsearch-core/src/useDocSearchKeyboardEvents.ts
@@ -46,6 +46,10 @@ export function useDocSearchKeyboardEvents({
 }: UseDocSearchKeyboardEventsProps): void {
   React.useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
+      if (event.isComposing) {
+        return;
+      }
+
       if (isOpen && event.code === 'Escape' && isAskAiActive) {
         onAskAiToggle(false);
         return;

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -615,6 +615,10 @@ export function DocSearchModal({
       id: 'docsearch',
       defaultActiveItemId: 0,
       openOnFocus: true,
+      // Search once an IME composition ends instead of on every update:
+      // mid-composition rerenders interrupt the session in Firefox.
+      // See https://github.com/algolia/docsearch/issues/2503
+      ignoreCompositionEvents: true,
       initialState: {
         query: initialQuery,
         context: {

--- a/packages/docsearch-react/src/SearchBox.tsx
+++ b/packages/docsearch-react/src/SearchBox.tsx
@@ -163,6 +163,12 @@ export function SearchBox({
     ...baseInputProps,
     enterKeyHint: props.isAskAiActive ? ('enter' as const) : ('search' as const),
     onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>): void => {
+      // during an IME composition, keys interact with the candidate list:
+      // enter must confirm the composition, not select a hit or ask AI.
+      // See https://github.com/algolia/docsearch/issues/1304
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       // block these up, down, enter listeners when Ask AI is active
       if (props.isAskAiActive && blockedKeys.has(e.key)) {
         // enter key asks another question
@@ -186,6 +192,14 @@ export function SearchBox({
         return;
       }
       origOnChange?.(e);
+    },
+    onCompositionEnd: (e: React.CompositionEvent<HTMLInputElement>): void => {
+      // block search when Ask AI is active, like `onChange` above
+      if (props.isAskAiActive) {
+        props.setQuery(e.currentTarget.value);
+        return;
+      }
+      baseInputProps.onCompositionEnd?.(e);
     },
     disabled: isAskAiStreaming || (isThreadDepthError && props.isAskAiActive),
   };

--- a/packages/docsearch-react/src/SearchBox.tsx
+++ b/packages/docsearch-react/src/SearchBox.tsx
@@ -118,6 +118,7 @@ export function SearchBox({
   const blockedKeys = new Set(['ArrowUp', 'ArrowDown', 'Enter']);
   const origOnKeyDown = baseInputProps.onKeyDown;
   const origOnChange = baseInputProps.onChange;
+  const origOnCompositionEnd = baseInputProps.onCompositionEnd;
   const isAskAiStreaming = props.askAiStatus === 'streaming' || props.askAiStatus === 'submitted';
   const isKeywordSearchLoading = props.state.status === 'stalled';
   const renderMoreOptions = props.isAskAiActive && askAiState !== 'conversation-history';
@@ -199,7 +200,7 @@ export function SearchBox({
         props.setQuery(e.currentTarget.value);
         return;
       }
-      baseInputProps.onCompositionEnd?.(e);
+      origOnCompositionEnd?.(e);
     },
     disabled: isAskAiStreaming || (isThreadDepthError && props.isAskAiActive),
   };

--- a/packages/docsearch-react/src/Sidepanel/PromptForm.tsx
+++ b/packages/docsearch-react/src/Sidepanel/PromptForm.tsx
@@ -134,6 +134,9 @@ export const PromptForm = React.forwardRef<HTMLTextAreaElement, Props>(
       // Allow Enter to work normally (new line) when streaming
       if (isStreaming || showThreadDepthBanner) return;
 
+      // Enter during an IME composition confirms it and must not send the prompt
+      if (e.nativeEvent.isComposing) return;
+
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
 

--- a/packages/docsearch-react/src/__tests__/ime.test.tsx
+++ b/packages/docsearch-react/src/__tests__/ime.test.tsx
@@ -1,0 +1,191 @@
+import { render, act, fireEvent, screen, cleanup } from '@testing-library/react';
+import React, { type JSX } from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import '@testing-library/jest-dom/vitest';
+
+import { DocSearch as DocSearchComponent } from '../DocSearch';
+import type { DocSearchProps } from '../DocSearch';
+import { PromptForm } from '../Sidepanel/PromptForm';
+
+function DocSearch(props: Partial<DocSearchProps>): JSX.Element {
+  return <DocSearchComponent appId="woo" apiKey="foo" indexName="bar" {...props} />;
+}
+
+async function openModal(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(await screen.findByText('Search'));
+  });
+}
+
+function createSearchMock(hits: Array<Record<string, unknown>> = []): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({
+    results: [
+      {
+        hits,
+        hitsPerPage: 20,
+        nbHits: hits.length,
+        nbPages: 1,
+        page: 0,
+        processingTimeMS: 0,
+        exhaustiveNbHits: true,
+        params: '',
+        query: '',
+      },
+    ],
+  });
+}
+
+const HIT = {
+  objectID: '1',
+  type: 'lvl1',
+  url: 'https://example.org/docs/hello',
+  url_without_anchor: 'https://example.org/docs/hello',
+  anchor: null,
+  content: null,
+  hierarchy: { lvl0: 'Documentation', lvl1: 'Hello world', lvl2: null, lvl3: null, lvl4: null, lvl5: null, lvl6: null },
+  _highlightResult: {
+    hierarchy: {
+      lvl0: { value: 'Documentation', matchLevel: 'none', matchedWords: [] },
+      lvl1: { value: 'Hello world', matchLevel: 'full', matchedWords: ['hello'] },
+    },
+  },
+  _snippetResult: {
+    hierarchy: {
+      lvl1: { value: 'Hello world', matchLevel: 'full' },
+    },
+  },
+};
+
+describe('IME composition', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('modal shortcuts', () => {
+    it('does not close the modal on Escape pressed during composition', async () => {
+      render(<DocSearch />);
+      await openModal();
+
+      expect(document.querySelector('.DocSearch-Modal')).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.keyDown(document, { code: 'Escape', isComposing: true });
+      });
+
+      expect(document.querySelector('.DocSearch-Modal')).toBeInTheDocument();
+
+      // still closes once the composition is over
+      act(() => {
+        fireEvent.keyDown(document, { code: 'Escape' });
+      });
+
+      expect(document.querySelector('.DocSearch-Modal')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('search input', () => {
+    it('searches once the composition ends instead of on every composition update', async () => {
+      const search = createSearchMock();
+      render(<DocSearch transformSearchClient={(searchClient) => ({ ...searchClient, search })} />);
+      await openModal();
+
+      const input = document.querySelector('.DocSearch-Input') as HTMLInputElement;
+
+      act(() => {
+        fireEvent.compositionStart(input);
+        fireEvent.input(input, { target: { value: 'ni' }, isComposing: true });
+        fireEvent.input(input, { target: { value: 'nihao' }, isComposing: true });
+      });
+
+      expect(search).not.toHaveBeenCalled();
+
+      await act(async () => {
+        fireEvent.input(input, { target: { value: '你好' }, isComposing: true });
+        fireEvent.compositionEnd(input);
+        // flush the mocked search response
+        await Promise.resolve();
+      });
+
+      expect(search).toHaveBeenCalledTimes(1);
+      expect(search.mock.calls[0][0].requests[0].query).toBe('你好');
+    });
+
+    // https://github.com/algolia/docsearch/issues/1304
+    it('does not open the active result on Enter pressed during composition', async () => {
+      const navigate = vi.fn();
+      const search = createSearchMock([HIT]);
+      render(
+        <DocSearch
+          navigator={{ navigate, navigateNewTab: vi.fn(), navigateNewWindow: vi.fn() }}
+          transformSearchClient={(searchClient) => ({ ...searchClient, search })}
+        />,
+      );
+      await openModal();
+
+      const input = document.querySelector('.DocSearch-Input') as HTMLInputElement;
+
+      await act(async () => {
+        fireEvent.input(input, { target: { value: 'hello' } });
+        // flush the mocked search response
+        await Promise.resolve();
+      });
+
+      await screen.findByText('Hello world');
+
+      act(() => {
+        fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+      });
+
+      expect(navigate).not.toHaveBeenCalled();
+
+      act(() => {
+        fireEvent.keyDown(input, { key: 'Enter' });
+      });
+
+      expect(navigate).toHaveBeenCalledTimes(1);
+    });
+
+    it('searches on every keystroke outside of a composition session', async () => {
+      const search = createSearchMock();
+      render(<DocSearch transformSearchClient={(searchClient) => ({ ...searchClient, search })} />);
+      await openModal();
+
+      const input = document.querySelector('.DocSearch-Input') as HTMLInputElement;
+
+      await act(async () => {
+        fireEvent.input(input, { target: { value: 'hello' } });
+        // flush the mocked search response
+        await Promise.resolve();
+      });
+
+      expect(search).toHaveBeenCalledTimes(1);
+      expect(search.mock.calls[0][0].requests[0].query).toBe('hello');
+    });
+  });
+
+  describe('sidepanel prompt', () => {
+    it('does not send the prompt on Enter pressed during composition', () => {
+      const onSend = vi.fn();
+      render(
+        <PromptForm
+          exchanges={[]}
+          isStreaming={false}
+          showThreadDepthBanner={false}
+          onSend={onSend}
+          onStartNewConversation={() => {}}
+          onStopStreaming={() => {}}
+        />,
+      );
+
+      const textarea = document.querySelector('.DocSearch-Sidepanel-Prompt--textarea') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: 'nihao' } });
+
+      fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
+      expect(onSend).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      expect(onSend).toHaveBeenCalledWith('nihao');
+    });
+  });
+});

--- a/packages/docsearch-react/src/useDocSearchKeyboardEvents.ts
+++ b/packages/docsearch-react/src/useDocSearchKeyboardEvents.ts
@@ -49,6 +49,10 @@ export function useDocSearchKeyboardEvents({
 
   React.useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
+      if (event.isComposing) {
+        return;
+      }
+
       if (isOpen && event.code === 'Escape' && isAskAiActive) {
         onAskAiToggle(false);
         return;


### PR DESCRIPTION
fixes #2503
fixes #1304

Search now runs once a composition session ends instead of on every update, so mid-composition re-renders no longer interrupt the session. Keys pressed while composing no longer leak into DocSearch behaviors: enter doesn't open the active hit, ask AI, or send the sidepanel prompt, and escape doesn't close the modal.
