### PR TITLE
fix(askai): copy the full answer instead of the first text part

### DIFF
--- a/packages/docsearch-react/src/AskAiScreen.tsx
+++ b/packages/docsearch-react/src/AskAiScreen.tsx
@@ -150,7 +150,7 @@ function AskAiExchangeCard({
     <div className="DocSearch-AskAiScreen-Response-Container">
       <div className="DocSearch-AskAiScreen-Response">
         <div className="DocSearch-AskAiScreen-Message DocSearch-AskAiScreen-Message--user">
-          <p className="DocSearch-AskAiScreen-Query">{userContent?.text ?? ''}</p>
+          <p className="DocSearch-AskAiScreen-Query">{userContent}</p>
         </div>
         <div className="DocSearch-AskAiScreen-Message DocSearch-AskAiScreen-Message--assistant">
           <div className="DocSearch-AskAiScreen-MessageContent">
@@ -244,7 +244,7 @@ function AskAiExchangeCard({
           <AskAiScreenFooterActions
             id={messageId}
             showActions={showActions}
-            latestAssistantMessageContent={assistantContent?.text || null}
+            latestAssistantMessageContent={assistantContent || null}
             translations={translations}
             conversations={conversations}
             onFeedback={onFeedback}

--- a/packages/docsearch-react/src/Sidepanel/ConversationScreen.tsx
+++ b/packages/docsearch-react/src/Sidepanel/ConversationScreen.tsx
@@ -132,7 +132,7 @@ const ConversationExchange = React.forwardRef<HTMLDivElement, ConversationnExcha
       <div className="DocSearch-AskAiScreen-Response-Container" ref={conversationRef}>
         <div className="DocSearch-AskAiScreen-Response">
           <div className="DocSearch-AskAiScreen-Message DocSearch-AskAiScreen-Message--user">
-            <p className="DocSearch-AskAiScreen-Query">{userContent?.text ?? ''}</p>
+            <p className="DocSearch-AskAiScreen-Query">{userContent}</p>
           </div>
           <div className="DocSearch-AskAiScreen-Message DocSearch-AskAiScreen-Message--assistant">
             <div className="DocSearch-AskAiScreen-MessageContent">
@@ -222,7 +222,7 @@ const ConversationExchange = React.forwardRef<HTMLDivElement, ConversationnExcha
             <ConversationActions
               id={messageId}
               showActions={showActions}
-              latestAssistantMessageContent={assistantContent?.text || null}
+              latestAssistantMessageContent={assistantContent || null}
               translations={translations}
               conversations={conversations}
               onFeedback={onFeedback}

--- a/packages/docsearch-react/src/utils/__tests__/ai.test.ts
+++ b/packages/docsearch-react/src/utils/__tests__/ai.test.ts
@@ -6,12 +6,40 @@ import {
   extractAgentStudioErrorFieldMessage,
   getAskAiBlockingBannerMessage,
   getAskAiPromptBlockingUserFacingMessage,
+  getMessageContent,
   getThreadDepthErrorUserFacingMessage,
   isAgentStudioTokenOutputLimitError,
   isAskAiPromptBlockingError,
   isThreadDepthError,
   showAskAiBlockingBannerNewConversationLink,
 } from '../ai';
+
+describe('getMessageContent', () => {
+  it('joins the text parts around tool calls so copying returns the full answer', () => {
+    const message = {
+      id: 'a1',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'Let me look that up.', state: 'done' },
+        { type: 'tool-searchIndex', toolCallId: 't1', state: 'output-available' },
+        { type: 'text', text: 'Docusaurus is a static site generator.', state: 'done' },
+      ],
+    } as unknown as AIMessage;
+
+    expect(getMessageContent(message)).toBe('Let me look that up.\n\nDocusaurus is a static site generator.');
+  });
+
+  it('returns an empty string without a message or text parts', () => {
+    expect(getMessageContent(null)).toBe('');
+    expect(
+      getMessageContent({
+        id: 'a1',
+        role: 'assistant',
+        parts: [{ type: 'tool-searchIndex', toolCallId: 't1', state: 'output-available' }],
+      } as unknown as AIMessage),
+    ).toBe('');
+  });
+});
 
 describe('isThreadDepthError', () => {
   it('detects AI-217 in message (any case)', () => {

--- a/packages/docsearch-react/src/utils/ai.ts
+++ b/packages/docsearch-react/src/utils/ai.ts
@@ -101,8 +101,14 @@ export const buildDummyAskAiHit = (query: string, messages: AIMessage[]): Stored
   };
 };
 
-export const getMessageContent = (message: AIMessage | null): TextUIPart | undefined =>
-  message?.parts.find((part) => part.type === 'text');
+// answers can interleave text with tool calls, so join every text part
+// instead of stopping at the first one
+// see https://github.com/algolia/docsearch/issues/2782
+export const getMessageContent = (message: AIMessage | null): string =>
+  (message?.parts ?? [])
+    .filter((part): part is TextUIPart => part.type === 'text')
+    .map((part) => part.text)
+    .join('\n\n');
 
 type ExchangeWithOptionalAssistant = {
   assistantMessage: AIMessage | null;


### PR DESCRIPTION
fixes #2782

Ask AI answers interleave text with search tool calls; the copy button only copied the text before the first tool call.