### PR TITLE
feat(js): Document JS based hybrid mode, fix JS packages

### DIFF
--- a/examples/demo-js/src/main.ts
+++ b/examples/demo-js/src/main.ts
@@ -30,7 +30,10 @@ function logSidepanelState(instance: SidepanelInstance, label: string): void {
   });
 }
 
-const sidepanelInstance = sidepanel({
+let docsearchInstance: DocSearchInstance | undefined = undefined;
+let sidepanelInstance: SidepanelInstance | undefined = undefined;
+
+sidepanelInstance = sidepanel({
   container: '#docsearch-sidepanel',
   indexName: 'docsearch',
   appId: 'PMZUYBQDAK',
@@ -43,6 +46,7 @@ const sidepanelInstance = sidepanel({
   onOpen: () => {
     // eslint-disable-next-line no-console
     console.log('[demo-js] sidepanel onOpen()');
+    docsearchInstance?.close();
   },
   onClose: () => {
     // eslint-disable-next-line no-console
@@ -63,13 +67,13 @@ console.log('[demo-js] sidepanel try:', {
 });
 logSidepanelState(sidepanelInstance, 'sidepanel initial state');
 
-const docsearchInstance = docsearch({
+docsearchInstance = docsearch({
   container: '#docsearch',
   indexName: 'docsearch',
   appId: 'PMZUYBQDAK',
   apiKey: '24b09689d5b4223813d9b8e48563c8f6',
   interceptAskAiEvent: (initialMessage: InitialAskAiMessage) => {
-    docsearchInstance.close();
+    docsearchInstance?.close();
     sidepanelInstance.open(initialMessage);
     return true;
   },
@@ -80,6 +84,7 @@ const docsearchInstance = docsearch({
   onOpen: () => {
     // eslint-disable-next-line no-console
     console.log('[demo-js] docsearch onOpen()');
+    sidepanelInstance.close();
   },
   onClose: () => {
     // eslint-disable-next-line no-console

--- a/packages/docsearch-js/tsdown.config.ts
+++ b/packages/docsearch-js/tsdown.config.ts
@@ -22,6 +22,7 @@ const sharedConfig: UserConfig = {
     js: '.js',
   }),
   sourcemap: true,
+  noExternal: ['@docsearch/react', '@docsearch/core'],
 };
 
 export default defineConfig([

--- a/packages/docsearch-sidepanel-js/tsdown.config.ts
+++ b/packages/docsearch-sidepanel-js/tsdown.config.ts
@@ -22,6 +22,7 @@ const sharedConfig: UserConfig = {
     js: '.js',
   }),
   sourcemap: true,
+  noExternal: ['@docsearch/react', '@docsearch/core'],
 };
 
 export default defineConfig([

--- a/packages/website/docs/sidepanel/hybrid.mdx
+++ b/packages/website/docs/sidepanel/hybrid.mdx
@@ -152,6 +152,9 @@ docsearchInstance = docsearch({
     docsearchInstance?.close();
     sidepanelInstance.open(initialMessage);
     return true;
+  },
+  onOpen: () => {
+    sidepanelInstance?.close();
   }
 });
 

--- a/packages/website/docs/sidepanel/hybrid.mdx
+++ b/packages/website/docs/sidepanel/hybrid.mdx
@@ -5,10 +5,6 @@ title: Hybrid Mode
 import Tabs from  '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::info
-Currently Hybrid Mode is only available when using the React usage approach. Hybrid Mode is not available in the JavaScript-only (vanilla) integration.
-:::
-
 ## Introduction
 
 Sidepanel can run alongside the DocSearch Modal through what we call "Hybrid Mode." When a user initiates an Ask AI action from within
@@ -20,15 +16,19 @@ the continuation of the conversation.
 To set up the Hybrid Mode experience, you will need the following:
 
 - [DocSearch Modal][1] packages installed
-- Sidepanel Component package installed
+- [Sidepanel Component][2] package installed
 
-The Sidepanel Component package can be installed as follows:
+The needed packages can be installed as follows:
 
 <Tabs>
 <TabItem value="npm">
 
 ```bash
-npm install @docsearch/sidepanel
+npm install @docsearch/css @docsearch/modal @docsearch/sidepanel
+
+# Or if using JS based packages
+
+npm install @docsearch/css @docsearch/js @docsearch/sidepanel-js
 ```
 
 </TabItem>
@@ -36,7 +36,11 @@ npm install @docsearch/sidepanel
 <TabItem value="yarn">
 
 ```bash
-yarn add @docsearch/sidepanel
+yarn add @docsearch/css @docsearch/modal @docsearch/sidepanel
+
+# Or if using JS based packages
+
+yarn add @docsearch/css @docsearch/js @docsearch/sidepanel-js
 ```
 
 </TabItem>
@@ -44,7 +48,11 @@ yarn add @docsearch/sidepanel
 <TabItem value="pnpm">
 
 ```bash
-pnpm add @docsearch/sidepanel
+pnpm add @docsearch/css @docsearch/modal @docsearch/sidepanel
+
+# Or if using JS based packages
+
+pnpm add @docsearch/css @docsearch/js @docsearch/sidepanel-js
 ```
 
 </TabItem>
@@ -52,7 +60,11 @@ pnpm add @docsearch/sidepanel
 <TabItem value="bun">
 
 ```bash
-bun add @docsearch/sidepanel
+bun add @docsearch/css @docsearch/modal @docsearch/sidepanel
+
+# Or if using JS based packages
+
+bun add @docsearch/css @docsearch/js @docsearch/sidepanel-js
 ```
 
 </TabItem>
@@ -63,6 +75,9 @@ bun add @docsearch/sidepanel
 ## Implementation
 
 Once everything is installed, you can set up Hybrid Mode as such:
+
+<Tabs>
+<TabItem value="React">
 
 ```tsx
 import { DocSearch } from '@docsearch/core';
@@ -97,4 +112,53 @@ function HybridMode() {
 
 There is no manual opt-in for Hybrid Mode to work. When both the Modal and Sidepanel are rendered inside the same `<DocSearch>` context, Hybrid Mode is enabled automatically. No additional configuration is required.
 
+</TabItem>
+
+<TabItem value="JavaScript">
+
+```html
+<div id="docsearch"></div>
+<div id="sidepanel"></div>
+```
+
+```js
+import docsearch from '@docsearch/js';
+import sidepanel from '@docsearch/sidepanel-js';
+
+import '@docsearch/css/dist/style.css';
+import '@docsearch/css/dist/sidepanel.css';
+
+let docsearchInstance = undefined;
+let sidepanelInstance = undefined;
+
+sidepanelInstance = sidepanel({
+  container: "#sidepanel",
+  indexName: "YOUR_INDEX_NAME",
+  appId: "YOUR_APP_ID",
+  apiKey: "YOUR_SEARCH_API_KEY",
+  assistantId: "YOUR_ASSISTANT_ID",
+  onOpen: () => {
+    docsearchInstance?.close();
+  }
+});
+
+docsearchInstance = docsearch({
+  container: "#docsearch",
+  indexName: "YOUR_INDEX_NAME",
+  appId: "YOUR_APP_ID",
+  apiKey: "YOUR_SEARCH_API_KEY",
+  askAi: "YOUR_ASSISTANT_ID",  // Or configuration object
+  interceptAskAiEvent: (initialMessage) => {
+    docsearchInstance?.close();
+    sidepanelInstance.open(initialMessage);
+    return true;
+  }
+});
+
+```
+
+</TabItem>
+</Tabs>
+
 [1]: /docs/docsearch#installation
+[2]: /docs/sidepanel/getting-started#installation


### PR DESCRIPTION
## Summary

Hybrid Mode (Sidepanel running alongside the DocSearch Modal) previously only worked with the React integration, and the docs explicitly called out that the vanilla JS path was unsupported. This PR makes Hybrid Mode actually usable from the JS-only packages and documents how to wire it up.

The JS packages were not bundling their internal dependencies (`@docsearch/react` and `@docsearch/core`), which left them broken for consumers who don't already have those packages resolved. Marking them as `noExternal` in the tsdown config bundles them in so the JS entry points work standalone.

The demo was also updated so the Modal and Sidepanel close each other when one opens, which is the expected Hybrid Mode behavior and doubles as the reference implementation shown in the docs.

## Why

- The JS builds shipped with unresolved internal imports, so `@docsearch/js` and `@docsearch/sidepanel-js` did not work on their own.
- Users had no guidance for setting up Hybrid Mode outside of React, and the docs claimed it wasn't possible at all.

## Testing

- Build `@docsearch/js` and `@docsearch/sidepanel-js` and confirm the output bundles include the core/react code rather than leaving them as external imports.
- Run the JS demo (`bun run playground-js:start`) and:
  - Trigger Ask AI from the Modal and confirm the Modal closes and the Sidepanel opens with the conversation carried over.
  - Open the Sidepanel and confirm the Modal closes if it was open, and vice versa.
- Follow the new JavaScript tab in the Hybrid Mode docs in a fresh project and confirm the setup works end to end.