### PR TITLE
docs(mcp): add service disclaimer

### DIFF
--- a/packages/website/docs/mcp/installation.mdx
+++ b/packages/website/docs/mcp/installation.mdx
@@ -24,3 +24,9 @@ Use DocSearch MCP to find the current Next.js middleware matcher docs.
 ```
 
 The client should call the DocSearch tools and answer with content from the matching documentation, ideally with source links.
+
+:::note
+
+Algolia DocSearch MCP is a free service and is provided by Algolia "AS IS" and "AS AVAILABLE" without warranty of any kind, and may be suspended, modified, or discontinued by Algolia at any time in its sole discretion. Algolia disclaims all obligation and liability arising out of or in connection with Your use of DocSearch MCP. You shall comply with all laws and governmental regulations in Your use of the DocSearch MCP.
+
+:::

--- a/packages/website/docs/mcp/overview.mdx
+++ b/packages/website/docs/mcp/overview.mdx
@@ -41,3 +41,9 @@ Step 2 of the manual flow. Retrieves documentation content for one or more `docs
 
 - [Install DocSearch MCP](/docs/mcp/installation)
 - [Use DocSearch MCP](/docs/mcp/usage)
+
+:::note
+
+Algolia DocSearch MCP is a free service and is provided by Algolia "AS IS" and "AS AVAILABLE" without warranty of any kind, and may be suspended, modified, or discontinued by Algolia at any time in its sole discretion. Algolia disclaims all obligation and liability arising out of or in connection with Your use of DocSearch MCP. You shall comply with all laws and governmental regulations in Your use of the DocSearch MCP.
+
+:::

--- a/packages/website/docusaurus.config.mjs
+++ b/packages/website/docusaurus.config.mjs
@@ -111,7 +111,8 @@ export default {
           },
           {
             label: 'MCP',
-            to: '/mcp',
+            // Sibling SPA at /mcp — pathname:// bypasses Docusaurus route/link checks.
+            to: 'pathname:///mcp',
             position: 'left',
           },
           {

--- a/packages/website/docusaurus.config.mjs
+++ b/packages/website/docusaurus.config.mjs
@@ -111,7 +111,7 @@ export default {
           },
           {
             label: 'MCP',
-            to: 'docs/mcp/overview',
+            to: '/mcp',
             position: 'left',
           },
           {


### PR DESCRIPTION
## Summary
- add the DocSearch MCP free-service disclaimer to installation and overview docs
- route the MCP navigation item to the MCP landing page

## Test plan
- [x] `bunx prettier --check packages/website/docs/mcp/installation.mdx packages/website/docs/mcp/overview.mdx packages/website/docusaurus.config.mjs`
- [x] `git diff --check`
- [ ] Website build (known to fail under Bun in this environment because of Docusaurus dependency exports)

Made with [Cursor](https://cursor.com)