### PR TITLE
chore: Get NPM OIDC token before publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,9 @@ jobs:
             git config --global user.name "algolia-bot"
       - run:
           name: Release if needed
-          command: bun run release
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            bun run release
   test_playwright:
     <<: *playwright
     steps:


### PR DESCRIPTION
## What

We are moving to use [trusted publishing](https://docs.npmjs.com/trusted-publishers) on NPM for our packages. This change has CircleCI fetch the NPM OIDC token and set as env var before attempting to publish.