### PR TITLE
[docsearch-react] Bug Fix: Preserve searchSuggestions array shape for no-results suggestions

### DIFF
--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -201,12 +201,13 @@ const buildQuerySources = async ({
 
       // We store the `lvl0`s to display them as search suggestions
       // in the "no results" screen.
-      if ((sourcesState.context.searchSuggestions as any[]).length < Object.keys(sources).length) {
+      const existingSearchSuggestions = Array.isArray(sourcesState.context.searchSuggestions)
+        ? sourcesState.context.searchSuggestions
+        : [];
+
+      if (existingSearchSuggestions.length < Object.keys(sources).length) {
         setContext({
-          searchSuggestions: {
-            ...(sourcesState.context.searchSuggestions ?? []),
-            ...Object.keys(sources),
-          },
+          searchSuggestions: [...existingSearchSuggestions, ...Object.keys(sources)],
         });
       }
 

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -1,5 +1,5 @@
 import { render, act, fireEvent, screen, cleanup } from '@testing-library/react';
-import type { LiteClient, SearchResponse, SearchResponses } from 'algoliasearch/lite';
+import type { Hit, LiteClient, SearchResponse, SearchResponses } from 'algoliasearch/lite';
 import React, { type JSX } from 'react';
 import { describe, it, expect, afterEach } from 'vitest';
 
@@ -13,25 +13,22 @@ function DocSearch(props: Partial<DocSearchProps>): JSX.Element {
 }
 
 // mock empty response
-function noResultSearch<T = unknown>(
+function noResultSearch<T = Record<string, unknown>>(
   _queries: Parameters<LiteClient['search']>[0],
   _requestOptions?: Parameters<LiteClient['search']>[1],
 ): Promise<SearchResponses<T>> {
-  return Promise.resolve({
-    results: [
-      {
-        hits: [] as T[],
-        hitsPerPage: 0,
-        nbHits: 0,
-        nbPages: 0,
-        page: 0,
-        processingTimeMS: 0,
-        exhaustiveNbHits: true,
-        params: '',
-        query: '',
-      } as SearchResponse<T>,
-    ],
-  } as SearchResponses<T>);
+  const emptyResult: SearchResponse<T> = {
+    hits: [] as Array<Hit<T>>,
+    hitsPerPage: 0,
+    nbHits: 0,
+    nbPages: 0,
+    page: 0,
+    processingTimeMS: 0,
+    exhaustiveNbHits: true,
+    params: '',
+    query: '',
+  };
+  return Promise.resolve({ results: [emptyResult] });
 }
 
 describe('api', () => {
@@ -267,57 +264,59 @@ describe('api', () => {
   it('renders no-results suggestions from previous successful searches', async () => {
     let shouldReturnResults = true;
 
-    const search = async <T = unknown>(
+    const search = <T = Record<string, unknown>,>(
       _queries: Parameters<LiteClient['search']>[0],
       _requestOptions?: Parameters<LiteClient['search']>[1],
     ): Promise<SearchResponses<T>> => {
-      return {
-        results: shouldReturnResults
-          ? [
-              {
-                hits: [
-                  {
-                    hierarchy: { lvl0: 'React' },
-                    objectID: '1',
-                    url: 'https://react.dev',
-                    content: 'React content',
-                    type: 'lvl0',
-                  },
-                  {
-                    hierarchy: { lvl0: 'Hooks' },
-                    objectID: '2',
-                    url: 'https://react.dev/hooks',
-                    content: 'Hooks content',
-                    type: 'lvl0',
-                  },
-                ] as T[],
-                hitsPerPage: 20,
-                nbHits: 2,
-                nbPages: 1,
-                page: 0,
-                processingTimeMS: 0,
-                exhaustiveNbHits: true,
-                params: '',
-                query: 'react',
-              } as SearchResponse<T>,
-            ]
-          : [
-              {
-                hits: [] as T[],
-                hitsPerPage: 0,
-                nbHits: 0,
-                nbPages: 0,
-                page: 0,
-                processingTimeMS: 0,
-                exhaustiveNbHits: true,
-                params: '',
-                query: 'nothing',
-              } as SearchResponse<T>,
-            ],
-      } as SearchResponses<T>;
+      const successResult: SearchResponse<T> = {
+        hits: [
+          {
+            hierarchy: { lvl0: 'React' },
+            objectID: '1',
+            url: 'https://react.dev',
+            content: 'React content',
+            type: 'lvl0',
+          } as unknown as Hit<T>,
+          {
+            hierarchy: { lvl0: 'Hooks' },
+            objectID: '2',
+            url: 'https://react.dev/hooks',
+            content: 'Hooks content',
+            type: 'lvl0',
+          } as unknown as Hit<T>,
+        ],
+        hitsPerPage: 20,
+        nbHits: 2,
+        nbPages: 1,
+        page: 0,
+        processingTimeMS: 0,
+        exhaustiveNbHits: true,
+        params: '',
+        query: 'react',
+      };
+      const emptyResult: SearchResponse<T> = {
+        hits: [],
+        hitsPerPage: 0,
+        nbHits: 0,
+        nbPages: 0,
+        page: 0,
+        processingTimeMS: 0,
+        exhaustiveNbHits: true,
+        params: '',
+        query: 'nothing',
+      };
+      const resultsResponse: SearchResponses<T> = {
+        results: shouldReturnResults ? [successResult] : [emptyResult],
+      };
+      return Promise.resolve(resultsResponse);
     };
 
-    render(<DocSearch transformSearchClient={(searchClient) => ({ ...searchClient, search: search as DocSearchTransformClient['search'] }) as DocSearchTransformClient} />);
+    const transformSearchClient = (searchClient: DocSearchTransformClient): DocSearchTransformClient => ({
+      ...searchClient,
+      search,
+    });
+
+    render(<DocSearch transformSearchClient={transformSearchClient} />);
 
     await act(async () => {
       fireEvent.click(await screen.findByText('Search'));
@@ -353,15 +352,12 @@ describe('api', () => {
     });
 
     it('opens ask AI screen and returns to search', async () => {
-      render(
-        <DocSearch
-          askAi="assistant"
-          transformSearchClient={(searchClient) => ({
-            ...searchClient,
-            search: noResultSearch as DocSearchTransformClient['search'],
-          }) as DocSearchTransformClient}
-        />,
-      );
+      const transformAiSearchClient = (searchClient: DocSearchTransformClient): DocSearchTransformClient => ({
+        ...searchClient,
+        search: noResultSearch,
+      });
+
+      render(<DocSearch askAi="assistant" transformSearchClient={transformAiSearchClient} />);
 
       await act(async () => {
         fireEvent.click(await screen.findByText('Search'));

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -262,6 +262,82 @@ describe('api', () => {
     });
   });
 
+  it('renders no-results suggestions from previous successful searches', async () => {
+    let shouldReturnResults = true;
+
+    const search = () => {
+      return new Promise((resolve) => {
+        resolve({
+          results: shouldReturnResults
+            ? [
+                {
+                  hits: [
+                    {
+                      hierarchy: { lvl0: 'React' },
+                      objectID: '1',
+                      url: 'https://react.dev',
+                      content: 'React content',
+                      type: 'lvl0',
+                    },
+                    {
+                      hierarchy: { lvl0: 'Hooks' },
+                      objectID: '2',
+                      url: 'https://react.dev/hooks',
+                      content: 'Hooks content',
+                      type: 'lvl0',
+                    },
+                  ],
+                  hitsPerPage: 20,
+                  nbHits: 2,
+                  nbPages: 1,
+                  page: 0,
+                  processingTimeMS: 0,
+                  exhaustiveNbHits: true,
+                  params: '',
+                  query: 'react',
+                },
+              ]
+            : [
+                {
+                  hits: [],
+                  hitsPerPage: 0,
+                  nbHits: 0,
+                  nbPages: 0,
+                  page: 0,
+                  processingTimeMS: 0,
+                  exhaustiveNbHits: true,
+                  params: '',
+                  query: 'nothing',
+                },
+              ],
+        });
+      });
+    };
+
+    render(<DocSearch transformSearchClient={(searchClient) => ({ ...searchClient, search })} />);
+
+    await act(async () => {
+      fireEvent.click(await screen.findByText('Search'));
+    });
+
+    await act(async () => {
+      fireEvent.input(await screen.findByPlaceholderText('Search docs'), {
+        target: { value: 'react' },
+      });
+    });
+
+    await act(async () => {
+      shouldReturnResults = false;
+      fireEvent.input(await screen.findByPlaceholderText('Search docs'), {
+        target: { value: 'nothing' },
+      });
+    });
+
+    expect(await screen.findByText(/Try searching for/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'React' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hooks' })).toBeInTheDocument();
+  });
+
   describe('ask AI integration', () => {
     it('updates placeholder when ask AI is available', async () => {
       render(<DocSearch askAi="assistant" />);

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -1,35 +1,37 @@
 import { render, act, fireEvent, screen, cleanup } from '@testing-library/react';
+import type { LiteClient, SearchResponse, SearchResponses } from 'algoliasearch/lite';
 import React, { type JSX } from 'react';
 import { describe, it, expect, afterEach } from 'vitest';
 
 import '@testing-library/jest-dom/vitest';
 
 import { DocSearch as DocSearchComponent } from '../DocSearch';
-import type { DocSearchProps } from '../DocSearch';
+import type { DocSearchProps, DocSearchTransformClient } from '../DocSearch';
 
 function DocSearch(props: Partial<DocSearchProps>): JSX.Element {
   return <DocSearchComponent appId="woo" apiKey="foo" indexName="bar" {...props} />;
 }
 
 // mock empty response
-function noResultSearch(_queries: any, _requestOptions?: any): Promise<any> {
-  return new Promise((resolve) => {
-    resolve({
-      results: [
-        {
-          hits: [],
-          hitsPerPage: 0,
-          nbHits: 0,
-          nbPages: 0,
-          page: 0,
-          processingTimeMS: 0,
-          exhaustiveNbHits: true,
-          params: '',
-          query: '',
-        },
-      ],
-    });
-  });
+function noResultSearch<T = unknown>(
+  _queries: Parameters<LiteClient['search']>[0],
+  _requestOptions?: Parameters<LiteClient['search']>[1],
+): Promise<SearchResponses<T>> {
+  return Promise.resolve({
+    results: [
+      {
+        hits: [] as T[],
+        hitsPerPage: 0,
+        nbHits: 0,
+        nbPages: 0,
+        page: 0,
+        processingTimeMS: 0,
+        exhaustiveNbHits: true,
+        params: '',
+        query: '',
+      } as SearchResponse<T>,
+    ],
+  } as SearchResponses<T>);
 }
 
 describe('api', () => {
@@ -265,56 +267,57 @@ describe('api', () => {
   it('renders no-results suggestions from previous successful searches', async () => {
     let shouldReturnResults = true;
 
-    const search = () => {
-      return new Promise((resolve) => {
-        resolve({
-          results: shouldReturnResults
-            ? [
-                {
-                  hits: [
-                    {
-                      hierarchy: { lvl0: 'React' },
-                      objectID: '1',
-                      url: 'https://react.dev',
-                      content: 'React content',
-                      type: 'lvl0',
-                    },
-                    {
-                      hierarchy: { lvl0: 'Hooks' },
-                      objectID: '2',
-                      url: 'https://react.dev/hooks',
-                      content: 'Hooks content',
-                      type: 'lvl0',
-                    },
-                  ],
-                  hitsPerPage: 20,
-                  nbHits: 2,
-                  nbPages: 1,
-                  page: 0,
-                  processingTimeMS: 0,
-                  exhaustiveNbHits: true,
-                  params: '',
-                  query: 'react',
-                },
-              ]
-            : [
-                {
-                  hits: [],
-                  hitsPerPage: 0,
-                  nbHits: 0,
-                  nbPages: 0,
-                  page: 0,
-                  processingTimeMS: 0,
-                  exhaustiveNbHits: true,
-                  params: '',
-                  query: 'nothing',
-                },
-              ],
-        });
-      });
+    const search = async <T = unknown>(
+      _queries: Parameters<LiteClient['search']>[0],
+      _requestOptions?: Parameters<LiteClient['search']>[1],
+    ): Promise<SearchResponses<T>> => {
+      return {
+        results: shouldReturnResults
+          ? [
+              {
+                hits: [
+                  {
+                    hierarchy: { lvl0: 'React' },
+                    objectID: '1',
+                    url: 'https://react.dev',
+                    content: 'React content',
+                    type: 'lvl0',
+                  },
+                  {
+                    hierarchy: { lvl0: 'Hooks' },
+                    objectID: '2',
+                    url: 'https://react.dev/hooks',
+                    content: 'Hooks content',
+                    type: 'lvl0',
+                  },
+                ] as T[],
+                hitsPerPage: 20,
+                nbHits: 2,
+                nbPages: 1,
+                page: 0,
+                processingTimeMS: 0,
+                exhaustiveNbHits: true,
+                params: '',
+                query: 'react',
+              } as SearchResponse<T>,
+            ]
+          : [
+              {
+                hits: [] as T[],
+                hitsPerPage: 0,
+                nbHits: 0,
+                nbPages: 0,
+                page: 0,
+                processingTimeMS: 0,
+                exhaustiveNbHits: true,
+                params: '',
+                query: 'nothing',
+              } as SearchResponse<T>,
+            ],
+      } as SearchResponses<T>;
     };
 
-    render(<DocSearch transformSearchClient={(searchClient) => ({ ...searchClient, search })} />);
+    render(<DocSearch transformSearchClient={(searchClient) => ({ ...searchClient, search: search as DocSearchTransformClient['search'] }) as DocSearchTransformClient} />);
 
     await act(async () => {
       fireEvent.click(await screen.findByText('Search'));
@@ -355,8 +358,8 @@ describe('api', () => {
           askAi="assistant"
           transformSearchClient={(searchClient) => ({
             ...searchClient,
-            search: noResultSearch,
-          })}
+            search: noResultSearch as DocSearchTransformClient['search'],
+          }) as DocSearchTransformClient}
         />,
       );
 


### PR DESCRIPTION
## Description

Fixes an issue where "Try searching for" suggestions were not displayed on the no-results screen.

The issue was caused by `searchSuggestions` being converted from an array into an object-like structure when updating the state in `DocSearchModal`.

`NoResultsScreen` expects `searchSuggestions` to remain an array and uses array operations such as `.length` and `.slice()`. Because the value was stored with the wrong shape, the no-results suggestions were silently skipped.

Closes #2922

## Changes

- Updated `DocSearchModal` to preserve `searchSuggestions` as an array by using array spread instead of object spread.
- Added a regression test covering the previous successful search → no-results flow.

## Root Cause

Before:

```ts
searchSuggestions: {
  ...(previousSuggestions ?? []),
  ...Object.keys(sources)
}


This converted the array into an object:

{
  0: "Suggestion A",
  1: "Suggestion B"
}

After:

searchSuggestions: [
  ...(previousSuggestions ?? []),
  ...Object.keys(sources)
]

This keeps the expected array structure:

[
  "Suggestion A",
  "Suggestion B"
]
Test Plan
Before
Open the DocSearch modal.
Perform a search that returns results to populate suggestions.
Search for a query that returns no results.
Verify that the "Try searching for" suggestions are missing.
After

Added a regression test verifying that previous search suggestions are displayed on the no-results screen.

Command:

yarn vitest run packages/docsearch-react/src/__tests__/api.test.tsx -t "renders no-results suggestions from previous successful searches"

Result:

✓ 1 passed
✓ 14 skipped

The targeted regression test passes with this change.

Note: The full API test file still reports an unrelated Ask AI failure in this environment.


---

## Commit message

```bash
fix(docsearch-react): preserve searchSuggestions array shape