### PR TITLE
chore: version v5.0.0-beta.1

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,6 +16,8 @@
     "@docsearch/website": "4.6.0"
   },
   "changesets": [
+    "sharp-donkeys-search",
+    "tidy-moons-argue",
     "vast-numbers-read"
   ]
 }

--- a/adapters/docusaurus-theme-search-algolia/CHANGELOG.md
+++ b/adapters/docusaurus-theme-search-algolia/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @docsearch/docusaurus-adapter
 
+## 5.0.0-beta.1
+
+### Patch Changes
+
+- 09861c8: Align CSS class and animation names with the `DocSearch-` naming convention.
+
+  - The `shimmer` utility class is now `DocSearch-shimmer`
+  - Fixed a typo in `DocSearck-AskAiScreen-MessageContent-Stopped`, now
+    `DocSearch-AskAiScreen-MessageContent-Stopped`
+  - Keyframes renamed to kebab-case: `shimmerText` → `shimmer-text`,
+    `slideDown` → `slide-down`, `fadeIn` → `fade-in`
+  - Dark theme selectors use `:root[data-theme='dark']` instead of
+    `html[data-theme='dark']`
+  - Dropped redundant type qualifiers from `.DocSearch-Hits-padded` and
+    `.DocSearch-Hit-Select-Icon` selectors, slightly lowering their specificity
+
+  If you override these classes or keyframes in custom styles, update your
+  selectors accordingly.
+
+- Updated dependencies [f8e0678]
+- Updated dependencies [09861c8]
+  - @docsearch/react@5.0.0-beta.1
+  - @docsearch/modal@5.0.0-beta.1
+  - @docsearch/sidepanel@5.0.0-beta.1
+  - @docsearch/core@5.0.0-beta.1
+
 ## 5.0.0-beta.0
 
 ### Major Changes

--- a/adapters/docusaurus-theme-search-algolia/package.json
+++ b/adapters/docusaurus-theme-search-algolia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsearch/docusaurus-adapter",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "description": "Algolia search component for Docusaurus.",
   "main": "lib/index.js",
   "sideEffects": [

--- a/examples/demo-js/package.json
+++ b/examples/demo-js/package.json
@@ -10,9 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@docsearch/css": "5.0.0-beta.0",
-    "@docsearch/js": "5.0.0-beta.0",
-    "@docsearch/sidepanel-js": "5.0.0-beta.0"
+    "@docsearch/css": "5.0.0-beta.1",
+    "@docsearch/js": "5.0.0-beta.1",
+    "@docsearch/sidepanel-js": "5.0.0-beta.1"
   },
   "devDependencies": {
     "vite": "^6.0.7"

--- a/packages/docsearch-core/CHANGELOG.md
+++ b/packages/docsearch-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @docsearch/core
 
+## 5.0.0-beta.1
+
 ## 5.0.0-beta.0
 
 ### Major Changes

--- a/packages/docsearch-core/package.json
+++ b/packages/docsearch-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docsearch/core",
   "description": "Core package logic for DocSearch",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "license": "MIT",
   "type": "module",
   "homepage": "https://docsearch.algolia.com",

--- a/packages/docsearch-css/CHANGELOG.md
+++ b/packages/docsearch-css/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @docsearch/css
 
+## 5.0.0-beta.1
+
+### Patch Changes
+
+- 09861c8: Align CSS class and animation names with the `DocSearch-` naming convention.
+
+  - The `shimmer` utility class is now `DocSearch-shimmer`
+  - Fixed a typo in `DocSearck-AskAiScreen-MessageContent-Stopped`, now
+    `DocSearch-AskAiScreen-MessageContent-Stopped`
+  - Keyframes renamed to kebab-case: `shimmerText` → `shimmer-text`,
+    `slideDown` → `slide-down`, `fadeIn` → `fade-in`
+  - Dark theme selectors use `:root[data-theme='dark']` instead of
+    `html[data-theme='dark']`
+  - Dropped redundant type qualifiers from `.DocSearch-Hits-padded` and
+    `.DocSearch-Hit-Select-Icon` selectors, slightly lowering their specificity
+
+  If you override these classes or keyframes in custom styles, update your
+  selectors accordingly.
+
 ## 5.0.0-beta.0
 
 ### Major Changes

--- a/packages/docsearch-css/package.json
+++ b/packages/docsearch-css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docsearch/css",
   "description": "Styles for DocSearch.",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
   "repository": {

--- a/packages/docsearch-js/CHANGELOG.md
+++ b/packages/docsearch-js/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @docsearch/js
 
+## 5.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f8e0678]
+- Updated dependencies [09861c8]
+  - @docsearch/react@5.0.0-beta.1
+  - @docsearch/core@5.0.0-beta.1
+
 ## 5.0.0-beta.0
 
 ### Major Changes

--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docsearch/js",
   "description": "JavaScript package for DocSearch, the best search experience for docs.",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
   "repository": {
@@ -33,8 +33,8 @@
     "watch": "tsdown --watch"
   },
   "dependencies": {
-    "@docsearch/core": "5.0.0-beta.0",
-    "@docsearch/react": "5.0.0-beta.0"
+    "@docsearch/core": "5.0.0-beta.1",
+    "@docsearch/react": "5.0.0-beta.1"
   },
   "devDependencies": {
     "htm": "3.1.1",

--- a/packages/docsearch-modal/CHANGELOG.md
+++ b/packages/docsearch-modal/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @docsearch/modal
 
+## 5.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f8e0678]
+- Updated dependencies [09861c8]
+  - @docsearch/react@5.0.0-beta.1
+  - @docsearch/core@5.0.0-beta.1
+
 ## 5.0.0-beta.0
 
 ### Major Changes

--- a/packages/docsearch-modal/package.json
+++ b/packages/docsearch-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docsearch/modal",
   "description": "DocSearch modal package for keyword search and Ask AI.",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
   "repository": {
@@ -35,8 +35,8 @@
     "watch": "tsdown --watch"
   },
   "dependencies": {
-    "@docsearch/core": "5.0.0-beta.0",
-    "@docsearch/react": "5.0.0-beta.0"
+    "@docsearch/core": "5.0.0-beta.1",
+    "@docsearch/react": "5.0.0-beta.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.6.3",

--- a/packages/docsearch-react/CHANGELOG.md
+++ b/packages/docsearch-react/CHANGELOG.md
@@ -1,5 +1,45 @@
 # @docsearch/react
 
+## 5.0.0-beta.1
+
+### Patch Changes
+
+- f8e0678: fix(askai): support Agent Studio's batched MCP search tool
+
+  The Algolia MCP search tool can now issue multiple queries in a single tool
+  call (`queries[]`), which previously rendered as an empty query and broke
+  consecutive tool-call aggregation.
+
+  - `AlgoliaMCPSearchTool["input"]` accepts both the legacy single-query shape
+    and the new batched `queries[]` shape, and tolerates a missing `output`
+  - New `getSearchToolQueries()` helper normalizes query extraction across
+    `searchIndex`, batched MCP, and legacy MCP tool parts
+  - `ToolCall` renders one tool state per query for both `input-available` and
+    `output-available` states
+  - `groupConsecutiveToolResults` reuses the shared helper so batched calls
+    aggregate correctly
+  - Fix `AggregatedSearchBlock` keyboard handler comparing `e.key === 'enter'`,
+    which never matched and made query chips unusable via keyboard
+
+- 09861c8: Align CSS class and animation names with the `DocSearch-` naming convention.
+
+  - The `shimmer` utility class is now `DocSearch-shimmer`
+  - Fixed a typo in `DocSearck-AskAiScreen-MessageContent-Stopped`, now
+    `DocSearch-AskAiScreen-MessageContent-Stopped`
+  - Keyframes renamed to kebab-case: `shimmerText` → `shimmer-text`,
+    `slideDown` → `slide-down`, `fadeIn` → `fade-in`
+  - Dark theme selectors use `:root[data-theme='dark']` instead of
+    `html[data-theme='dark']`
+  - Dropped redundant type qualifiers from `.DocSearch-Hits-padded` and
+    `.DocSearch-Hit-Select-Icon` selectors, slightly lowering their specificity
+
+  If you override these classes or keyframes in custom styles, update your
+  selectors accordingly.
+
+- Updated dependencies [09861c8]
+  - @docsearch/css@5.0.0-beta.1
+  - @docsearch/core@5.0.0-beta.1
+
 ## 5.0.0-beta.0
 
 ### Major Changes

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docsearch/react",
   "description": "React package for DocSearch, the best search experience for docs.",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
   "repository": {
@@ -50,8 +50,8 @@
     "@ai-sdk/react": "^2.0.30",
     "@algolia/autocomplete-core": "1.19.2",
     "@base-ui/react": "^1.5.0",
-    "@docsearch/core": "5.0.0-beta.0",
-    "@docsearch/css": "5.0.0-beta.0",
+    "@docsearch/core": "5.0.0-beta.1",
+    "@docsearch/css": "5.0.0-beta.1",
     "ai": "^5.0.30",
     "algoliasearch": "^5.28.0",
     "marked": "^16.3.0",
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@algolia/autocomplete-core": "1.19.2",
-    "@docsearch/core": "5.0.0-beta.0",
+    "@docsearch/core": "5.0.0-beta.1",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",
     "preact": "11.0.0-beta.0",

--- a/packages/docsearch-sidepanel-js/CHANGELOG.md
+++ b/packages/docsearch-sidepanel-js/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @docsearch/sidepanel-js
 
+## 5.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f8e0678]
+- Updated dependencies [09861c8]
+  - @docsearch/react@5.0.0-beta.1
+  - @docsearch/core@5.0.0-beta.1
+
 ## 5.0.0-beta.0
 
 ### Major Changes

--- a/packages/docsearch-sidepanel-js/package.json
+++ b/packages/docsearch-sidepanel-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docsearch/sidepanel-js",
   "description": "JavaScript package for DocSearch Sidepanel for interfacing with Ask AI.",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
   "repository": {
@@ -32,8 +32,8 @@
     "watch": "tsdown --watch"
   },
   "dependencies": {
-    "@docsearch/core": "5.0.0-beta.0",
-    "@docsearch/react": "5.0.0-beta.0"
+    "@docsearch/core": "5.0.0-beta.1",
+    "@docsearch/react": "5.0.0-beta.1"
   },
   "devDependencies": {
     "preact": "11.0.0-beta.0",

--- a/packages/docsearch-sidepanel/CHANGELOG.md
+++ b/packages/docsearch-sidepanel/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @docsearch/sidepanel
 
+## 5.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [f8e0678]
+- Updated dependencies [09861c8]
+  - @docsearch/react@5.0.0-beta.1
+  - @docsearch/css@5.0.0-beta.1
+  - @docsearch/core@5.0.0-beta.1
+
 ## 5.0.0-beta.0
 
 ### Major Changes

--- a/packages/docsearch-sidepanel/package.json
+++ b/packages/docsearch-sidepanel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@docsearch/sidepanel",
   "description": "DocSearch Sidepanel package for Ask AI.",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "license": "MIT",
   "homepage": "https://docsearch.algolia.com",
   "repository": {
@@ -38,9 +38,9 @@
     "watch": "tsdown --watch"
   },
   "dependencies": {
-    "@docsearch/core": "5.0.0-beta.0",
-    "@docsearch/css": "5.0.0-beta.0",
-    "@docsearch/react": "5.0.0-beta.0"
+    "@docsearch/core": "5.0.0-beta.1",
+    "@docsearch/css": "5.0.0-beta.1",
+    "@docsearch/react": "5.0.0-beta.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.6.3",


### PR DESCRIPTION
Bump to `5.0.0-beta.1`