### PR TITLE
fix(website): use bare @import for tailwindcss

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "adapters/docusaurus-theme-search-algolia": {
       "name": "@docsearch/docusaurus-adapter",
-      "version": "4.6.0",
+      "version": "5.0.0-beta.0",
       "dependencies": {
         "@algolia/autocomplete-core": "1.19.2",
         "@docsearch/core": "workspace:*",
@@ -115,7 +115,7 @@
     },
     "packages/docsearch-core": {
       "name": "@docsearch/core",
-      "version": "4.6.0",
+      "version": "5.0.0-beta.0",
       "devDependencies": {
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "16.2.0",
@@ -137,7 +137,7 @@
     },
     "packages/docsearch-css": {
       "name": "@docsearch/css",
-      "version": "4.6.0",
+      "version": "5.0.0-beta.0",
       "devDependencies": {
         "browserslist": "4.28.2",
         "lightningcss": "1.32.0",
@@ -146,7 +146,7 @@
     },
     "packages/docsearch-js": {
       "name": "@docsearch/js",
-      "version": "4.6.0",
+      "version": "5.0.0-beta.0",
       "dependencies": {
         "@docsearch/core": "4.6.0",
         "@docsearch/react": "4.6.0",
@@ -160,7 +160,7 @@
     },
     "packages/docsearch-modal": {
       "name": "@docsearch/modal",
-      "version": "4.6.0",
+      "version": "5.0.0-beta.0",
       "dependencies": {
         "@docsearch/core": "4.6.0",
         "@docsearch/react": "4.6.0",
@@ -185,13 +185,13 @@
     },
     "packages/docsearch-react": {
       "name": "@docsearch/react",
-      "version": "4.6.0",
+      "version": "5.0.0-beta.0",
       "dependencies": {
         "@ai-sdk/react": "^2.0.30",
         "@algolia/autocomplete-core": "1.19.2",
         "@base-ui/react": "^1.5.0",
-        "@docsearch/core": "4.6.0",
-        "@docsearch/css": "4.6.0",
+        "@docsearch/core": "5.0.0-beta.0",
+        "@docsearch/css": "5.0.0-beta.0",
         "ai": "^5.0.30",
         "algoliasearch": "^5.28.0",
         "marked": "^16.3.0",
@@ -199,7 +199,7 @@
       },
       "devDependencies": {
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.6.0",
+        "@docsearch/core": "5.0.0-beta.0",
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "16.2.0",
         "preact": "11.0.0-beta.0",
@@ -222,7 +222,7 @@
     },
     "packages/docsearch-sidepanel": {
       "name": "@docsearch/sidepanel",
-      "version": "4.6.0",
+      "version": "5.0.0-beta.0",
       "dependencies": {
         "@docsearch/core": "4.6.0",
         "@docsearch/css": "4.6.0",
@@ -248,7 +248,7 @@
     },
     "packages/docsearch-sidepanel-js": {
       "name": "@docsearch/sidepanel-js",
-      "version": "4.6.0",
+      "version": "5.0.0-beta.0",
       "dependencies": {
         "@docsearch/core": "4.6.0",
         "@docsearch/react": "4.6.0",

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -1,7 +1,8 @@
 /* stylelint-disable selector-max-id */
 
 /* tailwindcss */
-@import url('tailwindcss');
+/* stylelint-disable-next-line import-notation */
+@import 'tailwindcss';
 
 /* fonts */
 @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Sora:wght@100..800&display=swap');


### PR DESCRIPTION
## Summary

`packages/website/src/css/custom.css` imported Tailwind with `url()` notation:

```css
@import url('tailwindcss');
```

Tailwind's build-time `@import` cannot use `url()` notation — with `url()` the
statement is treated as a plain runtime CSS import and passed straight through
instead of being processed by Tailwind, so the framework's styles never get
injected. Changed to the bare form:

```css
/* stylelint-disable-next-line import-notation */
@import 'tailwindcss';
```

The `stylelint-disable-next-line import-notation` comment is required because
`stylelint-config-standard` enforces `url()` notation for imports, which is the
opposite of what Tailwind needs here.

## Also included

`bun.lock` is synced with the `5.0.0-beta.0` versions already committed to the
`package.json` files in #2925 — the lockfile still recorded `4.6.0`. Unrelated to
the CSS fix, but it's a real staleness that `bun install` resolves.

## No changeset

Intentionally omitted. This only touches `@docsearch/website`, which is in the
`ignore` list in `.changeset/config.json` and is not published. Adding a
changeset for an ignored package makes `changeset version` fail, and attaching it
to a published package instead would force a spurious `5.0.0-beta.1` release of
all eight public packages via the `fixed` group, for a change that ships zero
library code.

## Test plan

- `bun run lint:css` passes clean.
- `bun website:start` - Tailwind utility classes render on the docs site.