### PR TITLE
feat(react): remove deprecated index props

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import '@docsearch/css';
 docsearch({
   container: '#docsearch',
   appId: 'YOUR_APP_ID',
-  indexName: 'YOUR_INDEX_NAME',
+  indices: ['YOUR_INDEX_NAME'],
   apiKey: 'YOUR_SEARCH_API_KEY',
 });
 ```

--- a/adapters/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/adapters/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -73,13 +73,11 @@ type AskAiOptions = NonNullable<ThemeConfigDocSearch['askAi']> &
 type AdapterDocSearchProps = Omit<
   DocSearchAskAiModalProps,
   | 'askAi'
-  | 'indexName'
   | 'initialScrollY'
   | 'isAskAiActive'
   | 'isHybridModeSupported'
   | 'onAskAiToggle'
   | 'onClose'
-  | 'searchParameters'
 > & {
   askAi?: AskAiOptions;
   contextualSearch?: boolean;

--- a/examples/demo-js/src/main.ts
+++ b/examples/demo-js/src/main.ts
@@ -70,7 +70,7 @@ logSidepanelState(sidepanelInstance, 'sidepanel initial state');
 
 docsearchInstance = docsearch({
   container: '#docsearch',
-  indexName: 'docsearch',
+  indices: ['docsearch'],
   appId: 'PMZUYBQDAK',
   apiKey: '24b09689d5b4223813d9b8e48563c8f6',
   askAi: {

--- a/examples/demo-react/src/examples/basic-askai.tsx
+++ b/examples/demo-react/src/examples/basic-askai.tsx
@@ -29,7 +29,7 @@ export default function BasicAskAI({
 }): JSX.Element {
   return (
     <DocSearchAI
-      indexName="docsearch"
+      indices={['docsearch']}
       appId="PMZUYBQDAK"
       apiKey="24b09689d5b4223813d9b8e48563c8f6"
       askAi={{

--- a/examples/demo-react/src/examples/basic.tsx
+++ b/examples/demo-react/src/examples/basic.tsx
@@ -7,7 +7,7 @@ import type { DemoTheme } from '../App';
 export default function Basic({ theme }: { theme: DemoTheme }): JSX.Element {
   return (
     <DocSearch
-      indexName="docsearch"
+      indices={['docsearch']}
       appId="PMZUYBQDAK"
       apiKey="24b09689d5b4223813d9b8e48563c8f6"
       translations={{ button: { buttonText: 'Keyword search' } }}

--- a/examples/demo-react/src/examples/composable.tsx
+++ b/examples/demo-react/src/examples/composable.tsx
@@ -14,7 +14,7 @@ export default function Composable({
     <DocSearch theme={theme}>
       <DocSearchButton translations={{ buttonText: 'Composable API' }} />
       <DocSearchAskAiModal
-        indexName="docsearch"
+        indices={['docsearch']}
         appId="PMZUYBQDAK"
         apiKey="24b09689d5b4223813d9b8e48563c8f6"
         askAi={{

--- a/examples/demo-react/src/examples/default.tsx
+++ b/examples/demo-react/src/examples/default.tsx
@@ -11,7 +11,7 @@ export default function DefaultExperience({
 }): JSX.Element {
   return (
     <DocSearch
-      indexName="docsearch"
+      indices={['docsearch']}
       appId="PMZUYBQDAK"
       apiKey="24b09689d5b4223813d9b8e48563c8f6"
       theme={theme}

--- a/examples/demo-react/src/examples/dynamic-import-modal.tsx
+++ b/examples/demo-react/src/examples/dynamic-import-modal.tsx
@@ -94,7 +94,7 @@ function DocSearch({ theme }: { theme: DemoTheme }): JSX.Element {
         searchContainer.current &&
         createPortal(
           <DocSearchModal
-            indexName="docsearch"
+            indices={['docsearch']}
             appId="PMZUYBQDAK"
             apiKey="24b09689d5b4223813d9b8e48563c8f6"
             askAi={{

--- a/examples/demo-react/src/examples/hybrid.tsx
+++ b/examples/demo-react/src/examples/hybrid.tsx
@@ -15,7 +15,7 @@ export default function BasicHybrid({
     <DocSearch theme={theme}>
       <DocSearchButton />
       <DocSearchAskAiModal
-        indexName="docsearch"
+        indices={['docsearch']}
         appId="PMZUYBQDAK"
         apiKey="24b09689d5b4223813d9b8e48563c8f6"
         askAi={{

--- a/examples/demo-react/src/examples/w-hit-component.tsx
+++ b/examples/demo-react/src/examples/w-hit-component.tsx
@@ -130,7 +130,7 @@ export default function WHitComponent({
 }): JSX.Element {
   return (
     <DocSearch
-      indexName="docsearch"
+      indices={['docsearch']}
       appId="PMZUYBQDAK"
       apiKey="24b09689d5b4223813d9b8e48563c8f6"
       insights={true}

--- a/examples/demo-react/src/examples/w-hit-transformItems.tsx
+++ b/examples/demo-react/src/examples/w-hit-transformItems.tsx
@@ -28,18 +28,22 @@ export default function WTransformItems({
 }): JSX.Element {
   return (
     <DocSearchAI
-      indexName="crawler_doc"
+      indices={[
+        {
+          name: 'crawler_doc',
+          searchParameters: {
+            attributesToRetrieve: ['*'],
+            attributesToSnippet: ['*'],
+            hitsPerPage: 20,
+          },
+        },
+      ]}
       appId="PMZUYBQDAK"
       apiKey="24b09689d5b4223813d9b8e48563c8f6"
       askAi={{
         assistantId: 'ccdec697-e3fe-465b-a1c3-657e7bf18aef',
       }}
       insights={true}
-      searchParameters={{
-        attributesToRetrieve: ['*'],
-        attributesToSnippet: ['*'],
-        hitsPerPage: 20,
-      }}
       transformItems={(items) => {
         return items.map((item: any) => ({
           objectID: item.objectID,

--- a/examples/demo-react/src/examples/w-results-footer.tsx
+++ b/examples/demo-react/src/examples/w-results-footer.tsx
@@ -32,7 +32,7 @@ export default function WResultsFooter({
 }): JSX.Element {
   return (
     <DocSearch
-      indexName="docsearch"
+      indices={['docsearch']}
       appId="PMZUYBQDAK"
       apiKey="24b09689d5b4223813d9b8e48563c8f6"
       insights={true}

--- a/packages/docsearch-js/README.md
+++ b/packages/docsearch-js/README.md
@@ -34,7 +34,7 @@ import '@docsearch/css';
 docsearch({
   container: '#docsearch',
   appId: 'YOUR_APP_ID',
-  indexName: 'YOUR_INDEX_NAME',
+  indices: ['YOUR_INDEX_NAME'],
   apiKey: 'YOUR_SEARCH_API_KEY',
 });
 ```
@@ -53,7 +53,7 @@ import '@docsearch/css';
 docsearch({
   container: '#docsearch',
   appId: 'YOUR_APP_ID',
-  indexName: 'YOUR_INDEX_NAME',
+  indices: ['YOUR_INDEX_NAME'],
   apiKey: 'YOUR_SEARCH_API_KEY',
 });
 ```
@@ -66,7 +66,7 @@ For a standalone keyword-only script, load the explicit UMD file:
   window.docsearch({
     container: '#docsearch',
     appId: 'YOUR_APP_ID',
-    indexName: 'YOUR_INDEX_NAME',
+    indices: ['YOUR_INDEX_NAME'],
     apiKey: 'YOUR_SEARCH_API_KEY',
   });
 </script>

--- a/packages/docsearch-modal/src/__tests__/DocSearchModal.test.tsx
+++ b/packages/docsearch-modal/src/__tests__/DocSearchModal.test.tsx
@@ -21,7 +21,7 @@ const INDEX_NAME = 'test_index';
 const DEFAULT_PROPS: DocSearchModalProps = {
   appId: APP_ID,
   apiKey: API_KEY,
-  indexName: INDEX_NAME,
+  indices: [INDEX_NAME],
   transformSearchClient(searchClient) {
     return {
       ...searchClient,

--- a/packages/docsearch-react/README.md
+++ b/packages/docsearch-react/README.md
@@ -27,7 +27,7 @@ function App() {
   return (
     <DocSearch
       appId="YOUR_APP_ID"
-      indexName="YOUR_INDEX_NAME"
+      indices={['YOUR_INDEX_NAME']}
       apiKey="YOUR_SEARCH_API_KEY"
     />
   );

--- a/packages/docsearch-react/src/AskAiScreenState.tsx
+++ b/packages/docsearch-react/src/AskAiScreenState.tsx
@@ -61,7 +61,7 @@ export interface AskAiScreenStateProps<
   canHandleAskAi: boolean;
   inputRef: React.MutableRefObject<HTMLInputElement | null>;
   hitComponent: DocSearchProps['hitComponent'];
-  indexName: DocSearchProps['indexName'];
+  indexName: string;
   messages: UseChatHelpers<AIMessage>['messages'];
   tools: ToolCalls;
   status: UseChatHelpers<AIMessage>['status'];

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -49,18 +49,11 @@ export interface DocSearchProps {
   /** Public api key with search permissions for the index. */
   apiKey: string;
   /**
-   * Name of the algolia index to query.
-   *
-   * @deprecated `indexName` will be removed in a future version. Please use
-   *   `indices` property going forward.
-   */
-  indexName?: string;
-  /**
    * List of indices and _optional_ searchParameters to be used for search.
    *
    * @see {@link https://docsearch.algolia.com/docs/api#indices}
    */
-  indices?: Array<DocSearchIndex | string>;
+  indices: Array<DocSearchIndex | string>;
   /**
    * Facets to display as keyword-search filter controls. Values are read
    * dynamically from the configured Algolia indices.
@@ -72,13 +65,6 @@ export interface DocSearchProps {
   theme?: DocSearchTheme;
   /** Placeholder text for the search input. */
   placeholder?: string;
-  /**
-   * Additional algolia search parameters to merge into each query.
-   *
-   * @deprecated `searchParameters` will be removed in a future version. Please
-   *   use `indices` property going forward.
-   */
-  searchParameters?: SearchParamsObject;
   /** Maximum number of hits to display per source/group. */
   maxResultsPerGroup?: number;
   /** Hook to post-process hits before rendering. */

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -98,9 +98,7 @@ export function DocSearchAskAiModal({
   isAskAiActive = false,
   recentSearchesLimit = 7,
   recentSearchesWithFavoritesLimit = 4,
-  indices = [],
-  indexName,
-  searchParameters,
+  indices,
   facets,
   isHybridModeSupported = false,
   ...props
@@ -173,11 +171,9 @@ export function DocSearchAskAiModal({
   const indexes = React.useMemo(
     () =>
       normalizeDocSearchIndexes({
-        indexName,
         indices,
-        searchParameters,
       }),
-    [indexName, indices, searchParameters]
+    [indices]
   );
   const defaultIndexName = indexes[0].name;
 

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -67,9 +67,7 @@ export function DocSearchModal({
   insights = false,
   recentSearchesLimit = 7,
   recentSearchesWithFavoritesLimit = 4,
-  indices = [],
-  indexName,
-  searchParameters,
+  indices,
   facets,
   ...props
 }: DocSearchModalProps): JSX.Element {
@@ -112,11 +110,9 @@ export function DocSearchModal({
   const indexes = React.useMemo(
     () =>
       normalizeDocSearchIndexes({
-        indexName,
         indices,
-        searchParameters,
       }),
-    [indexName, indices, searchParameters]
+    [indices]
   );
   const defaultIndexName = indexes[0].name;
 

--- a/packages/docsearch-react/src/ScreenState.tsx
+++ b/packages/docsearch-react/src/ScreenState.tsx
@@ -41,7 +41,7 @@ export interface ScreenStateProps<
   ) => void;
   inputRef: React.MutableRefObject<HTMLInputElement | null>;
   hitComponent: DocSearchProps['hitComponent'];
-  indexName: DocSearchProps['indexName'];
+  indexName: string;
   disableUserPersonalization: boolean;
   resultsFooterComponent: DocSearchProps['resultsFooterComponent'];
   translations: ScreenStateTranslations;

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -16,7 +16,7 @@ import type { DocSearchAIProps } from '../DocSearchAI';
 
 function DocSearch(props: Partial<DocSearchProps>): JSX.Element {
   return (
-    <DocSearchComponent appId="woo" apiKey="foo" indexName="bar" {...props} />
+    <DocSearchComponent appId="woo" apiKey="foo" indices={['bar']} {...props} />
   );
 }
 
@@ -25,7 +25,7 @@ function DocSearchAI(props: Partial<DocSearchAIProps>): JSX.Element {
     <DocSearchAIComponent
       appId="woo"
       apiKey="foo"
-      indexName="bar"
+      indices={['bar']}
       askAi="assistant"
       {...props}
     />

--- a/packages/docsearch-react/src/__tests__/imperative.test.tsx
+++ b/packages/docsearch-react/src/__tests__/imperative.test.tsx
@@ -22,7 +22,7 @@ function DocSearch(props: TestDocSearchProps): JSX.Element {
       ref={ref}
       appId="woo"
       apiKey="foo"
-      indexName="bar"
+      indices={['bar']}
       {...props}
     />
   );

--- a/packages/docsearch-react/src/__tests__/keyboardShortcuts.test.tsx
+++ b/packages/docsearch-react/src/__tests__/keyboardShortcuts.test.tsx
@@ -14,7 +14,7 @@ import type { DocSearchProps } from '../DocSearch';
 
 function DocSearch(props: Partial<DocSearchProps>): JSX.Element {
   return (
-    <DocSearchComponent appId="woo" apiKey="foo" indexName="bar" {...props} />
+    <DocSearchComponent appId="woo" apiKey="foo" indices={['bar']} {...props} />
   );
 }
 

--- a/packages/docsearch-react/src/utils/__tests__/normalizeDocSearchIndexes.test.ts
+++ b/packages/docsearch-react/src/utils/__tests__/normalizeDocSearchIndexes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeDocSearchIndexes } from '../normalizeDocSearchIndexes';
+
+describe('normalizeDocSearchIndexes', () => {
+  it('normalizes string and configured indices in order', () => {
+    expect(
+      normalizeDocSearchIndexes({
+        indices: [
+          'docs',
+          { name: 'blog', searchParameters: { facetFilters: ['type:blog'] } },
+        ],
+      })
+    ).toEqual([
+      { name: 'docs' },
+      { name: 'blog', searchParameters: { facetFilters: ['type:blog'] } },
+    ]);
+  });
+
+  it('requires at least one index', () => {
+    expect(() => normalizeDocSearchIndexes({ indices: [] })).toThrow(
+      'Must supply at least one `indices` entry for DocSearch'
+    );
+  });
+
+  it('reports a configuration error when indices are missing at runtime', () => {
+    expect(() => normalizeDocSearchIndexes({} as never)).toThrow(
+      'Must supply at least one `indices` entry for DocSearch'
+    );
+  });
+
+  it('reports a configuration error when indices are not an array at runtime', () => {
+    expect(() =>
+      normalizeDocSearchIndexes({ indices: 'docs' } as never)
+    ).toThrow('Must supply at least one `indices` entry for DocSearch');
+  });
+});

--- a/packages/docsearch-react/src/utils/normalizeDocSearchIndexes.ts
+++ b/packages/docsearch-react/src/utils/normalizeDocSearchIndexes.ts
@@ -1,36 +1,17 @@
-import type { SearchParamsObject } from 'algoliasearch/lite';
-
 import type { DocSearchIndex } from '../DocSearch';
 
 export function normalizeDocSearchIndexes({
-  indexName,
-  indices = [],
-  searchParameters,
+  indices,
 }: {
-  indexName?: string;
-  indices?: Array<DocSearchIndex | string>;
-  searchParameters?: SearchParamsObject;
+  indices: Array<DocSearchIndex | string>;
 }): DocSearchIndex[] {
-  const indexes: DocSearchIndex[] = [];
-
-  if (indexName && indexName !== '') {
-    indexes.push({
-      name: indexName,
-      searchParameters,
-    });
+  if (!Array.isArray(indices) || indices.length < 1) {
+    throw new Error('Must supply at least one `indices` entry for DocSearch');
   }
 
-  if (indices.length > 0) {
-    indices.forEach((index) => {
-      indexes.push(typeof index === 'string' ? { name: index } : index);
-    });
-  }
-
-  if (indexes.length < 1) {
-    throw new Error(
-      'Must supply either `indexName` or `indices` for DocSearch to work'
-    );
-  }
+  const indexes = indices.map((index) =>
+    typeof index === 'string' ? { name: index } : index
+  );
 
   return indexes;
 }

--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -47,7 +47,7 @@ Your Algolia Search API key.
 
 ## `indices`
 
-> `type: Array<string | DocSearchIndex>`
+> `type: Array<string | DocSearchIndex>` | **required**
 
 The list of indices and their _optional_ `searchParameters` to be used for keyword search.
 
@@ -58,8 +58,6 @@ The list of indices and their _optional_ `searchParameters` to be used for keywo
 The ordering matters in the list, as results are ordered based on `indices` order.
 
 :::
-
-> While `indexName` is in deprecation, it is required to pass either `indices` or `indexName`. Not passing either will result in an `Error` being thrown.
 
 <Tabs
   groupId="language"
@@ -129,20 +127,6 @@ in case you want to use custom `searchParameters` for the index
 
 </TabItem>
 </Tabs>
-
-## `indexName`
-
-> `type: string` | **deprecated**
-
-:::warning[Deprecation warning]
-
-`indexName` is currently being planned for deprecation. The new recommended property to use is `indices`.
-
-:::
-
-Your Algolia index name.
-
-> While `indexName` is in deprecation, it is required to pass either `indices` or `indexName`. Not passing either will result in an `Error` being thrown.
 
 ## `placeholder`
 
@@ -272,18 +256,6 @@ These parameters provide the essential functionality for Ask AI while keeping th
 :::
 
 If `agentStudio` is true, the Ask AI chat will use Algolia's [Agent Studio][12] as the chat backend instead of the Ask AI backend. Learn more on [Algolia Agent Studio Docs][13].
-
-## `searchParameters`
-
-> `type: SearchParameters` | **optional** | **deprecated**
-
-:::warning[Deprecation warning]
-
-`searchParameters` is currently being planned for deprecation. The new recommended property to use is `indices`.
-
-:::
-
-The [Algolia Search Parameters][7].
 
 ## `transformItems`
 
@@ -872,7 +844,7 @@ const portalEl = document.getElementById('modal-root');
 <DocSearch
   appId="YOUR_APP_ID"
   apiKey="YOUR_SEARCH_API_KEY"
-  indexName="YOUR_INDEX_NAME"
+  indices={['YOUR_INDEX_NAME']}
   // render the modal inside #modal-root instead of document.body
   portalContainer={portalEl}
 />;
@@ -888,7 +860,7 @@ docsearch({
   container: '#modal-root',
   appId: 'YOUR_APP_ID',
   apiKey: 'YOUR_SEARCH_API_KEY',
-  indexName: 'YOUR_INDEX_NAME',
+  indices: ['YOUR_INDEX_NAME'],
 });
 ```
 

--- a/packages/website/docs/composable-api.mdx
+++ b/packages/website/docs/composable-api.mdx
@@ -89,7 +89,7 @@ export function Search() {
     <DocSearch>
       <DocSearchButton />
       <DocSearchModal
-        indexName="YOUR_INDEX_NAME"
+        indices={['YOUR_INDEX_NAME']}
         appId="YOUR_APP_ID"
         apiKey="YOUR_SEARCH_API_KEY"
       />
@@ -123,7 +123,7 @@ export function Search() {
     <DocSearch>
       <DocSearchButton />
       <DocSearchModal
-        indexName="YOUR_INDEX_NAME"
+        indices={['YOUR_INDEX_NAME']}
         appId="YOUR_APP_ID"
         apiKey="YOUR_SEARCH_API_KEY"
         // With just a simple assistant ID
@@ -160,7 +160,7 @@ export default function AdvancedSearch(): JSX.Element {
         translations={{ buttonText: 'Advanced Search' }} // Change the displayed text on the DocSearchButton
       />
       <DocSearchModal
-        indexName="YOUR_INDEX_NAME"
+        indices={['YOUR_INDEX_NAME']}
         appId="YOUR_APP_ID"
         apiKey="YOUR_SEARCH_API_KEY"
         askAi={{ // Enable Ask AI
@@ -219,7 +219,7 @@ export default function DynamicModal() {
       <DocSearchButton onClick={loadModal} />
       {modalLoaded && DocSearchModal && (
         <DocSearchModal
-          indexName="YOUR_INDEX_NAME"
+          indices={['YOUR_INDEX_NAME']}
           appId="YOUR_APP_ID"
           apiKey="YOUR_SEARCH_API_KEY"
         />
@@ -289,17 +289,11 @@ interface DocSearchModalProps {
    */
   apiKey: string;
   /**
-   * Name of the algolia index to query.
-   *
-   * @deprecated `indexName` will be removed in a future version. Please use `indices` property going forward.
-   */
-  indexName?: string;
-  /**
    * List of indices and _optional_ searchParameters to be used for search.
    *
    * @see {@link https://docsearch.algolia.com/docs/api#indices}
    */
-  indices?: Array<DocSearchIndex | string>;
+  indices: Array<DocSearchIndex | string>;
   /**
    * Configuration or assistant id to enable ask ai mode. Pass a string assistant id or a full config object.
    */

--- a/packages/website/docs/crawler.mdx
+++ b/packages/website/docs/crawler.mdx
@@ -54,7 +54,7 @@ docsearch({
   container: '#docsearch',
   appId: 'YOUR_NEW_ALGOLIA_APP_ID',
   apiKey: 'YOUR_NEW_ALGOLIA_SEARCH_API_KEY',
-  indexName: 'YOUR_INDEX_NAME', // it does not change
+  indices: ['YOUR_INDEX_NAME'], // it does not change
 });
 ```
 
@@ -66,7 +66,7 @@ docsearch({
 <DocSearch
   appId="YOUR_NEW_ALGOLIA_APP_ID"
   apiKey="YOUR_NEW_ALGOLIA_SEARCH_API_KEY"
-  indexName="YOUR_INDEX_NAME" // it does not change
+  indices={['YOUR_INDEX_NAME']} // it does not change
 />
 ```
 

--- a/packages/website/docs/migrating-from-v3.md
+++ b/packages/website/docs/migrating-from-v3.md
@@ -36,7 +36,7 @@ DocSearch v4 introduces seamless support for Algolia's Ask AI feature. To enable
 
 ```javascript
 docsearch({
-  indexName: 'YOUR_INDEX_NAME',
+  indices: ['YOUR_INDEX_NAME'],
   apiKey: 'YOUR_SEARCH_API_KEY',
   appId: 'YOUR_APP_ID',
   askAi: 'YOUR_ALGOLIA_ASSISTANT_ID',
@@ -51,7 +51,7 @@ If you prefer to utilize Ask AI with a separate configuration from your main Doc
 
 ```javascript
 docsearch({
-  indexName: 'YOUR_INDEX_NAME',
+  indices: ['YOUR_INDEX_NAME'],
   apiKey: 'YOUR_SEARCH_API_KEY',
   appId: 'YOUR_APP_ID',
   askAi: {

--- a/packages/website/docs/sidepanel/hybrid.mdx
+++ b/packages/website/docs/sidepanel/hybrid.mdx
@@ -92,7 +92,7 @@ function HybridMode() {
     <DocSearch>
       <DocSearchButton />
       <DocSearchModal
-        indexName="YOUR_INDEX_NAME"
+        indices={['YOUR_INDEX_NAME']}
         appId="YOUR_APP_ID"
         apiKey="YOUR_SEARCH_API_KEY"
         askAi="YOUR_ASSISTANT_ID" // Or configuration object
@@ -144,7 +144,7 @@ sidepanelInstance = sidepanel({
 
 docsearchInstance = docsearch({
   container: "#docsearch",
-  indexName: "YOUR_INDEX_NAME",
+  indices: ["YOUR_INDEX_NAME"],
   appId: "YOUR_APP_ID",
   apiKey: "YOUR_SEARCH_API_KEY",
   askAi: "YOUR_ASSISTANT_ID",  // Or configuration object

--- a/packages/website/docs/v4/askai-markdown-indexing.mdx
+++ b/packages/website/docs/v4/askai-markdown-indexing.mdx
@@ -165,7 +165,7 @@ Configure DocSearch to use both your main keyword index and your markdown index 
 
 ```js
 docsearch({
-  indexName: 'YOUR_INDEX_NAME', // Main DocSearch keyword index
+  indices: ['YOUR_INDEX_NAME'], // Main DocSearch keyword index
   apiKey: 'YOUR_SEARCH_API_KEY',
   appId: 'YOUR_APP_ID',
   askAi: {
@@ -186,7 +186,7 @@ docsearch({
 
 ```jsx
 <DocSearch
-  indexName="YOUR_INDEX_NAME" // Main DocSearch keyword index
+  indices={['YOUR_INDEX_NAME']} // Main DocSearch keyword index
   apiKey="YOUR_SEARCH_API_KEY"
   appId="YOUR_APP_ID"
   askAi={{
@@ -205,7 +205,7 @@ docsearch({
 
 </Tabs>
 
-- `indexName`: Your main DocSearch index for keyword search.
+- `indices`: Your main DocSearch index or indices for keyword search.
 - `askAi.indexName`: The markdown index you created for Ask AI context.
 - `assistantId`: The ID of your configured Ask AI assistant.
 - `searchParameters.facetFilters`: Optional filters to limit Ask AI context (useful for multi-language sites).


### PR DESCRIPTION
## Summary
- remove deprecated root `indexName` and `searchParameters` props in favor of required `indices`
- validate that runtime `indices` values are non-empty arrays
- migrate examples, tests, and relevant documentation while preserving Ask AI, sidepanel, and crawler index configuration

## Verification
- `bun run test --run packages/docsearch-react/src/utils/__tests__/normalizeDocSearchIndexes.test.ts packages/docsearch-react/src/__tests__/api.test.tsx packages/docsearch-modal/src/__tests__/DocSearchModal.test.tsx`
- `bun run test:types`
- `bun run --sequential build:stage:base build:stage:react build:stage:consumers build:stage:adapter`