### PR TITLE
fix: crash on the demo

### DIFF
--- a/packages/website/src/components/demo/DemoApp.jsx
+++ b/packages/website/src/components/demo/DemoApp.jsx
@@ -183,7 +183,7 @@ export default function DemoApp() {
               translations={{ buttonText: 'Search or ask a question' }}
             />
             <DocSearchAskAiModal
-              indexName={INDEX_NAME}
+              indices={[INDEX_NAME]}
               appId={APP_ID}
               apiKey={API_KEY}
               askAi={{ assistantId: ASSISTANT_ID }}


### PR DESCRIPTION
## Summary
- Configure the composable Ask AI demo modal with the required `indices` array.
- Preserve `indexName` for the sidepanel, whose API still requires it.

## Test plan
- [x] Checked `DemoApp.jsx` for linter errors.