### PR TITLE
fix: General v5 fixes

### DIFF
--- a/packages/docsearch-react/src/AskAiScreenState.tsx
+++ b/packages/docsearch-react/src/AskAiScreenState.tsx
@@ -30,6 +30,7 @@ import type {
   SuggestedQuestionHit,
 } from './types';
 import type { AIMessage, AskAiState, ToolCalls } from './types/AskiAi';
+import { isQueryEmpty } from './utils';
 
 export type AskAiScreenStateTranslations = Partial<{
   errorScreen: ErrorScreenTranslations;
@@ -141,7 +142,7 @@ export const AskAiScreenState = React.memo(
       return <ErrorScreen translations={translations?.errorScreen} />;
     }
 
-    if (!props.state.query) {
+    if (isQueryEmpty(props.state.query)) {
       return (
         <AskAiStartScreen
           {...props}
@@ -175,14 +176,27 @@ export const AskAiScreenState = React.memo(
       </>
     );
   },
-  function areEqual(_prevProps, nextProps) {
-    // We don't update the screen when Autocomplete is loading or stalled to
-    // avoid UI flashes:
-    //  - Empty screen → Results screen
-    //  - NoResults screen → NoResults screen with another query
-    return (
+  function areEqual(prevProps, nextProps) {
+    const askAiStateChanged =
+      prevProps.isAskAiActive !== nextProps.isAskAiActive ||
+      prevProps.askAiState !== nextProps.askAiState ||
+      prevProps.canHandleAskAi !== nextProps.canHandleAskAi;
+
+    // Something triggered an Ask AI related state change, perform a new render
+    if (askAiStateChanged) {
+      return false;
+    }
+
+    const isLoading =
       nextProps.state.status === 'loading' ||
-      nextProps.state.status === 'stalled'
-    );
+      nextProps.state.status === 'stalled';
+
+    const isWaitingForCollections =
+      nextProps.state.status === 'idle' &&
+      !isQueryEmpty(nextProps.state.query) &&
+      prevProps.state.query !== nextProps.state.query &&
+      prevProps.state.collections === nextProps.state.collections;
+
+    return isLoading || isWaitingForCollections;
   }
 );

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -38,6 +38,7 @@ import { useSuggestedQuestions } from './useSuggestedQuestions';
 import {
   identity,
   isModifierEvent,
+  isQueryEmpty,
   noop,
   scrollTo as scrollToUtils,
   SOURCE_IDS,
@@ -386,7 +387,7 @@ export function DocSearchAskAiModal({
         setState(changes.state);
       },
       async getSources({ query, state: sourcesState, setContext, setStatus }) {
-        if (!query) {
+        if (isQueryEmpty(query)) {
           const noQuerySources = buildNoQuerySources({
             recentSearches,
             favoriteSearches,
@@ -526,7 +527,7 @@ export function DocSearchAskAiModal({
   if (
     state.status === 'idle' &&
     hasCollections === false &&
-    state.query.length === 0 &&
+    isQueryEmpty(state.query) &&
     !isAskAiActive
   ) {
     showDocsearchDropdown = false;
@@ -546,7 +547,7 @@ export function DocSearchAskAiModal({
           {...autocomplete}
           state={state}
           placeholder={placeholder || 'Search docs'}
-          autoFocus={initialQuery.length === 0}
+          autoFocus={isQueryEmpty(initialQuery)}
           inputRef={inputRef}
           isFromSelection={
             Boolean(initialQuery) && initialQuery === initialQueryFromSelection
@@ -571,7 +572,7 @@ export function DocSearchAskAiModal({
         />
       }
       filterBar={
-        !isAskAiActive && state.query !== '' ? (
+        !isAskAiActive && !isQueryEmpty(state.query) ? (
           <FacetBar
             facets={visibleFacets}
             selections={facetSelections}

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -25,6 +25,7 @@ import { useSearchClient } from './useSearchClient';
 import {
   identity,
   isModifierEvent,
+  isQueryEmpty,
   noop,
   scrollTo as scrollToUtils,
 } from './utils';
@@ -170,7 +171,7 @@ export function DocSearchModal({
         setState(changes.state);
       },
       getSources({ query, state: sourcesState, setContext, setStatus }) {
-        if (!query) {
+        if (isQueryEmpty(query)) {
           const noQuerySources = buildNoQuerySources({
             recentSearches,
             favoriteSearches,
@@ -240,7 +241,7 @@ export function DocSearchModal({
   if (
     state.status === 'idle' &&
     hasCollections === false &&
-    state.query.length === 0
+    isQueryEmpty(state.query)
   ) {
     showDocsearchDropdown = false;
   }
@@ -259,7 +260,7 @@ export function DocSearchModal({
           {...autocomplete}
           state={state}
           placeholder={placeholder || 'Search docs'}
-          autoFocus={initialQuery.length === 0}
+          autoFocus={isQueryEmpty(initialQuery)}
           inputRef={inputRef}
           isFromSelection={
             Boolean(initialQuery) && initialQuery === initialQueryFromSelection
@@ -269,7 +270,7 @@ export function DocSearchModal({
         />
       }
       filterBar={
-        state.query !== '' ? (
+        !isQueryEmpty(state.query) ? (
           <FacetBar
             facets={visibleFacets}
             selections={facetSelections}

--- a/packages/docsearch-react/src/ScreenState.tsx
+++ b/packages/docsearch-react/src/ScreenState.tsx
@@ -16,6 +16,7 @@ import type { ResultsScreenTranslations } from './ResultsScreen';
 import { ResultsScreen } from './ResultsScreen';
 import type { StoredSearchPlugin } from './stored-searches';
 import type { InternalDocSearchHit, StoredDocSearchHit } from './types';
+import { isQueryEmpty } from './utils';
 
 export type ScreenStateTranslations = Partial<{
   errorScreen: ErrorScreenTranslations;
@@ -56,7 +57,7 @@ export const ScreenState = React.memo(
       return <ErrorScreen translations={translations?.errorScreen} />;
     }
 
-    if (!props.state.query) {
+    if (isQueryEmpty(props.state.query)) {
       return (
         <KeywordStartScreen
           {...props}
@@ -79,14 +80,17 @@ export const ScreenState = React.memo(
       <ResultsScreen {...props} translations={translations?.resultsScreen} />
     );
   },
-  function areEqual(_prevProps, nextProps) {
-    // We don't update the screen when Autocomplete is loading or stalled to
-    // avoid UI flashes:
-    //  - Empty screen → Results screen
-    //  - NoResults screen → NoResults screen with another query
-    return (
+  function areEqual(prevProps, nextProps) {
+    const isLoading =
       nextProps.state.status === 'loading' ||
-      nextProps.state.status === 'stalled'
-    );
+      nextProps.state.status === 'stalled';
+
+    const isWaitingForCollections =
+      nextProps.state.status === 'idle' &&
+      !isQueryEmpty(nextProps.state.query) &&
+      prevProps.state.query !== nextProps.state.query &&
+      prevProps.state.collections === nextProps.state.collections;
+
+    return isLoading || isWaitingForCollections;
   }
 );

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -342,6 +342,33 @@ describe('api', () => {
     });
   });
 
+  describe('whitespace-only queries', () => {
+    it('does not trigger a keyword search', async () => {
+      const search = vi.fn(noResultSearch);
+
+      render(
+        <DocSearch
+          transformSearchClient={(searchClient) => ({
+            ...searchClient,
+            search,
+          })}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      await act(async () => {
+        fireEvent.input(await screen.findByPlaceholderText('Search docs'), {
+          target: { value: ' \t\n ' },
+        });
+      });
+
+      expect(search).not.toHaveBeenCalled();
+    });
+  });
+
   describe('ask AI integration', () => {
     it('updates placeholder when ask AI is available', async () => {
       render(<DocSearchAI />);

--- a/packages/docsearch-react/src/__tests__/screenState.test.tsx
+++ b/packages/docsearch-react/src/__tests__/screenState.test.tsx
@@ -1,0 +1,200 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import React, { type JSX } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+import { AskAiScreenState } from '../AskAiScreenState';
+import { ScreenState } from '../ScreenState';
+
+function Hit({ children }: { children: React.ReactNode }): JSX.Element {
+  return <>{children}</>;
+}
+
+function createState(overrides = {}): any {
+  return {
+    activeItemId: null,
+    collections: [],
+    completion: null,
+    context: { searchSuggestions: [] },
+    isOpen: true,
+    query: 'old query',
+    status: 'idle',
+    ...overrides,
+  };
+}
+
+function createProps(overrides = {}): any {
+  return {
+    state: createState(),
+    recentSearches: { add: vi.fn(), remove: vi.fn() },
+    favoriteSearches: { add: vi.fn(), remove: vi.fn() },
+    conversations: { add: vi.fn(), remove: vi.fn() },
+    getItemProps: vi.fn(() => ({})),
+    getListProps: vi.fn(() => ({})),
+    inputRef: React.createRef<HTMLInputElement>(),
+    onItemClick: vi.fn(),
+    refresh: vi.fn(),
+    setQuery: vi.fn(),
+    hitComponent: Hit,
+    indexName: 'docs',
+    disableUserPersonalization: false,
+    resultsFooterComponent: () => null,
+    translations: {},
+    hasCollections: false,
+    ...overrides,
+  };
+}
+
+function createAskAiProps(overrides = {}): any {
+  return {
+    ...createProps(),
+    askAiState: 'initial',
+    canHandleAskAi: true,
+    isAskAiActive: false,
+    messages: [],
+    onAskAiToggle: vi.fn(),
+    onNewConversation: vi.fn(),
+    selectAskAiQuestion: vi.fn(),
+    selectSuggestedQuestion: vi.fn(),
+    status: 'ready',
+    suggestedQuestions: [],
+    tools: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ScreenState', () => {
+  it('keeps the current screen until collections for a new query arrive', () => {
+    const collections = [];
+    const props = createProps({ state: createState({ collections }) });
+    const view = render(<ScreenState {...props} />);
+
+    expect(screen.getByText(/No results found for/)).toHaveTextContent(
+      'old query'
+    );
+
+    view.rerender(
+      <ScreenState
+        {...props}
+        state={createState({ collections, query: 'new query' })}
+      />
+    );
+
+    expect(screen.getByText(/No results found for/)).toHaveTextContent(
+      'old query'
+    );
+
+    view.rerender(
+      <ScreenState
+        {...props}
+        state={createState({
+          collections: [{ items: [], source: { sourceId: 'hits_docs' } }],
+          query: 'new query',
+        })}
+      />
+    );
+
+    expect(screen.getByText(/No results found for/)).toHaveTextContent(
+      'new query'
+    );
+  });
+
+  it('keeps the current screen while loading or stalled', () => {
+    const collections = [];
+    const props = createProps({ state: createState({ collections }) });
+    const view = render(<ScreenState {...props} />);
+
+    view.rerender(
+      <ScreenState
+        {...props}
+        state={createState({
+          collections,
+          query: 'loading query',
+          status: 'loading',
+        })}
+      />
+    );
+
+    expect(screen.getByText(/No results found for/)).toHaveTextContent(
+      'old query'
+    );
+
+    view.rerender(
+      <ScreenState
+        {...props}
+        state={createState({
+          collections,
+          query: 'stalled query',
+          status: 'stalled',
+        })}
+      />
+    );
+
+    expect(screen.getByText(/No results found for/)).toHaveTextContent(
+      'old query'
+    );
+  });
+
+  it('renders the start screen when the query is cleared', () => {
+    const props = createProps();
+    const view = render(<ScreenState {...props} />);
+
+    view.rerender(
+      <ScreenState {...props} state={createState({ query: '' })} />
+    );
+
+    expect(screen.queryByText(/No results found for/)).not.toBeInTheDocument();
+    expect(
+      document.querySelector('.DocSearch-Dropdown-Container')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('AskAiScreenState', () => {
+  it('leaves Ask AI when the active mode changes during a pending search', () => {
+    const collections = [];
+    const props = createAskAiProps({
+      isAskAiActive: true,
+      state: createState({ collections }),
+    });
+    const view = render(<AskAiScreenState {...props} />);
+
+    expect(document.querySelector('.DocSearch-AskAiScreen')).toBeInTheDocument();
+
+    view.rerender(
+      <AskAiScreenState
+        {...props}
+        isAskAiActive={false}
+        state={createState({ collections, query: 'new query' })}
+      />
+    );
+
+    expect(
+      document.querySelector('.DocSearch-AskAiScreen')
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/No results found for/)).toHaveTextContent(
+      'new query'
+    );
+  });
+
+  it('rerenders when the Ask AI screen state changes', () => {
+    const props = createAskAiProps({
+      askAiState: 'new-conversation',
+      isAskAiActive: true,
+    });
+    const view = render(<AskAiScreenState {...props} />);
+
+    expect(screen.getByText('How can I help you today?')).toBeInTheDocument();
+
+    view.rerender(<AskAiScreenState {...props} askAiState="initial" />);
+
+    expect(
+      screen.queryByText('How can I help you today?')
+    ).not.toBeInTheDocument();
+    expect(document.querySelector('.DocSearch-AskAiScreen')).toBeInTheDocument();
+  });
+});

--- a/packages/docsearch-react/src/__tests__/searchbox.test.tsx
+++ b/packages/docsearch-react/src/__tests__/searchbox.test.tsx
@@ -234,6 +234,21 @@ describe('AskAiSearchBox', () => {
     expect(onAskAgain).toHaveBeenCalledWith('follow up');
   });
 
+  it('does not submit a whitespace-only follow-up question', () => {
+    const onAskAgain = vi.fn();
+
+    renderAskAiSearchBox({
+      state: createState({ query: ' \t\n ' }),
+      onAskAgain,
+    });
+
+    fireEvent.keyDown(screen.getByPlaceholderText('Ask another question...'), {
+      key: 'Enter',
+    });
+
+    expect(onAskAgain).not.toHaveBeenCalled();
+  });
+
   it('uses thread-depth behavior in Ask AI mode', () => {
     const onNewConversation = vi.fn();
 

--- a/packages/docsearch-react/src/components/AskAiSearchBox.tsx
+++ b/packages/docsearch-react/src/components/AskAiSearchBox.tsx
@@ -16,7 +16,7 @@ import { Menu } from '../Menu';
 import { ModalHeading } from '../ModalHeading';
 import type { InternalDocSearchHit } from '../types';
 import type { AIMessage, AskAiState } from '../types/AskiAi';
-import { getCollection } from '../utils';
+import { getCollection, isQueryEmpty } from '../utils';
 
 import { SearchBoxForm } from './ui/SearchBoxForm';
 
@@ -162,7 +162,11 @@ export function AskAiSearchBox({
       // block these up, down, enter listeners when Ask AI is active
       if (props.isAskAiActive && blockedKeys.has(e.key)) {
         // enter key asks another question
-        if (e.key === 'Enter' && !isAskAiStreaming && props.state.query) {
+        if (
+          e.key === 'Enter' &&
+          !isAskAiStreaming &&
+          !isQueryEmpty(props.state.query)
+        ) {
           props.onAskAgain(props.state.query);
         }
 

--- a/packages/docsearch-react/src/components/ui/Menu.tsx
+++ b/packages/docsearch-react/src/components/ui/Menu.tsx
@@ -7,13 +7,13 @@ export function Menu({ ...props }: MenuPrimitive.Root.Props): JSX.Element {
   return <MenuPrimitive.Root {...props} />;
 }
 
-function MenuTrigger({
-  className,
-  ...props
-}: MenuPrimitive.Trigger.Props): JSX.Element {
+const MenuTrigger = React.forwardRef<
+  HTMLButtonElement,
+  MenuPrimitive.Trigger.Props
+>(({ className, ...props }, ref): JSX.Element => {
   const cn = `DocSearch-Menu-Trigger${className ? ` ${className}` : ''}`;
-  return <MenuPrimitive.Trigger className={cn} {...props} />;
-}
+  return <MenuPrimitive.Trigger className={cn} ref={ref} {...props} />;
+});
 
 Menu.Trigger = MenuTrigger;
 

--- a/packages/docsearch-react/src/utils/__tests__/isQueryEmpty.test.ts
+++ b/packages/docsearch-react/src/utils/__tests__/isQueryEmpty.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { isQueryEmpty } from '../isQueryEmpty';
+
+describe('isQueryEmpty', () => {
+  it.each([
+    ['an omitted query', undefined],
+    ['an empty query', ''],
+    ['a whitespace-only query', ' \t\n '],
+  ])('returns true for %s', (_, query) => {
+    expect(isQueryEmpty(query)).toBe(true);
+  });
+
+  it('returns false for a query containing text', () => {
+    expect(isQueryEmpty('  DocSearch  ')).toBe(false);
+  });
+});

--- a/packages/docsearch-react/src/utils/index.ts
+++ b/packages/docsearch-react/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './getNestedValue';
 export * from './groupBy';
 export * from './identity';
 export * from './isModifierEvent';
+export * from './isQueryEmpty';
 export * from './keyboard';
 export * from './noop';
 export * from './removeHighlightTags';

--- a/packages/docsearch-react/src/utils/isQueryEmpty.ts
+++ b/packages/docsearch-react/src/utils/isQueryEmpty.ts
@@ -1,0 +1,7 @@
+export function isQueryEmpty(query?: string): boolean {
+  if (!query || query.trim().length === 0) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

General fixes for `v5`.

## Changes

- Fix `ref` console error for a `FacetMenu`
- Whitespace only search/conversation input does not trigger requests
- Fix flash of no results page on search