### PR TITLE
chore: push git tags on version release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,7 @@ jobs:
           command: |
             export NPM_ID_TOKEN="$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')"
             bun run release
+            git push --follow-tags
   test_playwright:
     <<: *playwright
     steps:


### PR DESCRIPTION
We weren't pushing our git tags after release, this fixes that.