### PR TITLE
feat(v5): Add new footerAction prop

### DIFF
--- a/.changeset/sixty-lights-try.md
+++ b/.changeset/sixty-lights-try.md
@@ -1,0 +1,14 @@
+---
+"@docsearch/react": patch
+"@docsearch/css": patch
+"@docsearch/js": patch
+---
+
+feat(v5): add customizable footer action
+
+- New `footerAction` prop renders a custom action in the modal footer,
+  before the Algolia logo, inside `.DocSearch-Footer-Action`
+- `@docsearch/js` supports `footerAction` via template patterns (html helper,
+  JSX, or function-based)
+- Fixes typing differences between `@docsearch/react` and `@docsearch/js`
+- Restyle the footer with a `.DocSearch-Footer-Actions` wrapper

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "adapters/docusaurus-theme-search-algolia": {
       "name": "@docsearch/docusaurus-adapter",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "dependencies": {
         "@algolia/autocomplete-core": "1.19.2",
         "@docsearch/core": "workspace:*",
@@ -115,7 +115,7 @@
     },
     "packages/docsearch-core": {
       "name": "@docsearch/core",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "devDependencies": {
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "16.2.0",
@@ -137,7 +137,7 @@
     },
     "packages/docsearch-css": {
       "name": "@docsearch/css",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "devDependencies": {
         "browserslist": "4.28.2",
         "lightningcss": "1.32.0",
@@ -146,7 +146,7 @@
     },
     "packages/docsearch-js": {
       "name": "@docsearch/js",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "dependencies": {
         "@docsearch/core": "4.6.0",
         "@docsearch/react": "4.6.0",
@@ -160,7 +160,7 @@
     },
     "packages/docsearch-modal": {
       "name": "@docsearch/modal",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "dependencies": {
         "@docsearch/core": "4.6.0",
         "@docsearch/react": "4.6.0",
@@ -185,13 +185,13 @@
     },
     "packages/docsearch-react": {
       "name": "@docsearch/react",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "dependencies": {
         "@ai-sdk/react": "^2.0.30",
         "@algolia/autocomplete-core": "1.19.2",
         "@base-ui/react": "^1.5.0",
-        "@docsearch/core": "5.0.0-beta.1",
-        "@docsearch/css": "5.0.0-beta.1",
+        "@docsearch/core": "5.0.0-beta.2",
+        "@docsearch/css": "5.0.0-beta.2",
         "ai": "^5.0.30",
         "algoliasearch": "^5.28.0",
         "marked": "^16.3.0",
@@ -199,7 +199,7 @@
       },
       "devDependencies": {
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "5.0.0-beta.1",
+        "@docsearch/core": "5.0.0-beta.2",
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "16.2.0",
         "preact": "11.0.0-beta.0",
@@ -222,7 +222,7 @@
     },
     "packages/docsearch-sidepanel": {
       "name": "@docsearch/sidepanel",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "dependencies": {
         "@docsearch/core": "4.6.0",
         "@docsearch/css": "4.6.0",
@@ -248,7 +248,7 @@
     },
     "packages/docsearch-sidepanel-js": {
       "name": "@docsearch/sidepanel-js",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "dependencies": {
         "@docsearch/core": "4.6.0",
         "@docsearch/react": "4.6.0",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/docsearch-css/dist/style.css",
-      "maxSize": "8.05 kB"
+      "maxSize": "8.1 kB"
     },
     {
       "path": "packages/docsearch-react/dist/umd/index.js",

--- a/examples/demo-js/package.json
+++ b/examples/demo-js/package.json
@@ -10,9 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@docsearch/css": "5.0.0-beta.2",
-    "@docsearch/js": "5.0.0-beta.2",
-    "@docsearch/sidepanel-js": "5.0.0-beta.2"
+    "@docsearch/css": "workspace:*",
+    "@docsearch/js": "workspace:*",
+    "@docsearch/sidepanel-js": "workspace:*"
   },
   "devDependencies": {
     "vite": "^6.0.7"

--- a/examples/demo-js/src/main.ts
+++ b/examples/demo-js/src/main.ts
@@ -1,7 +1,4 @@
-import docsearch, {
-  type DocSearchInstance,
-  type TemplateHelpers,
-} from '@docsearch/js';
+import docsearch, { type DocSearchInstance } from '@docsearch/js';
 import sidepanel, { type SidepanelInstance } from '@docsearch/sidepanel-js';
 
 import './app.css';
@@ -91,10 +88,7 @@ docsearchInstance = docsearch({
     // eslint-disable-next-line no-console
     console.log('[demo-js] docsearch onClose()');
   },
-  resultsFooterComponent: ({ state }, helpers?: TemplateHelpers) => {
-    const { html } = helpers || {};
-    if (!html) return null;
-
+  resultsFooterComponent: ({ state }, { html }) => {
     return html`
       <div class="DocSearch-HitsFooter">
         <a href="https://docsearch.algolia.com/apply" target="_blank">

--- a/examples/demo-react/src/examples/basic-askai.tsx
+++ b/examples/demo-react/src/examples/basic-askai.tsx
@@ -23,6 +23,10 @@ const customTools: ToolCalls = {
   },
 };
 
+const FooterAction = (): JSX.Element => {
+  return <span>Bonjour</span>;
+};
+
 export default function BasicAskAI({
   theme,
 }: {
@@ -50,9 +54,7 @@ export default function BasicAskAI({
       translations={{ button: { buttonText: 'Search with Ask AI' } }}
       theme={theme}
       resultBadgeKey="type"
-      footerAction={() => {
-        return <span>Hello world!</span>;
-      }}
+      footerAction={<FooterAction />}
     />
   );
 }

--- a/examples/demo-react/src/examples/basic-askai.tsx
+++ b/examples/demo-react/src/examples/basic-askai.tsx
@@ -50,6 +50,9 @@ export default function BasicAskAI({
       translations={{ button: { buttonText: 'Search with Ask AI' } }}
       theme={theme}
       resultBadgeKey="type"
+      footerAction={() => {
+        return <span>Hello world!</span>;
+      }}
     />
   );
 }

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -1034,7 +1034,6 @@
   border-block-start: 1px solid var(--docsearch-subtle-color);
   border-radius: 0 0 var(--docsearch-modal-radius) var(--docsearch-modal-radius);
   display: flex;
-  flex-direction: row-reverse;
   flex-shrink: 0;
   height: var(--docsearch-footer-height);
   justify-content: space-between;
@@ -1089,6 +1088,23 @@
   letter-spacing: normal;
   text-align: center;
   text-transform: uppercase;
+}
+
+.DocSearch-Footer-Actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+  width: 100%;
+
+  @media screen and (width > 768px) {
+    justify-content: unset;
+    width: auto;
+  }
+
+  &:not(:has(.DocSearch-Footer-Action)) .DocSearch-Logo {
+    margin-inline-start: auto;
+  }
 }
 
 /* Hide element accessibly, so that it is still accessible to

--- a/packages/docsearch-js/src/__tests__/createDocSearch.test.tsx
+++ b/packages/docsearch-js/src/__tests__/createDocSearch.test.tsx
@@ -1,21 +1,16 @@
 import { createElement, type JSX } from 'preact';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createDocSearch, type DocSearchInstance } from './createDocSearch';
-import type { FooterActionFn as KeywordFooterActionFn } from './docsearch';
-
-import type { FooterActionFn as AskAiFooterActionFn } from './index';
+import { createDocSearch, type DocSearchInstance } from '../createDocSearch';
+import type { FooterActionFn as KeywordFooterActionFn } from '../docsearch';
+import type { FooterActionFn as AskAiFooterActionFn } from '../index';
 
 interface TestComponentProps {
-  footerAction?: () => JSX.Element | null;
+  footerAction?: JSX.Element | null;
 }
 
 function TestComponent({ footerAction }: TestComponentProps): JSX.Element {
-  return createElement(
-    'div',
-    null,
-    footerAction && createElement(footerAction, null)
-  );
+  return createElement('div', null, footerAction);
 }
 
 const askAiFooterAction: AskAiFooterActionFn = (_props, { html }) =>

--- a/packages/docsearch-js/src/createDocSearch.test.tsx
+++ b/packages/docsearch-js/src/createDocSearch.test.tsx
@@ -1,0 +1,108 @@
+import { createElement, type JSX } from 'preact';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createDocSearch, type DocSearchInstance } from './createDocSearch';
+import type { FooterActionFn as KeywordFooterActionFn } from './docsearch';
+
+import type { FooterActionFn as AskAiFooterActionFn } from './index';
+
+interface TestComponentProps {
+  footerAction?: () => JSX.Element | null;
+}
+
+function TestComponent({ footerAction }: TestComponentProps): JSX.Element {
+  return createElement(
+    'div',
+    null,
+    footerAction && createElement(footerAction, null)
+  );
+}
+
+const askAiFooterAction: AskAiFooterActionFn = (_props, { html }) =>
+  html`<button type="button">Ask AI footer action</button>`;
+
+const keywordFooterAction: KeywordFooterActionFn = (_props, { html }) =>
+  html`<button type="button">Keyword footer action</button>`;
+
+describe('createDocSearch', () => {
+  let instance: DocSearchInstance | undefined;
+
+  afterEach(() => {
+    instance?.destroy();
+    instance = undefined;
+  });
+
+  it('adapts footerAction templates for the rendered component', () => {
+    const container = document.createElement('div');
+    const footerAction = (): JSX.Element =>
+      createElement('button', { type: 'button' }, 'Footer action');
+    const docsearch = createDocSearch<TestComponentProps>(
+      TestComponent,
+      'test'
+    );
+
+    instance = docsearch({ container, footerAction });
+
+    expect(container.textContent).toContain('Footer action');
+  });
+
+  it('provides the html helper to footerAction templates', () => {
+    const container = document.createElement('div');
+    const docsearch = createDocSearch<TestComponentProps>(
+      TestComponent,
+      'test'
+    );
+
+    instance = docsearch({ container, footerAction: askAiFooterAction });
+
+    expect(container.textContent).toContain('Ask AI footer action');
+  });
+
+  it('accepts footerAction templates from the keyword-only entry point', () => {
+    const container = document.createElement('div');
+    const docsearch = createDocSearch<TestComponentProps>(
+      TestComponent,
+      'test'
+    );
+
+    instance = docsearch({ container, footerAction: keywordFooterAction });
+
+    expect(container.textContent).toContain('Keyword footer action');
+  });
+
+  it('renders string and component footerAction template returns', () => {
+    const container = document.createElement('div');
+    const docsearch = createDocSearch<TestComponentProps>(
+      TestComponent,
+      'test'
+    );
+
+    instance = docsearch({
+      container,
+      footerAction: () => () =>
+        createElement('button', { type: 'button' }, 'Component footer action'),
+    });
+
+    expect(container.textContent).toContain('Component footer action');
+
+    instance.destroy();
+    instance = docsearch({
+      container,
+      footerAction: () => 'Text footer action',
+    });
+
+    expect(container.textContent).toContain('Text footer action');
+  });
+
+  it('supports footerAction templates that return null', () => {
+    const container = document.createElement('div');
+    const docsearch = createDocSearch<TestComponentProps>(
+      TestComponent,
+      'test'
+    );
+
+    instance = docsearch({ container, footerAction: () => null });
+
+    expect(container.textContent).toBe('');
+  });
+});

--- a/packages/docsearch-js/src/createDocSearch.tsx
+++ b/packages/docsearch-js/src/createDocSearch.tsx
@@ -29,7 +29,7 @@ export interface DocSearchCallbacks {
   interceptAskAiEvent?: (initialMessage: InitialAskAiMessage) => boolean | void;
 }
 
-export type TemplateHelpers = Record<string, unknown> & { html: typeof html };
+export type TemplateHelpers = { html: typeof html };
 
 // Defines the public facing interface for each "template" function
 type TemplateFnReturnType = JSX.Element | string | (() => JSX.Element) | null;
@@ -45,7 +45,7 @@ export type ResultsFooterComponentFn = (
 ) => TemplateFnReturnType;
 
 export type FooterActionFn = (
-  props: unknown,
+  props: never,
   helpers: TemplateHelpers
 ) => TemplateFnReturnType;
 
@@ -114,7 +114,7 @@ function createTemplateFunction<
   R = TemplateFnReturnType,
 >(
   original: ((props: P, helpers: TemplateHelpers) => R) | undefined
-): ((props: P) => JSX.Element) | undefined {
+): ((props: P) => JSX.Element | null) | undefined {
   if (!original) return undefined;
 
   return (props: P) => {
@@ -157,6 +157,8 @@ export function createDocSearch<TComponentProps, TInputProps = TComponentProps>(
     const ref = createRef<DocSearchRef>();
     let isReady = false;
 
+    const FooterAction = createTemplateFunction(footerAction);
+
     const props: TComponentProps = {
       ...rest,
       ref,
@@ -165,7 +167,9 @@ export function createDocSearch<TComponentProps, TInputProps = TComponentProps>(
         createTemplateFunction<ResultsFooterComponentProps>(
           resultsFooterComponent
         ),
-      footerAction: createTemplateFunction(footerAction),
+      footerAction: FooterAction
+        ? createElement(FooterAction, null)
+        : undefined,
       transformSearchClient: (searchClient: unknown): unknown => {
         if (
           typeof searchClient === 'object' &&

--- a/packages/docsearch-js/src/createDocSearch.tsx
+++ b/packages/docsearch-js/src/createDocSearch.tsx
@@ -1,4 +1,8 @@
 import type { DocSearchRef, InitialAskAiMessage } from '@docsearch/core';
+import type {
+  ResultsFooterComponentProps,
+  HitComponentProps,
+} from '@docsearch/react';
 import htm from 'htm';
 import type { ComponentType, JSX, Attributes } from 'preact';
 import {
@@ -25,10 +29,64 @@ export interface DocSearchCallbacks {
   interceptAskAiEvent?: (initialMessage: InitialAskAiMessage) => boolean | void;
 }
 
+export type TemplateHelpers = Record<string, unknown> & { html: typeof html };
+
+// Defines the public facing interface for each "template" function
+type TemplateFnReturnType = JSX.Element | string | (() => JSX.Element) | null;
+
+export type HitComponentFn = (
+  props: HitComponentProps,
+  helpers: TemplateHelpers
+) => TemplateFnReturnType;
+
+export type ResultsFooterComponentFn = (
+  props: ResultsFooterComponentProps,
+  helpers: TemplateHelpers
+) => TemplateFnReturnType;
+
+export type FooterActionFn = (
+  props: unknown,
+  helpers: TemplateHelpers
+) => TemplateFnReturnType;
+
 export type DocSearchProps<TProps> = DocSearchCallbacks &
-  Omit<TProps, 'onSidepanelClose' | 'onSidepanelOpen'> & {
+  Omit<
+    TProps,
+    | 'onSidepanelClose'
+    | 'onSidepanelOpen'
+    | 'hitComponent'
+    | 'resultsFooterComponent'
+    | 'footerAction'
+  > & {
     container: HTMLElement | string;
     environment?: typeof window;
+    /**
+     * Custom component to render an individual hit. Supports template patterns:
+     *
+     * - HTML strings with html helper: (props, { html }) => html`<div>...</div>`
+     * - JSX templates: (props) => <div>...</div>
+     * - Function-based templates: (props) => string | JSX.Element | Function.
+     */
+    hitComponent?: HitComponentFn;
+    /**
+     * Custom component rendered at the bottom of the results panel. Supports
+     * template patterns:
+     *
+     * - HTML strings with html helper: (props, { html }) => html`<div>...</div>`
+     * - JSX templates: (props) => <div>...</div>
+     * - Function-based templates: (props) => string | JSX.Element | Function.
+     */
+    resultsFooterComponent?: ResultsFooterComponentFn;
+    /**
+     * A custom action that can be rendered in the Modal's footer before the
+     * Algolia logo. The component will be rendered as a child of `<div
+     * className="DocSearch-Footer-Action" />`. Supports template patterns:
+     *
+     * - HTML strings with html helper: (props, { html }) => html`<div>...</div>`
+     * - JSX templates: (props) => <div>...</div>
+     * - Function-based templates: (props) => string | JSX.Element | Function.
+     */
+    footerAction?: FooterActionFn;
   };
 
 function getHTMLElement(
@@ -51,13 +109,11 @@ const html = htm.bind(createElement) as unknown as (
   ...values: unknown[]
 ) => JSX.Element;
 
-export type TemplateHelpers = Record<string, unknown> & { html: typeof html };
-
 function createTemplateFunction<
-  P extends Record<string, unknown>,
-  R = JSX.Element | string | (() => JSX.Element),
+  P = Record<string, unknown>,
+  R = TemplateFnReturnType,
 >(
-  original: ((props: P, helpers?: TemplateHelpers) => R) | undefined
+  original: ((props: P, helpers: TemplateHelpers) => R) | undefined
 ): ((props: P) => JSX.Element) | undefined {
   if (!original) return undefined;
 
@@ -73,15 +129,10 @@ function createTemplateFunction<
 }
 
 interface ComponentProps {
-  hitComponent?: (
-    props: Record<string, unknown>,
-    helpers?: TemplateHelpers
-  ) => JSX.Element;
-  resultsFooterComponent?: (
-    props: Record<string, unknown>,
-    helpers?: TemplateHelpers
-  ) => JSX.Element | null;
+  hitComponent?: HitComponentFn;
+  resultsFooterComponent?: ResultsFooterComponentFn;
   transformSearchClient?: (searchClient: unknown) => unknown;
+  footerAction?: FooterActionFn;
 }
 
 export function createDocSearch<TComponentProps, TInputProps = TComponentProps>(
@@ -96,6 +147,7 @@ export function createDocSearch<TComponentProps, TInputProps = TComponentProps>(
       transformSearchClient,
       hitComponent,
       resultsFooterComponent,
+      footerAction,
       ...rest
     } = input;
     const containerElement = getHTMLElement(
@@ -108,8 +160,12 @@ export function createDocSearch<TComponentProps, TInputProps = TComponentProps>(
     const props: TComponentProps = {
       ...rest,
       ref,
-      hitComponent: createTemplateFunction(hitComponent),
-      resultsFooterComponent: createTemplateFunction(resultsFooterComponent),
+      hitComponent: createTemplateFunction<HitComponentProps>(hitComponent),
+      resultsFooterComponent:
+        createTemplateFunction<ResultsFooterComponentProps>(
+          resultsFooterComponent
+        ),
+      footerAction: createTemplateFunction(footerAction),
       transformSearchClient: (searchClient: unknown): unknown => {
         if (
           typeof searchClient === 'object' &&

--- a/packages/docsearch-js/src/docsearch.ts
+++ b/packages/docsearch-js/src/docsearch.ts
@@ -1,7 +1,12 @@
+export type {
+  HitComponentFn,
+  ResultsFooterComponentFn,
+  FooterActionFn,
+  TemplateHelpers,
+} from './createDocSearch';
 export { docsearch as default } from './docsearchComponent';
 export type {
   DocSearchCallbacks,
   DocSearchInstance,
   DocSearchProps,
-  TemplateHelpers,
 } from './docsearchComponent';

--- a/packages/docsearch-js/src/docsearchAi.tsx
+++ b/packages/docsearch-js/src/docsearchAi.tsx
@@ -8,11 +8,7 @@ import {
   type DocSearchProps as CreateDocSearchProps,
 } from './createDocSearch';
 
-export type {
-  DocSearchCallbacks,
-  DocSearchInstance,
-  TemplateHelpers,
-} from './createDocSearch';
+export type { DocSearchCallbacks, DocSearchInstance } from './createDocSearch';
 export type DocSearchAIProps = CreateDocSearchProps<DocSearchComponentProps>;
 
 export const docsearchAi: (allProps: DocSearchAIProps) => DocSearchInstance =

--- a/packages/docsearch-js/src/docsearchComponent.tsx
+++ b/packages/docsearch-js/src/docsearchComponent.tsx
@@ -7,11 +7,7 @@ import {
   type DocSearchProps as CreateDocSearchProps,
 } from './createDocSearch';
 
-export type {
-  DocSearchCallbacks,
-  DocSearchInstance,
-  TemplateHelpers,
-} from './createDocSearch';
+export type { DocSearchCallbacks, DocSearchInstance } from './createDocSearch';
 export type DocSearchProps = CreateDocSearchProps<DocSearchComponentProps>;
 
 export const docsearch: (allProps: DocSearchProps) => DocSearchInstance =

--- a/packages/docsearch-js/src/index.ts
+++ b/packages/docsearch-js/src/index.ts
@@ -1,7 +1,12 @@
+export type {
+  HitComponentFn,
+  ResultsFooterComponentFn,
+  FooterActionFn,
+  TemplateHelpers,
+} from './createDocSearch';
 export { docsearchAi as default } from './docsearchAi';
 export type {
   DocSearchAIProps as DocSearchProps,
   DocSearchInstance,
   DocSearchCallbacks,
-  TemplateHelpers,
 } from './docsearchAi';

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -89,7 +89,7 @@ export interface DocSearchProps {
    * Algolia logo. The component will be rendered as a child of `<div
    * className="DocSearch-Footer-Action" />`.
    */
-  footerAction?: () => JSX.Element | null;
+  footerAction?: React.ReactNode;
   /** Hook to wrap or modify the algolia search client. */
   transformSearchClient?: (
     searchClient: DocSearchTransformClient

--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -43,6 +43,15 @@ export interface DocSearchFacet {
   label?: string;
 }
 
+export interface HitComponentProps {
+  hit: InternalDocSearchHit | StoredDocSearchHit;
+  children: React.ReactNode;
+}
+
+export interface ResultsFooterComponentProps {
+  state: AutocompleteState<InternalDocSearchHit>;
+}
+
 export interface DocSearchProps {
   /** Algolia application id used by the search client. */
   appId: string;
@@ -69,38 +78,18 @@ export interface DocSearchProps {
   maxResultsPerGroup?: number;
   /** Hook to post-process hits before rendering. */
   transformItems?: (items: DocSearchHit[]) => DocSearchHit[];
-  /**
-   * Custom component to render an individual hit. Supports template patterns:
-   *
-   * - HTML strings with html helper: (props, { html }) => html`<div>...</div>`
-   * - JSX templates: (props) => <div>...</div>
-   * - Function-based templates: (props) => string | JSX.Element | Function.
-   */
-  hitComponent?: (
-    props: {
-      hit: InternalDocSearchHit | StoredDocSearchHit;
-      children: React.ReactNode;
-    },
-    helpers?: {
-      html: (template: TemplateStringsArray, ...values: any[]) => any;
-    }
-  ) => JSX.Element;
-  /**
-   * Custom component rendered at the bottom of the results panel. Supports
-   * template patterns:
-   *
-   * - HTML strings with html helper: (props, { html }) => html`<div>...</div>`
-   * - JSX templates: (props) => <div>...</div>
-   * - Function-based templates: (props) => string | JSX.Element | Function.
-   */
+  /** Custom component to render an individual hit. */
+  hitComponent?: (props: HitComponentProps) => JSX.Element;
+  /** Custom component rendered at the bottom of the results panel. */
   resultsFooterComponent?: (
-    props: {
-      state: AutocompleteState<InternalDocSearchHit>;
-    },
-    helpers?: {
-      html: (template: TemplateStringsArray, ...values: any[]) => any;
-    }
+    props: ResultsFooterComponentProps
   ) => JSX.Element | null;
+  /**
+   * A custom action that can be rendered in the Modal's footer before the
+   * Algolia logo. The component will be rendered as a child of `<div
+   * className="DocSearch-Footer-Action" />`.
+   */
+  footerAction?: () => JSX.Element | null;
   /** Hook to wrap or modify the algolia search client. */
   transformSearchClient?: (
     searchClient: DocSearchTransformClient

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -102,6 +102,7 @@ export function DocSearchAskAiModal({
   indices,
   facets,
   isHybridModeSupported = false,
+  footerAction,
   ...props
 }: DocSearchAskAiModalProps): JSX.Element {
   const {
@@ -653,7 +654,7 @@ export function DocSearchAskAiModal({
         <Footer
           translations={footerTranslations}
           isAskAiActive={isAskAiActive}
-          footerAction={props.footerAction}
+          footerAction={footerAction}
         />
       }
       onClose={onClose}

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -653,6 +653,7 @@ export function DocSearchAskAiModal({
         <Footer
           translations={footerTranslations}
           isAskAiActive={isAskAiActive}
+          footerAction={props.footerAction}
         />
       }
       onClose={onClose}

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -70,6 +70,7 @@ export function DocSearchModal({
   recentSearchesWithFavoritesLimit = 4,
   indices,
   facets,
+  footerAction,
   ...props
 }: DocSearchModalProps): JSX.Element {
   const {
@@ -305,10 +306,7 @@ export function DocSearchModal({
         />
       }
       footer={
-        <Footer
-          translations={footerTranslations}
-          footerAction={props.footerAction}
-        />
+        <Footer translations={footerTranslations} footerAction={footerAction} />
       }
       onClose={onClose}
     />

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -304,7 +304,12 @@ export function DocSearchModal({
           }}
         />
       }
-      footer={<Footer translations={footerTranslations} />}
+      footer={
+        <Footer
+          translations={footerTranslations}
+          footerAction={props.footerAction}
+        />
+      }
       onClose={onClose}
     />
   );

--- a/packages/docsearch-react/src/Footer.tsx
+++ b/packages/docsearch-react/src/Footer.tsx
@@ -1,7 +1,6 @@
 import React, { type JSX } from 'react';
 
 import { AlgoliaLogo } from './AlgoliaLogo';
-import type { DocSearchProps } from './DocSearch';
 
 export type FooterTranslations = Partial<{
   selectText: string;
@@ -19,7 +18,7 @@ export type FooterTranslations = Partial<{
 type FooterProps = Partial<{
   translations: FooterTranslations;
   isAskAiActive: boolean;
-  footerAction: DocSearchProps['footerAction'];
+  footerAction: React.ReactNode;
 }>;
 
 interface CommandIconProps {
@@ -52,7 +51,7 @@ function CommandIcon(props: CommandIconProps): JSX.Element {
 export function Footer({
   translations = {},
   isAskAiActive = false,
-  footerAction: FooterAction,
+  footerAction,
 }: FooterProps): JSX.Element {
   const {
     selectText = 'Select',
@@ -66,6 +65,11 @@ export function Footer({
     closeKeyAriaLabel = 'Escape key',
     poweredByText = 'Powered by',
   } = translations;
+
+  const hasFooterAction =
+    footerAction !== null &&
+    footerAction !== undefined &&
+    typeof footerAction !== 'boolean';
 
   return (
     <>
@@ -106,10 +110,8 @@ export function Footer({
         </li>
       </ul>
       <div className="DocSearch-Footer-Actions">
-        {FooterAction && (
-          <div className="DocSearch-Footer-Action">
-            <FooterAction />
-          </div>
+        {hasFooterAction && (
+          <div className="DocSearch-Footer-Action">{footerAction}</div>
         )}
         <div className="DocSearch-Logo">
           <AlgoliaLogo translations={{ poweredByText }} />

--- a/packages/docsearch-react/src/Footer.tsx
+++ b/packages/docsearch-react/src/Footer.tsx
@@ -1,6 +1,7 @@
 import React, { type JSX } from 'react';
 
 import { AlgoliaLogo } from './AlgoliaLogo';
+import type { DocSearchProps } from './DocSearch';
 
 export type FooterTranslations = Partial<{
   selectText: string;
@@ -18,6 +19,7 @@ export type FooterTranslations = Partial<{
 type FooterProps = Partial<{
   translations: FooterTranslations;
   isAskAiActive: boolean;
+  footerAction: DocSearchProps['footerAction'];
 }>;
 
 interface CommandIconProps {
@@ -50,6 +52,7 @@ function CommandIcon(props: CommandIconProps): JSX.Element {
 export function Footer({
   translations = {},
   isAskAiActive = false,
+  footerAction: FooterAction,
 }: FooterProps): JSX.Element {
   const {
     selectText = 'Select',
@@ -66,9 +69,6 @@ export function Footer({
 
   return (
     <>
-      <div className="DocSearch-Logo">
-        <AlgoliaLogo translations={{ poweredByText }} />
-      </div>
       <ul className="DocSearch-Commands">
         <li>
           <kbd className="DocSearch-Commands-Key">
@@ -105,6 +105,16 @@ export function Footer({
           </span>
         </li>
       </ul>
+      <div className="DocSearch-Footer-Actions">
+        {FooterAction && (
+          <div className="DocSearch-Footer-Action">
+            <FooterAction />
+          </div>
+        )}
+        <div className="DocSearch-Logo">
+          <AlgoliaLogo translations={{ poweredByText }} />
+        </div>
+      </div>
     </>
   );
 }

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -106,7 +106,7 @@ describe('api', () => {
 
   describe('footerAction', () => {
     it('renders the action in the standard modal', async () => {
-      render(<DocSearch footerAction={FooterAction} />);
+      render(<DocSearch footerAction={<FooterAction />} />);
 
       await act(async () => {
         fireEvent.click(await screen.findByText('Search'));
@@ -118,7 +118,7 @@ describe('api', () => {
     });
 
     it('does not render an empty action', async () => {
-      render(<DocSearch footerAction={EmptyFooterAction} />);
+      render(<DocSearch footerAction={<EmptyFooterAction />} />);
 
       await act(async () => {
         fireEvent.click(await screen.findByText('Search'));
@@ -129,8 +129,44 @@ describe('api', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('does not render an action wrapper when no action is provided', async () => {
+      render(<DocSearch />);
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      expect(
+        document.querySelector('.DocSearch-Footer-Action')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render an action wrapper for a boolean action', async () => {
+      render(<DocSearch footerAction={false} />);
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      expect(
+        document.querySelector('.DocSearch-Footer-Action')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders numeric footer actions', async () => {
+      render(<DocSearch footerAction={0} />);
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      expect(document.querySelector('.DocSearch-Footer-Action')).toHaveTextContent(
+        '0'
+      );
+    });
+
     it('renders the action in the Ask AI modal', async () => {
-      render(<DocSearchAI footerAction={FooterAction} />);
+      render(<DocSearchAI footerAction={<FooterAction />} />);
 
       await act(async () => {
         fireEvent.click(await screen.findByText('Search'));

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -32,6 +32,14 @@ function DocSearchAI(props: Partial<DocSearchAIProps>): JSX.Element {
   );
 }
 
+function FooterAction(): JSX.Element {
+  return <button type="button">Footer action</button>;
+}
+
+function EmptyFooterAction(): null {
+  return null;
+}
+
 // mock empty response
 function noResultSearch(_queries: any, _requestOptions?: any): Promise<any> {
   return new Promise((resolve) => {
@@ -94,6 +102,44 @@ describe('api', () => {
     render(<DocSearch />);
 
     expect(document.querySelector(docSearchSelector)).toBeInTheDocument();
+  });
+
+  describe('footerAction', () => {
+    it('renders the action in the standard modal', async () => {
+      render(<DocSearch footerAction={FooterAction} />);
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      expect(
+        await screen.findByRole('button', { name: 'Footer action' })
+      ).toBeInTheDocument();
+    });
+
+    it('does not render an empty action', async () => {
+      render(<DocSearch footerAction={EmptyFooterAction} />);
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      expect(
+        screen.queryByRole('button', { name: 'Footer action' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the action in the Ask AI modal', async () => {
+      render(<DocSearchAI footerAction={FooterAction} />);
+
+      await act(async () => {
+        fireEvent.click(await screen.findByText('Search'));
+      });
+
+      expect(
+        await screen.findByRole('button', { name: 'Footer action' })
+      ).toBeInTheDocument();
+    });
   });
 
   describe('translations', () => {

--- a/packages/website/docs/packages/js/api-reference.mdx
+++ b/packages/website/docs/packages/js/api-reference.mdx
@@ -176,15 +176,21 @@ Function that transforms hits before grouping and rendering. Defaults to the ide
 
 ### `hitComponent`
 
-> `type: template function` | **optional**
+> `type: ({ hit, children }, { html }) => JSX.Element` | **optional**
 
 Template for a result link. Defaults to the built-in hit template. See [Templates](#templates).
 
 ### `resultsFooterComponent`
 
-> `type: template function` | **optional**
+> `type: ({ state }, { html }) => JSX.Element | null` | **optional**
 
 Template below the result collections. There's no default. See [Templates](#templates).
+
+### `footerAction`
+
+> `type: (_, { html }) => JSX.Element | null` | **optional**
+
+Optional function to render a custom action in the Modal's footer. It will be rendered in line with the Algolia "powered by" logo. See [Templates](#templates).
 
 ### `transformSearchClient`
 
@@ -290,15 +296,25 @@ Set `translations.modal.resultsScreen.resultBadgeLabelText` to describe the badg
 
 ### Templates
 
-`hitComponent` receives `{ hit, children }`. `resultsFooterComponent` receives `{ state }`. JavaScript templates can return a Preact element, a string, or a component function. The optional second argument provides an `html` tagged-template helper.
+- `hitComponent` receives `{ hit, children }`.
+- `resultsFooterComponent` receives `{ state }`.
+- `footerAction` currently does not receive any extra props.
+
+JavaScript templates can return a Preact element, a string, or a component function. The optional second argument provides an `html` tagged-template helper.
 
 ```js title="docsearch-options.js"
-hitComponent({ hit, children }, { html }) {
-  return html`<a href=${hit.url} data-result-type=${hit.type}>${children}</a>`;
-}
+docsearch({
+  hitComponent({ hit, children }, { html }) {
+    return html`<a href=${hit.url} data-result-type=${hit.type}>${children}</a>`;
+  },
+  resultsFooterComponent({ state }, { html }) {
+    return html`<p>No results found for query: ${state.query}</p>`;
+  },
+  footerAction(_, { html }) {
+    return html`<a href="https://algolia.com">Our other project</a>`;
+  },
+});
 ```
-
-String returns render as text, not HTML.
 
 ## Ask AI options
 

--- a/packages/website/docs/packages/modal/api.mdx
+++ b/packages/website/docs/packages/modal/api.mdx
@@ -121,15 +121,21 @@ Receives the modal portal. Defaults to `document.body`.
 
 #### `hitComponent`
 
-> `type: (props, helpers?) => JSX.Element` | **optional**
+> `type: (props) => JSX.Element` | **optional**
 
 Renders an individual result. Defaults to the built-in hit component.
 
 #### `resultsFooterComponent`
 
-> `type: (props, helpers?) => JSX.Element | null` | **optional**
+> `type: (props) => JSX.Element | null` | **optional**
 
 Renders content below the results. Defaults to `null`.
+
+#### `footerAction`
+
+> `type: React.ReactNode` | **optional**
+
+Renders a custom element in the modal footer, before the "Powered by Algolia" logo. Passing `null` renders nothing.
 
 #### `disableUserPersonalization`
 

--- a/packages/website/docs/packages/react/api-reference.mdx
+++ b/packages/website/docs/packages/react/api-reference.mdx
@@ -95,12 +95,12 @@ Transforms hits before DocSearch groups and renders them. Defaults to the identi
 
 ### `hitComponent`
 
-> `type: ({ hit, children }) => JSX.Element` | **optional**
+> `type: ({ hit, children }: HitComponentProps) => JSX.Element` | **optional**
 
 Renders one result link. The default component renders the standard result content.
 
 ```tsx title="Hit.tsx"
-function Hit({ hit, children }): JSX.Element {
+function Hit({ hit, children }: HitComponentProps): JSX.Element {
   return (
     <a href={hit.url} data-result-type={hit.type}>
       {children}
@@ -113,26 +113,30 @@ Preserve `children` to retain the default hit content. `hit` is an `InternalDocS
 
 ### `resultsFooterComponent`
 
-> `type: ({ state }) => JSX.Element | null` | **optional**
+> `type: ({ state }: ResultsFooterComponentProps) => JSX.Element | null` | **optional**
 
 Renders below result collections. It receives the current Autocomplete state. By default, DocSearch doesn't render a footer.
 
 ### `footerAction`
 
-> `type: () => JSX.Element | null` | **optional**
+> `type: React.ReactNode` | **optional**
 
-Renders a custom element in the modal footer, before the "Powered by Algolia" logo. Returning null renders nothing.
+Renders a custom element in the modal footer, before the "Powered by Algolia" logo. Passing `null` renders nothing.
 
 ```tsx title="Search.tsx"
+function FooterAction(): JSX.Element {
+  return (
+    <a href="https://algolia.com">
+      Our other project
+    </a>
+  );
+}
+
 function Search() {
   return (
     <DocSearch
       // ...
-      footerAction={() => (
-        <a href="https://algolia.com">
-          Our other project
-        </a>
-      )}
+      footerAction={<FooterAction />}
     />
   );
 }

--- a/packages/website/docs/packages/react/api-reference.mdx
+++ b/packages/website/docs/packages/react/api-reference.mdx
@@ -95,12 +95,12 @@ Transforms hits before DocSearch groups and renders them. Defaults to the identi
 
 ### `hitComponent`
 
-> `type: React.ComponentType<HitProps>` | **optional**
+> `type: ({ hit, children }) => JSX.Element` | **optional**
 
 Renders one result link. The default component renders the standard result content.
 
 ```tsx title="Hit.tsx"
-function Hit({ hit, children }: HitProps): JSX.Element {
+function Hit({ hit, children }): JSX.Element {
   return (
     <a href={hit.url} data-result-type={hit.type}>
       {children}
@@ -113,9 +113,30 @@ Preserve `children` to retain the default hit content. `hit` is an `InternalDocS
 
 ### `resultsFooterComponent`
 
-> `type: React.ComponentType<ResultsFooterProps>` | **optional**
+> `type: ({ state }) => JSX.Element | null` | **optional**
 
 Renders below result collections. It receives the current Autocomplete state. By default, DocSearch doesn't render a footer.
+
+### `footerAction`
+
+> `type: () => JSX.Element | null` | **optional**
+
+Renders a custom element in the modal footer, before the "Powered by Algolia" logo. Returning null renders nothing.
+
+```tsx title="Search.tsx"
+function Search() {
+  return (
+    <DocSearch
+      // ...
+      footerAction={() => (
+        <a href="https://algolia.com">
+          Our other project
+        </a>
+      )}
+    />
+  );
+}
+```
 
 ### `transformSearchClient`
 


### PR DESCRIPTION
## Summary

DocSearch previously had no supported way to place a custom action in the modal footer. Integrators who wanted to surface things like a feedback link, a link to a related project, or a support shortcut had to fork the footer or hack around the DOM. This adds a first-class `footerAction` prop across both `@docsearch/react` and `@docsearch/js` so that content can be rendered inline with the "Powered by Algolia" logo without touching internals.

While wiring this up, the template typings between `@docsearch/react` and `@docsearch/js` had drifted apart, which made the JS wrapper harder to type correctly and led to duplicated inline type definitions. This aligns those types by extracting shared `HitComponentProps` and `ResultsFooterComponentProps` interfaces and centralizing the JS template function types (`HitComponentFn`, `ResultsFooterComponentFn`, `FooterActionFn`), so all three template hooks follow the same shape.

The footer markup was also restructured. It now wraps the logo and the new action in a `.DocSearch-Footer-Actions` container so the two can sit side by side, replacing the old `row-reverse` layout that assumed the logo was the only trailing element.

## What changed

- New `footerAction` prop in `@docsearch/react`, rendered inside `.DocSearch-Footer-Action` before the Algolia logo, in both the standard and Ask AI modals.
- `@docsearch/js` support for `footerAction` using the existing template patterns (html helper, JSX, or function based).
- Shared and consolidated template types between the React and JS packages.
- Footer CSS reworked around a `.DocSearch-Footer-Actions` wrapper, with the logo pushed to the end when no action is present.
- Updated React and JS API reference docs.

## Testing scenarios

- Open the modal with a `footerAction` set and confirm the custom element renders to the left of the Algolia logo.
- Set a `footerAction` that returns `null` and confirm nothing extra renders and the logo stays aligned to the end of the footer.
- Trigger the Ask AI modal with a `footerAction` set and confirm it also renders there.
- In `@docsearch/js`, pass `footerAction` returning a string, a JSX/Preact element, and a component function, and confirm each renders correctly.
- Resize below and above 768px to confirm the footer actions layout switches between full width spacing and inline alignment.
- Render without a `footerAction` and confirm the footer matches previous behavior.