### PR TITLE
chore: Fix pushing git tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
           command: |
             export NPM_ID_TOKEN="$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')"
             bun run release
-            git push --follow-tags
+            git push --follow-tags origin "HEAD:${CIRCLE_BRANCH}"
   test_playwright:
     <<: *playwright
     steps:


### PR DESCRIPTION
## Summary

The release job runs from CircleCI's detached HEAD checkout, so a bare `git push --follow-tags` has no upstream branch to push to and fails. This scopes the push to the branch the job is running on so release tags actually make it to the remote.

## Testing

- Trigger the `release` job on a release branch (`main` or a `v[0-9]+` branch) and confirm the job completes without the "no upstream branch" error.
- Verify the version tags created by `bun run release` appear on the remote after the job runs.
- Confirm tags pushed from a version branch (e.g. `v5`) remain on the remote and land in `main` history once the branch is merged.