### PR TITLE
fix(v5): ignore slash shortcut on focused buttons

### DIFF
--- a/.changeset/calm-buttons-listen.md
+++ b/.changeset/calm-buttons-listen.md
@@ -1,0 +1,6 @@
+---
+"@docsearch/core": patch
+"@docsearch/react": patch
+---
+
+Prevent the slash search shortcut from intercepting key events on focused buttons.

--- a/packages/docsearch-core/src/__tests__/DocSearch.test.tsx
+++ b/packages/docsearch-core/src/__tests__/DocSearch.test.tsx
@@ -138,6 +138,21 @@ describe('@docsearch/core', () => {
       expect(screen.getByText('State: modal-search')).toBeInTheDocument();
     });
 
+    it('does not open search with / from a focused button', () => {
+      renderWithProvider(
+        <>
+          <StateRender />
+          <button type="button">Action</button>
+        </>
+      );
+
+      const button = screen.getByRole('button', { name: 'Action' });
+      button.focus();
+      fireEvent.keyDown(button, { key: '/', code: 'Slash' });
+
+      expect(screen.getByText('State: ready')).toBeInTheDocument();
+    });
+
     it('respects keyboard shortcuts', () => {
       renderWithProvider(<StateRender />, {
         keyboardShortcuts: {

--- a/packages/docsearch-core/src/useDocSearchKeyboardEvents.ts
+++ b/packages/docsearch-core/src/useDocSearchKeyboardEvents.ts
@@ -34,7 +34,8 @@ function isEditingContent(event: KeyboardEvent): boolean {
     element.isContentEditable ||
     tagName === 'INPUT' ||
     tagName === 'SELECT' ||
-    tagName === 'TEXTAREA'
+    tagName === 'TEXTAREA' ||
+    tagName === 'BUTTON'
   );
 }
 

--- a/packages/docsearch-react/src/__tests__/keyboardShortcuts.test.tsx
+++ b/packages/docsearch-react/src/__tests__/keyboardShortcuts.test.tsx
@@ -62,6 +62,18 @@ describe('keyboard shortcuts', () => {
 
       expect(document.querySelector('.DocSearch-Modal')).toBeInTheDocument();
     });
+
+    it('does not respond to / from the search button', () => {
+      render(<DocSearch />);
+
+      const button = screen.getByRole('button', { name: /Search/ });
+      button.focus();
+      fireEvent.keyDown(button, { key: '/', code: 'Slash' });
+
+      expect(
+        document.querySelector('.DocSearch-Modal')
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('custom keyboard shortcuts configuration', () => {

--- a/packages/docsearch-react/src/useDocSearchKeyboardEvents.ts
+++ b/packages/docsearch-react/src/useDocSearchKeyboardEvents.ts
@@ -32,7 +32,8 @@ function isEditingContent(event: KeyboardEvent): boolean {
     element.isContentEditable ||
     tagName === 'INPUT' ||
     tagName === 'SELECT' ||
-    tagName === 'TEXTAREA'
+    tagName === 'TEXTAREA' ||
+    tagName === 'BUTTON'
   );
 }
 


### PR DESCRIPTION
## Summary

Backports the focused-button keyboard handling fix to v5. The slash shortcut no longer opens DocSearch when a button has focus.

## Attribution

- Original PR: https://github.com/algolia/docsearch/pull/2871
- Original commit: `0e41a78c44e9f731d825a75957e5668aeae30d69`
- Original author: Sigmabro (`@Sigmabrogz`)
- Original co-author: Dylan Tientcheu
- The backport commit preserves the original author metadata.

## Adaptation

The semantic change was applied to the reformatted v5 core and React hooks. Regression tests were added for both packages because the original patch had no automated coverage.

## Verification

- `bun run test --run packages/docsearch-core/src/__tests__/DocSearch.test.tsx packages/docsearch-react/src/__tests__/keyboardShortcuts.test.tsx`
- `bun run build:pkg:core`
- `bun run build:pkg:react`
- `bun run test:types`