### PR TITLE
fix(v5): recognize conversation depth errors

### DIFF
--- a/.changeset/deep-conversations-start.md
+++ b/.changeset/deep-conversations-start.md
@@ -1,0 +1,5 @@
+---
+"@docsearch/react": patch
+---
+
+Recognize current Agent Studio conversation-depth error messages.

--- a/packages/docsearch-react/src/utils/__tests__/ai.test.ts
+++ b/packages/docsearch-react/src/utils/__tests__/ai.test.ts
@@ -10,9 +10,46 @@ import {
   getSearchToolQueries,
   isAIToolPart,
   isAlgoliaMCPSearchOutputPart,
+  isThreadDepthError,
   sanitizeMessagesForRequest,
   getMessageContent,
 } from '../ai';
+
+describe('isThreadDepthError', () => {
+  it('detects AI-217 regardless of casing', () => {
+    expect(isThreadDepthError(new Error('AI-217: limit reached'))).toBe(true);
+    expect(isThreadDepthError(new Error('prefix ai-217 suffix'))).toBe(true);
+  });
+
+  it('detects conversation depth phrasing', () => {
+    expect(
+      isThreadDepthError(
+        new Error(
+          "You've hit the max conversation depth (4 messages), start a new conversation."
+        )
+      )
+    ).toBe(true);
+    expect(
+      isThreadDepthError(new Error('Maximum conversation depth reached.'))
+    ).toBe(true);
+  });
+
+  it('detects conversation depth in a JSON-shaped error message', () => {
+    expect(
+      isThreadDepthError(
+        new Error(
+          JSON.stringify({ message: 'Maximum conversation depth reached.' })
+        )
+      )
+    ).toBe(true);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(isThreadDepthError()).toBe(false);
+    expect(isThreadDepthError(new Error('Network failed'))).toBe(false);
+    expect(isThreadDepthError(new Error('AI-214: rate limit'))).toBe(false);
+  });
+});
 
 function message(id: string, parts: AIMessagePart[]): AIMessage {
   return {

--- a/packages/docsearch-react/src/utils/ai.ts
+++ b/packages/docsearch-react/src/utils/ai.ts
@@ -122,11 +122,11 @@ export const getMessageContent = (message: AIMessage | null): string =>
     .map((part) => part.text)
     .join('\n\n');
 
-/** Helper function to check if error is a thread depth error (AI-217). */
+/** Helper function to check if an error reports the conversation depth limit. */
 export function isThreadDepthError(error?: Error): boolean {
   if (!error) return false;
 
-  return error.message?.includes('AI-217') || false;
+  return /(?:ai-217|conversation\s+depth)/i.test(error.message ?? '');
 }
 
 export const EMPTY_TOOLS: Readonly<ToolCalls> = Object.freeze({});


### PR DESCRIPTION
## Summary

Backports recognition of the current Agent Studio conversation-depth error wording to v5. Matching is case-insensitive for both `AI-217` and `conversation depth`.

## Attribution

- Original PR: https://github.com/algolia/docsearch/pull/2881
- Original commit: `f68e52251ce464e199f12b7a1ac907de61982993`
- Original author: Felipe Bermudez (`@felipeberm`)
- The backport commit preserves the original author metadata.

## Adaptation

Main uses the broader blocking-error framework introduced by #2877 and #2878, which v5 does not contain. This backport applies the original fix through v5’s existing `isThreadDepthError` helper without importing unrelated infrastructure.

## Verification

- `bun run test --run packages/docsearch-react/src/utils/__tests__/ai.test.ts packages/docsearch-react/src/__tests__/askai.test.tsx packages/docsearch-react/src/__tests__/searchbox.test.tsx`
- `bun run build:pkg:react`
- `bun run test:types`