### PR TITLE
fix(v5): stop truncating mobile snippets

### DIFF
--- a/.changeset/long-snippets-wrap.md
+++ b/.changeset/long-snippets-wrap.md
@@ -1,0 +1,6 @@
+---
+"@docsearch/react": patch
+"@docsearch/css": patch
+---
+
+Stop over-truncating mobile snippets and allow long search hits to wrap.

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/docsearch-css/dist/style.css",
-      "maxSize": "8.05 kB"
+      "maxSize": "8.1 kB"
     },
     {
       "path": "packages/docsearch-react/dist/umd/index.js",

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -1135,8 +1135,16 @@ assistive tech users */
 
   .DocSearch-Hit-content-wrapper {
     display: flex;
+    overflow-wrap: break-word;
     position: relative;
+    white-space: normal;
     width: 80%;
+  }
+
+  .DocSearch-Hit-Container {
+    height: auto;
+    min-height: var(--docsearch-hit-height);
+    padding-block: 8px;
   }
 
   .DocSearch-Modal {

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -1141,6 +1141,14 @@ assistive tech users */
     width: 80%;
   }
 
+  .DocSearch-Hit-title,
+  .DocSearch-Hit-path {
+    max-width: 100%;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
   .DocSearch-Hit-Container {
     height: auto;
     min-height: var(--docsearch-hit-height);

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -142,14 +142,8 @@ export function DocSearchAskAiModal({
       'Ask another question...';
   }
 
-  const {
-    containerRef,
-    modalRef,
-    formElementRef,
-    dropdownRef,
-    inputRef,
-    snippetLength,
-  } = useModalRefs();
+  const { containerRef, modalRef, formElementRef, dropdownRef, inputRef } =
+    useModalRefs();
   const { initialQuery, initialQueryFromSelection } =
     useInitialModalQuery(initialQueryFromProp);
 
@@ -417,7 +411,6 @@ export function DocSearchAskAiModal({
           setStatus,
           searchClient,
           indexes,
-          snippetLength,
           insights: Boolean(insights),
           appId,
           apiKey,
@@ -460,7 +453,6 @@ export function DocSearchAskAiModal({
     inputRef,
     initialScrollY,
     modalRef,
-    snippetLength,
     theme,
   });
 

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -95,14 +95,8 @@ export function DocSearchModal({
     props.placeholder ||
     'Search docs';
 
-  const {
-    containerRef,
-    modalRef,
-    formElementRef,
-    dropdownRef,
-    inputRef,
-    snippetLength,
-  } = useModalRefs();
+  const { containerRef, modalRef, formElementRef, dropdownRef, inputRef } =
+    useModalRefs();
   const { initialQuery, initialQueryFromSelection } =
     useInitialModalQuery(initialQueryFromProp);
 
@@ -193,7 +187,6 @@ export function DocSearchModal({
           setStatus,
           searchClient,
           indexes,
-          snippetLength,
           insights: Boolean(insights),
           appId,
           apiKey,
@@ -221,7 +214,6 @@ export function DocSearchModal({
     inputRef,
     initialScrollY,
     modalRef,
-    snippetLength,
     theme,
   });
 

--- a/packages/docsearch-react/src/constants.ts
+++ b/packages/docsearch-react/src/constants.ts
@@ -1,3 +1,4 @@
 export const MAX_QUERY_SIZE = 512;
+export const SNIPPET_LENGTH = 15;
 export const SUGGESTED_QUETIONS_INDEX_NAME =
   'algolia_ask_ai_suggested_questions';

--- a/packages/docsearch-react/src/hooks/__tests__/modal.test.tsx
+++ b/packages/docsearch-react/src/hooks/__tests__/modal.test.tsx
@@ -117,7 +117,6 @@ describe('modal hooks', () => {
       expect(firstResult.formElementRef.current).toBeNull();
       expect(firstResult.dropdownRef.current).toBeNull();
       expect(firstResult.inputRef.current).toBeNull();
-      expect(firstResult.snippetLength.current).toBe(15);
 
       rerender(<TestComponent onResult={onResult} />);
 

--- a/packages/docsearch-react/src/hooks/useDocSearchModalEffects.ts
+++ b/packages/docsearch-react/src/hooks/useDocSearchModalEffects.ts
@@ -7,12 +7,10 @@ import { manageLocalStorageQuota } from '../utils/storage';
 export function useDocSearchModalEffects({
   initialScrollY,
   modalRef,
-  snippetLength,
   theme,
 }: {
   initialScrollY: number;
   modalRef: React.RefObject<HTMLDivElement | null>;
-  snippetLength: React.MutableRefObject<number>;
   theme?: DocSearchTheme;
 }): void {
   useTheme({ theme });
@@ -38,12 +36,6 @@ export function useDocSearchModalEffects({
       document.body.style.marginInlineEnd = '0px';
     };
   }, []);
-
-  React.useEffect(() => {
-    if (window.matchMedia('(max-width: 768px)').matches) {
-      snippetLength.current = 5;
-    }
-  }, [snippetLength]);
 
   React.useEffect(() => {
     function setFullViewportHeight(): void {

--- a/packages/docsearch-react/src/hooks/useModalEnvironment.ts
+++ b/packages/docsearch-react/src/hooks/useModalEnvironment.ts
@@ -15,7 +15,6 @@ export function useModalEnvironment({
   inputRef,
   initialScrollY,
   modalRef,
-  snippetLength,
   theme,
 }: {
   getEnvironmentProps: AutocompleteApi<
@@ -30,7 +29,6 @@ export function useModalEnvironment({
   inputRef: React.RefObject<HTMLInputElement | null>;
   initialScrollY: number;
   modalRef: React.RefObject<HTMLDivElement | null>;
-  snippetLength: React.MutableRefObject<number>;
   theme?: DocSearchTheme;
 }): void {
   useTouchEvents({
@@ -40,5 +38,5 @@ export function useModalEnvironment({
     inputElement: inputRef.current,
   });
   useTrapFocus({ container: containerRef.current });
-  useDocSearchModalEffects({ initialScrollY, modalRef, snippetLength, theme });
+  useDocSearchModalEffects({ initialScrollY, modalRef, theme });
 }

--- a/packages/docsearch-react/src/hooks/useModalRefs.ts
+++ b/packages/docsearch-react/src/hooks/useModalRefs.ts
@@ -6,14 +6,12 @@ export function useModalRefs(): {
   formElementRef: React.RefObject<HTMLDivElement | null>;
   dropdownRef: React.RefObject<HTMLDivElement | null>;
   inputRef: React.RefObject<HTMLInputElement | null>;
-  snippetLength: React.MutableRefObject<number>;
 } {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const modalRef = React.useRef<HTMLDivElement | null>(null);
   const formElementRef = React.useRef<HTMLDivElement | null>(null);
   const dropdownRef = React.useRef<HTMLDivElement | null>(null);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const snippetLength = React.useRef<number>(15);
 
   return {
     containerRef,
@@ -21,6 +19,5 @@ export function useModalRefs(): {
     formElementRef,
     dropdownRef,
     inputRef,
-    snippetLength,
   };
 }

--- a/packages/docsearch-react/src/utils/__tests__/createDocSearchSources.test.ts
+++ b/packages/docsearch-react/src/utils/__tests__/createDocSearchSources.test.ts
@@ -63,53 +63,69 @@ function createHit({
 
 describe('buildQuerySources', () => {
   it('creates a source per lvl0 group and scopes parents to that group', async () => {
+    const search = vi.fn().mockResolvedValue({
+      results: [
+        {
+          index: 'docs',
+          nbHits: 4,
+          hits: [
+            createHit({
+              objectID: 'guide-install',
+              lvl0: 'Guides',
+              lvl1: 'Installation',
+              type: 'lvl1',
+            }),
+            createHit({
+              objectID: 'guide-install-content',
+              lvl0: 'Guides',
+              lvl1: 'Installation',
+              type: 'content',
+            }),
+            createHit({
+              objectID: 'reference-install',
+              lvl0: 'Reference',
+              lvl1: 'Installation',
+              type: 'lvl1',
+            }),
+            createHit({
+              objectID: 'reference-install-content',
+              lvl0: 'Reference',
+              lvl1: 'Installation',
+              type: 'content',
+            }),
+          ],
+        },
+      ],
+    });
     const sources = await buildQuerySources({
       query: 'install',
       state: { context: { searchSuggestions: [] } },
       setContext: vi.fn(),
       setStatus: vi.fn(),
       searchClient: {
-        search: vi.fn().mockResolvedValue({
-          results: [
-            {
-              index: 'docs',
-              nbHits: 4,
-              hits: [
-                createHit({
-                  objectID: 'guide-install',
-                  lvl0: 'Guides',
-                  lvl1: 'Installation',
-                  type: 'lvl1',
-                }),
-                createHit({
-                  objectID: 'guide-install-content',
-                  lvl0: 'Guides',
-                  lvl1: 'Installation',
-                  type: 'content',
-                }),
-                createHit({
-                  objectID: 'reference-install',
-                  lvl0: 'Reference',
-                  lvl1: 'Installation',
-                  type: 'lvl1',
-                }),
-                createHit({
-                  objectID: 'reference-install-content',
-                  lvl0: 'Reference',
-                  lvl1: 'Installation',
-                  type: 'content',
-                }),
-              ],
-            },
-          ],
-        }),
+        search,
       } as any,
       indexes: [{ name: 'docs' }],
-      snippetLength: { current: 15 },
       insights: false,
       saveRecentSearch: vi.fn(),
       onClose: vi.fn(),
       facetSelections: { current: {} },
+    });
+
+    expect(search).toHaveBeenCalledWith({
+      requests: [
+        expect.objectContaining({
+          attributesToSnippet: [
+            'hierarchy.lvl1:15',
+            'hierarchy.lvl2:15',
+            'hierarchy.lvl3:15',
+            'hierarchy.lvl4:15',
+            'hierarchy.lvl5:15',
+            'hierarchy.lvl6:15',
+            'content:15',
+          ],
+        }),
+      ],
     });
 
     expect(sources.map((source) => source.sourceId)).toEqual([

--- a/packages/docsearch-react/src/utils/createDocSearchSources.ts
+++ b/packages/docsearch-react/src/utils/createDocSearchSources.ts
@@ -9,6 +9,7 @@ import type {
 } from 'algoliasearch/lite';
 import type React from 'react';
 
+import { SNIPPET_LENGTH } from '../constants';
 import type { DocSearchIndex, DocSearchProps } from '../DocSearch';
 import type {
   DocSearchHit,
@@ -135,7 +136,6 @@ export async function buildQuerySources({
   setStatus,
   searchClient,
   indexes,
-  snippetLength,
   insights,
   appId,
   apiKey,
@@ -153,7 +153,6 @@ export async function buildQuerySources({
   setStatus: (status: DocSearchState<InternalDocSearchHit>['status']) => void;
   searchClient: ReturnType<typeof useSearchClient>;
   indexes: DocSearchIndex[];
-  snippetLength: React.MutableRefObject<number>;
   insights: boolean;
   appId?: string;
   apiKey?: string;
@@ -191,13 +190,13 @@ export async function buildQuerySources({
             'url',
           ],
           attributesToSnippet: searchParams?.attributesToSnippet ?? [
-            `hierarchy.lvl1:${snippetLength.current}`,
-            `hierarchy.lvl2:${snippetLength.current}`,
-            `hierarchy.lvl3:${snippetLength.current}`,
-            `hierarchy.lvl4:${snippetLength.current}`,
-            `hierarchy.lvl5:${snippetLength.current}`,
-            `hierarchy.lvl6:${snippetLength.current}`,
-            `content:${snippetLength.current}`,
+            `hierarchy.lvl1:${SNIPPET_LENGTH}`,
+            `hierarchy.lvl2:${SNIPPET_LENGTH}`,
+            `hierarchy.lvl3:${SNIPPET_LENGTH}`,
+            `hierarchy.lvl4:${SNIPPET_LENGTH}`,
+            `hierarchy.lvl5:${SNIPPET_LENGTH}`,
+            `hierarchy.lvl6:${SNIPPET_LENGTH}`,
+            `content:${SNIPPET_LENGTH}`,
           ],
           snippetEllipsisText: searchParams?.snippetEllipsisText ?? '…',
           highlightPreTag: searchParams?.highlightPreTag ?? '<mark>',


### PR DESCRIPTION
## Summary

Backports the mobile snippet and long-hit wrapping fix to v5. Search requests now consistently use 15-word snippets on mobile, while mobile hit containers and their title/path children can grow and wrap long content.

## Attribution

- Original PR: https://github.com/algolia/docsearch/pull/2907
- Original commit: `9ad6d169fee62cb9558e40aa8475f99ecd41e7fe`
- Original author: Divyansh Singh (`@brc-dd`)
- All backport commits preserve the original author metadata.

## Adaptation

V5 extracted source construction and modal effects and split keyword search from Ask AI. The fixed snippet length was therefore moved through `createDocSearchSources`, the shared modal hooks, and both modal implementations. Later v5 child-level truncation rules are reset in the mobile breakpoint so the upstream wrapping behavior takes effect. Existing facet selections and custom `attributesToSnippet` behavior remain intact. The CSS bundle budget is adjusted for the intentional wrapping rules.

## Verification

- `bun run test --run packages/docsearch-react/src/utils/__tests__/createDocSearchSources.test.ts packages/docsearch-react/src/hooks/__tests__/modal.test.tsx`
- `bun run build:pkg:css`
- `bun run build:pkg:react`
- `bun run test:types`
- `bun run test:size`