### PR TITLE
chore: Post 5.0.0 cleanup

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,7 @@
   ],
   "linked": [],
   "access": "public",
-  "baseBranch": "v5",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
     "@docsearch/website",

--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ DocSearch crawls your documentation, pushes the content to an Algolia index and 
 #### Installation
 
 ```sh
-bun add @docsearch/js@4
+bun add @docsearch/js@5
 # or
-npm install @docsearch/js@4
+npm install @docsearch/js@5
 ```
 
 If you don’t want to use a package manager, you can use a standalone endpoint:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@5"></script>
 ```
 
 #### Get started
@@ -74,15 +74,15 @@ docsearch({
 #### Installation
 
 ```bash
-bun add @docsearch/react@4
+bun add @docsearch/react@5
 # or
-npm install @docsearch/react@4
+npm install @docsearch/react@5
 ```
 
 If you don’t want to use a package manager, you can use a standalone endpoint:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/react@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/react@5"></script>
 ```
 
 #### Get started

--- a/packages/docsearch-css/README.md
+++ b/packages/docsearch-css/README.md
@@ -5,13 +5,13 @@ Style package for [DocSearch](http://docsearch.algolia.com/), the best search ex
 ## Installation
 
 ```bash
-npm install @docsearch/css@4
+npm install @docsearch/css@5
 ```
 
 If you don’t want to use a package manager, you can use a standalone endpoint:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/css@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/css@5"></script>
 ```
 
 ## Get started
@@ -22,4 +22,4 @@ import '@docsearch/css';
 
 ## Documentation
 
-[Read documentation →](https://docsearch.algolia.com/docs/styling)
+[Read documentation →](https://docsearch.algolia.com/docs/packages/css/styling)

--- a/packages/docsearch-js/README.md
+++ b/packages/docsearch-js/README.md
@@ -76,4 +76,4 @@ Both UMD entries expose callable `window.docsearch`. Load only one of them: the 
 
 ## Documentation
 
-[Read documentation →](https://docsearch.algolia.com/docs/docsearch-v3)
+[Read documentation →](https://docsearch.algolia.com/docs/packages/js/getting-started)

--- a/packages/docsearch-react/README.md
+++ b/packages/docsearch-react/README.md
@@ -5,13 +5,13 @@ React package for [DocSearch](http://docsearch.algolia.com/), the best search ex
 ## Installation
 
 ```bash
-npm install @docsearch/react@4
+npm install @docsearch/react@5
 ```
 
 If you don’t want to use a package manager, you can use a standalone endpoint:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/react@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/react@5"></script>
 ```
 
 ## Get started
@@ -38,4 +38,4 @@ export default App;
 
 ## Documentation
 
-[Read documentation →](https://docsearch.algolia.com/docs/docsearch-v3)
+[Read documentation →](https://docsearch.algolia.com/docs/packages/react/getting-started)

--- a/packages/docsearch-sidepanel-js/README.md
+++ b/packages/docsearch-sidepanel-js/README.md
@@ -13,7 +13,7 @@ npm install @docsearch/sidepanel-js
 If you don’t want to use a package manager, you can use a standalone endpoint:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/sidepanel-js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/sidepanel-js@5"></script>
 ```
 
 To get started, you need a [`container`](https://docsearch.algolia.com/docs/api#container) for your DocSearch Sidepanel component to go in. If you don’t have one already, you can insert one into your markup:
@@ -36,10 +36,10 @@ sidepanel({
   indexName: 'YOUR_INDEX_NAME',
   appId: 'YOUR_APP_ID',
   apiKey: 'YOUR_SEARCH_API_KEY',
-  assistantId: 'YOUR_ASSISTANT_ID',
+  agentId: 'YOUR_AGENT_ID',
 });
 ```
 
 ## Documentation
 
-[Read documentation →](https://docsearch.algolia.com)
+[Read documentation →](https://docsearch.algolia.com/docs/packages/sidepanel-js/getting-started)

--- a/packages/docsearch-sidepanel/README.md
+++ b/packages/docsearch-sidepanel/README.md
@@ -6,7 +6,7 @@ React package for [DocSearch Sidepanel](http://docsearch.algolia.com/), a standa
 
 ```bash
 # or
-npm install @docsearch/core@4 @docsearch/sidepanel@4 @docsearch/css@4
+npm install @docsearch/core@5 @docsearch/sidepanel@5 @docsearch/css@5
 ```
 
 If you don’t want to use a package manager, you can use a standalone endpoint:
@@ -37,7 +37,7 @@ function App() {
       <Sidepanel
         appId="YOUR_APP_ID"
         apiKey="YOUR_SEARCH_API_KEY"
-        agentId="YOUR_ASK_AI_ASSISTANT_ID"
+        agentId="YOUR_AGENT_ID"
       />
     </DocSearch>
   );
@@ -46,4 +46,4 @@ function App() {
 
 ## Documentation
 
-[Read documentation →](https://docsearch.algolia.com)
+[Read documentation →](https://docsearch.algolia.com/docs/packages/sidepanel/getting-started)

--- a/packages/website/WRITING_GUIDE.md
+++ b/packages/website/WRITING_GUIDE.md
@@ -19,7 +19,6 @@
 
 ## Version references
 
-- When referencing installing a `v5` package, MUST use the caret (`^`) based versioning: `@^5.0.0-beta`
 - When displaying install commands, ONLY include `@docsearch/*` packages, there's no need to include any other packages unless specified
 
 ## Pages

--- a/packages/website/docs/agent-studio/getting-started.mdx
+++ b/packages/website/docs/agent-studio/getting-started.mdx
@@ -30,28 +30,28 @@ Install the React package and styles:
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
@@ -88,28 +88,28 @@ Install the JavaScript package and styles:
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/composable-api.mdx
+++ b/packages/website/docs/composable-api.mdx
@@ -35,28 +35,28 @@ Install matching v5 versions of the DocSearch packages:
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/core@^5 @docsearch/modal@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/css@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/hybrid-mode.mdx
+++ b/packages/website/docs/hybrid-mode.mdx
@@ -54,28 +54,28 @@ Install the connected React packages and CSS:
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/sidepanel@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/core@^5 @docsearch/modal@^5 @docsearch/sidepanel@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/sidepanel@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/sidepanel@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/sidepanel@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/sidepanel@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/sidepanel@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/sidepanel@^5 @docsearch/css@^5
 ```
 
   </TabItem>
@@ -196,28 +196,28 @@ The JavaScript packages create independent DocSearch and Sidepanel instances. Co
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/js@^5.0.0-beta @docsearch/sidepanel-js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/js@^5 @docsearch/sidepanel-js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/js@^5.0.0-beta @docsearch/sidepanel-js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/js@^5 @docsearch/sidepanel-js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/js@^5.0.0-beta @docsearch/sidepanel-js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/js@^5 @docsearch/sidepanel-js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/js@^5.0.0-beta @docsearch/sidepanel-js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/js@^5 @docsearch/sidepanel-js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
@@ -327,28 +327,28 @@ Install the adapter and keep `@docusaurus/preset-classic`:
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/docusaurus-adapter@^5.0.0-beta
+npm install @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/docusaurus-adapter@^5.0.0-beta
+yarn add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/docusaurus-adapter@^5.0.0-beta
+pnpm add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/docusaurus-adapter@^5.0.0-beta
+bun add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
@@ -434,7 +434,7 @@ Import both `style.css` and `sidepanel.css`. Check that your bundler includes CS
 
 ### Docusaurus rejects the configuration
 
-Use `themeConfig.docsearch`, pass `askAi` as an object, and put `sidePanel` beside `askAi`. Install `@docsearch/docusaurus-adapter@^5.0.0-beta` instead of configuring hybrid mode through the built-in Algolia theme.
+Use `themeConfig.docsearch`, pass `askAi` as an object, and put `sidePanel` beside `askAi`. Install `@docsearch/docusaurus-adapter@^5` instead of configuring hybrid mode through the built-in Algolia theme.
 
 ### Server rendering fails with `window` or `document` errors
 

--- a/packages/website/docs/migrating-from-v4.mdx
+++ b/packages/website/docs/migrating-from-v4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrate from DocSearch v4
-description: Move a DocSearch v4 integration to the 5.0.0 beta packages and Agent Studio APIs.
+description: Move a DocSearch v4 integration to the v5 and Agent Studio APIs.
 ---
 
 import TabItem from '@theme/TabItem';
@@ -12,7 +12,7 @@ Review the complete [v5 breaking changes](./v5-breaking-changes) before releasin
 
 ## 1. Upgrade the beta packages
 
-Upgrade every DocSearch package in the integration together with the `^5.0.0-beta` range.
+Upgrade every DocSearch package in the integration together with the `^5` range.
 
 <Tabs groupId="language" aria-label="Programming language">
   <TabItem value="react" label="React">
@@ -21,28 +21,28 @@ Upgrade every DocSearch package in the integration together with the `^5.0.0-bet
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
@@ -55,28 +55,28 @@ bun add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
@@ -85,7 +85,7 @@ bun add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
   </TabItem>
 </Tabs>
 
-If you use the Composable API or Sidepanel, also upgrade `@docsearch/core@^5.0.0-beta`, `@docsearch/modal@^5.0.0-beta`, `@docsearch/sidepanel@^5.0.0-beta`, or `@docsearch/sidepanel-js@^5.0.0-beta`.
+If you use the Composable API or Sidepanel, also upgrade `@docsearch/core@^5`, `@docsearch/modal@^5`, `@docsearch/sidepanel@^5`, or `@docsearch/sidepanel-js@^5`.
 
 ## 2. Choose keyword-only or AI-capable search
 
@@ -106,7 +106,7 @@ For a CDN integration, replace the root bundle with the keyword-only UMD file:
 
 ```diff title="index.html"
 -<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@4"></script>
-+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@^5.0.0-beta/dist/umd/docsearch.js"></script>
++<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@^5/dist/umd/docsearch.js"></script>
 ```
 
 ### JavaScript with Ask AI
@@ -168,16 +168,15 @@ Replace `DocSearch` with `DocSearchAI`:
 
 ## 3. Move Ask AI to Agent Studio
 
-V5 removes the legacy Ask AI token and chat transport. Create the assistant in [Agent Studio](/docs/agent-studio/getting-started) before switching production traffic. If you already have an Ask AI assistant, follow [Migrate Ask AI to Agent Studio](/docs/agent-studio/migrate-to-agent-studio).
+V5 removes the legacy Ask AI token and chat transport. Create the agent in [Agent Studio](/docs/agent-studio/getting-started) before switching production traffic. If you already have an Ask AI assistant, follow [Migrate Ask AI to Agent Studio](/docs/agent-studio/migrate-to-agent-studio).
 
-Rename `assistantId` to `agentId`. Remove `agentStudio` and `useStagingEnv` from `askAi`. Agent Studio is the only Ask AI backend in v5.
+Rename `assistantId` to `agentId`. Remove `agentStudio` from `askAi`. Agent Studio is the only Ask AI backend in v5.
 
 ```diff title="app.js"
  askAi: {
 -  assistantId: 'YOUR_ASSISTANT_ID',
 +  agentId: 'YOUR_AGENT_ID',
 -  agentStudio: true,
--  useStagingEnv: false,
  }
 ```
 

--- a/packages/website/docs/packages/core/overview.mdx
+++ b/packages/website/docs/packages/core/overview.mdx
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 
 :::info v5 beta
 
-These instructions use the `^5.0.0-beta` range.
+These instructions use the `^5` range.
 
 :::
 
@@ -20,28 +20,28 @@ These instructions use the `^5.0.0-beta` range.
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/core@^5.0.0-beta
+npm install @docsearch/core@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/core@^5.0.0-beta
+yarn add @docsearch/core@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/core@^5.0.0-beta
+pnpm add @docsearch/core@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/core@^5.0.0-beta
+bun add @docsearch/core@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/packages/css/bundle-exports.mdx
+++ b/packages/website/docs/packages/css/bundle-exports.mdx
@@ -57,7 +57,7 @@ The Sidepanel reuses Agent Studio response and Markdown classes from the root bu
 ```html title="index.html"
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5.0.0-beta/dist/style.css"
+  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5/dist/style.css"
 />
 ```
 
@@ -66,7 +66,7 @@ Add the Sidepanel asset when needed:
 ```html title="index.html"
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5.0.0-beta/dist/sidepanel.css"
+  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5/dist/sidepanel.css"
 />
 ```
 

--- a/packages/website/docs/packages/css/styling.mdx
+++ b/packages/website/docs/packages/css/styling.mdx
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 
 :::info v5 beta
 
-These instructions use the `^5.0.0-beta` range.
+These instructions use the `^5` range.
 
 :::
 
@@ -20,28 +20,28 @@ These instructions use the `^5.0.0-beta` range.
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/css@^5.0.0-beta
+npm install @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/css@^5.0.0-beta
+yarn add @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/css@^5.0.0-beta
+bun add @docsearch/css@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/packages/docusaurus-adapter/getting-started.mdx
+++ b/packages/website/docs/packages/docusaurus-adapter/getting-started.mdx
@@ -21,34 +21,34 @@ Use Node.js 20 or later, Docusaurus 3.10.2 or later in the Docusaurus 3 release 
 
 ## Install the adapter
 
-Install `@docsearch/docusaurus-adapter@^5.0.0-beta`:
+Install `@docsearch/docusaurus-adapter@^5`:
 
 <Tabs groupId="package-manager" aria-label="Package manager">
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/docusaurus-adapter@^5.0.0-beta
+npm install @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/docusaurus-adapter@^5.0.0-beta
+yarn add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/docusaurus-adapter@^5.0.0-beta
+pnpm add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/docusaurus-adapter@^5.0.0-beta
+bun add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/packages/docusaurus-adapter/migrating-from-v4.mdx
+++ b/packages/website/docs/packages/docusaurus-adapter/migrating-from-v4.mdx
@@ -16,34 +16,34 @@ Upgrade the site to Node.js 20 or later and Docusaurus 3.10.2 or later in the Do
 
 ## 2. Install the v5 adapter
 
-Install `@docsearch/docusaurus-adapter@^5.0.0-beta`:
+Install `@docsearch/docusaurus-adapter@^5`:
 
 <Tabs groupId="package-manager" aria-label="Package manager">
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/docusaurus-adapter@^5.0.0-beta
+npm install @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/docusaurus-adapter@^5.0.0-beta
+yarn add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/docusaurus-adapter@^5.0.0-beta
+pnpm add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/docusaurus-adapter@^5.0.0-beta
+bun add @docsearch/docusaurus-adapter@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/packages/js/api-reference.mdx
+++ b/packages/website/docs/packages/js/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: JS package API reference
-description: Configure @docsearch/js 5.0.0-beta.0 and control its returned instance.
+description: Configure @docsearch/js 5 and control its returned instance.
 toc_max_heading_level: 2
 ---
 

--- a/packages/website/docs/packages/js/getting-started.mdx
+++ b/packages/website/docs/packages/js/getting-started.mdx
@@ -18,28 +18,28 @@ Collect your Algolia application ID, Search API key, and index name. To add Ask 
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
@@ -101,9 +101,9 @@ Load the complete stylesheet and one JavaScript bundle. Both UMD bundles expose 
 ```html title="index.html"
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5.0.0-beta/dist/style.css"
+  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5/dist/style.css"
 />
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@^5.0.0-beta/dist/umd/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@^5/dist/umd/index.js"></script>
 <script>
   window.docsearch({
     container: '#docsearch',
@@ -122,9 +122,9 @@ Load the complete stylesheet and one JavaScript bundle. Both UMD bundles expose 
 ```html title="index.html"
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5.0.0-beta/dist/style.css"
+  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5/dist/style.css"
 />
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@^5.0.0-beta/dist/umd/docsearch.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@^5/dist/umd/docsearch.js"></script>
 <script>
   window.docsearch({
     container: '#docsearch',

--- a/packages/website/docs/packages/modal/overview.mdx
+++ b/packages/website/docs/packages/modal/overview.mdx
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 
 :::info v5 beta
 
-These instructions use the `^5.0.0-beta` range. Use the same range for every DocSearch package.
+These instructions use the `^5` range. Use the same range for every DocSearch package.
 
 :::
 
@@ -22,28 +22,28 @@ For the complete component workflow, see the [Composable API guide](/docs/compos
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/core@^5 @docsearch/modal@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/core@^5.0.0-beta @docsearch/modal@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/core@^5 @docsearch/modal@^5 @docsearch/css@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/packages/overview.mdx
+++ b/packages/website/docs/packages/overview.mdx
@@ -54,28 +54,28 @@ Install the v5 beta with the caret range:
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/js@^5 @docsearch/css@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/packages/react/api-reference.mdx
+++ b/packages/website/docs/packages/react/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: React API reference
-description: Reference for the components, props, ref, and exports in @docsearch/react 5.0.0-beta.0.
+description: Reference for the components, props, ref, and exports in @docsearch/react 5.
 ---
 
 ## Components

--- a/packages/website/docs/packages/react/getting-started.mdx
+++ b/packages/website/docs/packages/react/getting-started.mdx
@@ -18,28 +18,28 @@ Collect your Algolia application ID, Search API key, and index name. To add Ask 
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/react@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/react@^5 @docsearch/css@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/packages/sidepanel-js/api.mdx
+++ b/packages/website/docs/packages/sidepanel-js/api.mdx
@@ -54,7 +54,7 @@ Agent Studio agent ID.
 
 Primary index for Agent Studio and conversation storage.
 
-The public `SidepanelProps` type in `5.0.0-beta.0` doesn't include the React Sidepanel's top-level `searchParameters` field.
+The public `SidepanelProps` type in `5` doesn't include the React Sidepanel's top-level `searchParameters` field.
 
 ### UI props
 

--- a/packages/website/docs/packages/sidepanel-js/getting-started.mdx
+++ b/packages/website/docs/packages/sidepanel-js/getting-started.mdx
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 
 :::info v5 beta
 
-These instructions use the `^5.0.0-beta` range.
+These instructions use the `^5` range.
 
 :::
 
@@ -20,28 +20,28 @@ These instructions use the `^5.0.0-beta` range.
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/sidepanel-js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/sidepanel-js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/sidepanel-js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/sidepanel-js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/sidepanel-js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/sidepanel-js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/sidepanel-js@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/sidepanel-js@^5 @docsearch/css@^5
 ```
 
   </TabItem>
@@ -96,16 +96,16 @@ Call `assistant.destroy()` before removing the container or remounting another S
 ```html title="index.html"
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5.0.0-beta/dist/style.css"
+  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5/dist/style.css"
 />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5.0.0-beta/dist/sidepanel.css"
+  href="https://cdn.jsdelivr.net/npm/@docsearch/css@^5/dist/sidepanel.css"
 />
 
 <div id="docsearch-sidepanel"></div>
 
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/sidepanel-js@^5.0.0-beta/dist/umd/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/sidepanel-js@^5/dist/umd/index.js"></script>
 <script>
   const assistant = docsearchSidepanel({
     container: '#docsearch-sidepanel',

--- a/packages/website/docs/packages/sidepanel/getting-started.mdx
+++ b/packages/website/docs/packages/sidepanel/getting-started.mdx
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 
 :::info v5 beta
 
-These instructions use the `^5.0.0-beta` range. Use the same range for every DocSearch package.
+These instructions use the `^5` range. Use the same range for every DocSearch package.
 
 :::
 
@@ -20,28 +20,28 @@ These instructions use the `^5.0.0-beta` range. Use the same range for every Doc
   <TabItem value="npm" label="npm">
 
 ```bash
-npm install @docsearch/core@^5.0.0-beta @docsearch/sidepanel@^5.0.0-beta @docsearch/css@^5.0.0-beta
+npm install @docsearch/core@^5 @docsearch/sidepanel@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn add @docsearch/core@^5.0.0-beta @docsearch/sidepanel@^5.0.0-beta @docsearch/css@^5.0.0-beta
+yarn add @docsearch/core@^5 @docsearch/sidepanel@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @docsearch/core@^5.0.0-beta @docsearch/sidepanel@^5.0.0-beta @docsearch/css@^5.0.0-beta
+pnpm add @docsearch/core@^5 @docsearch/sidepanel@^5 @docsearch/css@^5
 ```
 
   </TabItem>
   <TabItem value="bun" label="Bun">
 
 ```bash
-bun add @docsearch/core@^5.0.0-beta @docsearch/sidepanel@^5.0.0-beta @docsearch/css@^5.0.0-beta
+bun add @docsearch/core@^5 @docsearch/sidepanel@^5 @docsearch/css@^5
 ```
 
   </TabItem>

--- a/packages/website/docs/v5-breaking-changes.mdx
+++ b/packages/website/docs/v5-breaking-changes.mdx
@@ -3,7 +3,7 @@ title: v5 breaking changes
 description: Complete user-facing breaking changes and compatibility notes for DocSearch v5.
 ---
 
-This page lists the user-facing changes between the v4.6.0 package source and `5.0.0-beta.0`. Use it with the [v4 migration guide](./migrating-from-v4).
+This page lists the user-facing changes between the v4.6.0 package source and `5`. Use it with the [v4 migration guide](./migrating-from-v4).
 
 ## JavaScript entry points
 
@@ -73,10 +73,6 @@ Create and configure an assistant in [Agent Studio](/docs/agent-studio/getting-s
 ### `askAi.agentStudio` is removed
 
 The backend switch is no longer needed because Agent Studio is the only backend. Remove both `agentStudio: true` and `agentStudio: false`.
-
-### `askAi.useStagingEnv` is removed
-
-The staging endpoint switch isn't part of `DocSearchAskAi` in v5.
 
 ### Flat Ask AI search parameters are removed
 
@@ -215,11 +211,11 @@ See [hybrid mode](/docs/hybrid-mode) for the supported integration.
 
 ### Package versions must match
 
-The `5.0.0-beta.0` packages depend on matching beta versions of the other DocSearch packages. Don't mix v4 and v5 packages in a Composable API or Sidepanel tree.
+The `5` packages depend on matching beta versions of the other DocSearch packages. Don't mix v4 and v5 packages in a Composable API or Sidepanel tree.
 
 ### CSS remains a separate install for top-level integrations
 
-Install `@docsearch/css@^5.0.0-beta`, then import `@docsearch/css`. For a CDN integration, load `dist/style.css` from the same caret beta range.
+Install `@docsearch/css@^5`, then import `@docsearch/css`. For a CDN integration, load `dist/style.css` from the same caret beta range.
 
 ## Additive v5 APIs
 

--- a/packages/website/versioned_docs/version-v4/composable-api.mdx
+++ b/packages/website/versioned_docs/version-v4/composable-api.mdx
@@ -311,5 +311,5 @@ interface DocSearchModalProps {
 More property documentation can be found in the [DocSearch API Reference][3] page.
 
 [1]: https://react.dev/reference/react/createContext
-[2]: /docs/v4/v4/askai
-[3]: /docs/api
+[2]: ./v4/askai
+[3]: ./api

--- a/packages/website/versioned_docs/version-v4/examples.mdx
+++ b/packages/website/versioned_docs/version-v4/examples.mdx
@@ -102,7 +102,7 @@ The sidepanel provides a persistent chat interface anchored to the side of the p
 
 ## Composable API: DocSearchButton + DocSearchModal
 
-Use the [Composable API](/docs/composable-api) to render the button and modal as separate components. This gives you explicit control over where each piece is rendered and when the modal code is loaded.
+Use the [Composable API](./composable-api) to render the button and modal as separate components. This gives you explicit control over where each piece is rendered and when the modal code is loaded.
 
 ```jsx
 import { DocSearch } from '@docsearch/core';
@@ -335,8 +335,8 @@ const newTabNavigator = {
 
 <br></br>
 
-:::warning 
-**Note**: Using only `hitComponent` with `target="_blank"` will work for mouse clicks, but keyboard navigation (arrows + Enter) requires the `navigator` prop to consistently open links in new tabs. 
+:::warning
+**Note**: Using only `hitComponent` with `target="_blank"` will work for mouse clicks, but keyboard navigation (arrows + Enter) requires the `navigator` prop to consistently open links in new tabs.
 :::
 
 ---

--- a/packages/website/versioned_docs/version-v4/migrating-from-v3.md
+++ b/packages/website/versioned_docs/version-v4/migrating-from-v3.md
@@ -2,11 +2,11 @@
 title: Migrating from v3 to v4
 ---
 
-This guide provides detailed information on migrating from [DocSearch v3](/docs/v3/docsearch) to [DocSearch v4](/docs/docsearch), highlighting key differences and new configuration options. For a comprehensive overview, refer to the [API reference](/docs/api) and [Getting Started Guide](/docs/docsearch).
+This guide provides detailed information on migrating from [DocSearch v3](/docs/v3/docsearch) to [DocSearch v4](./docsearch), highlighting key differences and new configuration options. For a comprehensive overview, refer to the [API reference](./api) and [Getting Started Guide](./docsearch).
 
 ## If You're Using Docusaurus
 
-Use [`@docsearch/docusaurus-adapter`](/docs/docusaurus-adapter) to get the latest DocSearch integration on your current Docusaurus version.
+Use [`@docsearch/docusaurus-adapter`](./docusaurus-adapter) to get the latest DocSearch integration on your current Docusaurus version.
 
 This is the recommended path when you need newer DocSearch features (for example, Ask AI sidepanel support) without waiting for changes in Docusaurus' built-in search integration.
 
@@ -26,7 +26,7 @@ We refreshed a few translations keys to make their purpose much clearer:
 | SearchBoxTranslations | `cancelButtonAriaLabel` | `closeButtonAriaLabel` |
 | FooterTranslations | `searchByText` | `poweredByText` |
 
-Find the full list of translations in the [API documentation](/docs/api#translations)
+Find the full list of translations in the [API documentation](./api#translations)
 
 ## Integrating Ask AI with DocSearch v4
 
@@ -87,7 +87,7 @@ For full details on endpoint security, caching strategies, and infrastructure, s
 
 ## Support and Resources
 
-* **Ask AI documentation**: Learn everything about Algolia Ask AI ([Documentation](/#)).
+* **Ask AI documentation**: Learn everything about Algolia Ask AI ([Documentation](./v4/askai)).
 * **DocSearch Playground**: Interactive environment to test DocSearch configurations ([Docsearch Playground](https://community.algolia.com/docsearch-playground/)).
 * **Community & Support**: Reach out through the [Algolia Discord](https://alg.li/discord).
 

--- a/packages/website/versioned_docs/version-v4/sidepanel/advanced-use-cases.mdx
+++ b/packages/website/versioned_docs/version-v4/sidepanel/advanced-use-cases.mdx
@@ -141,4 +141,4 @@ You can trigger the Modal for search and the Sidepanel for AI-powered assistance
 
 Learn more in the [Hybrid Mode guide][1].
 
-[1]: /docs/sidepanel/hybrid
+[1]: ./hybrid

--- a/packages/website/versioned_docs/version-v4/sidepanel/getting-started.mdx
+++ b/packages/website/versioned_docs/version-v4/sidepanel/getting-started.mdx
@@ -131,6 +131,6 @@ This is just the most basic form of implementation. To learn about other impleme
 
 To learn more about the different configuration options for Sidepanel, you can read our [Sidepanel API References][3].
 
-[1]: /docs/sidepanel/hybrid
-[2]: /docs/sidepanel/advanced-use-cases
-[3]: /docs/sidepanel/api-reference
+[1]: ./hybrid
+[2]: ./advanced-use-cases
+[3]: ./api-reference

--- a/packages/website/versioned_docs/version-v4/sidepanel/hybrid.mdx
+++ b/packages/website/versioned_docs/version-v4/sidepanel/hybrid.mdx
@@ -97,4 +97,4 @@ function HybridMode() {
 
 There is no manual opt-in for Hybrid Mode to work. When both the Modal and Sidepanel are rendered inside the same `<DocSearch>` context, Hybrid Mode is enabled automatically. No additional configuration is required.
 
-[1]: /docs/docsearch#installation
+[1]: ../docsearch#installation

--- a/packages/website/versioned_docs/version-v4/v4/askai-errors.mdx
+++ b/packages/website/versioned_docs/version-v4/v4/askai-errors.mdx
@@ -158,8 +158,8 @@ The request exceeded the model's maximum context length. This happens when the c
 
 > **Solution**: Reduce the size of your conversation history or input. You can either start a new conversation, remove older messages, or shorten your prompts. Check your model's token limits in the [models documentation][5].
 
-[1]: /docs/api#askai
+[1]: ../api#askai
 [2]: https://sitesearch.algolia.com/docs/experiences/search-askai#configuration
 [3]: https://www.algolia.com/doc/guides/algolia-ai/askai/reference/api
-[4]: /docs/v4/v4/askai-whitelisted-domains
+[4]: ./askai-whitelisted-domains
 [5]: https://www.algolia.com/doc/guides/algolia-ai/askai/guides/models

--- a/packages/website/versioned_docs/version-v4/v4/migrating-askai-to-agent-studio.mdx
+++ b/packages/website/versioned_docs/version-v4/v4/migrating-askai-to-agent-studio.mdx
@@ -117,7 +117,7 @@ Use the Agent Studio APIs:
 
 - [Integrate Agent Studio](https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/integration)
 - [Agent Studio API](https://www.algolia.com/doc/rest-api/agent-studio)
-- Completions endpoint example:  
+- Completions endpoint example:
   `https://{APPLICATION_ID}.algolia.net/agent-studio/1/agents/{AGENT_ID}/completions`
 
 Authenticate with your application ID and a search-only API key.
@@ -126,9 +126,9 @@ DocSearch wires the Agent Studio transport when `agentStudio` is `true`.
 
 ## See also
 
-- [Get started with Ask AI](/docs/v4/v4/askai)
-- [Ask AI API](/docs/v4/v4/askai-api) for existing custom clients
-- [`askAi.agentStudio` API reference](/docs/v4/api#askaiagentstudio)
+- [Get started with Ask AI](./askai)
+- [Ask AI API](./askai-api) for existing custom clients
+- [`askAi.agentStudio` API reference](../api#askaiagentstudio)
 - [Agent Studio](https://www.algolia.com/doc/guides/algolia-ai/agent-studio)
 - [Migrate Ask AI to Agent Studio (DocSearch v5)](/docs/agent-studio/migrate-to-agent-studio)
 - [Get started with Agent Studio (DocSearch v5)](/docs/agent-studio/getting-started)


### PR DESCRIPTION
## What

- Fixes some link issues on the website where legacy (`v4`) versioned docs were incorrectly linking to current (`v5`) pages
- Removes `-beta` references in installation examples and readmes