### PR TITLE
fix: Add missing export for search only

### DIFF
--- a/.changeset/brown-streets-take.md
+++ b/.changeset/brown-streets-take.md
@@ -1,0 +1,5 @@
+---
+"@docsearch/react": patch
+---
+
+Fixes missing published export for keyword only `<DocSearch />` that was missed in [#2884](https://github.com/algolia/docsearch/pull/2884).

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -22,6 +22,7 @@
     ".": "./dist/esm/index.js",
     "./askaiModal": "./dist/esm/askaiModal.js",
     "./button": "./dist/esm/button.js",
+    "./docsearch": "./dist/esm/docsearch.js",
     "./docsearchAi": "./dist/esm/docsearchAi.js",
     "./modal": "./dist/esm/modal.js",
     "./sidepanel": "./dist/esm/sidepanel.js",

--- a/packages/docsearch-react/tsdown.config.mts
+++ b/packages/docsearch-react/tsdown.config.mts
@@ -25,6 +25,7 @@ export default defineConfig([
   {
     entry: {
       index: 'src/index.ts',
+      docsearch: 'src/DocSearch.tsx',
       docsearchAi: 'src/DocSearchAI.tsx',
       askaiModal: 'src/DocSearchAskAiModal.tsx',
       button: 'src/DocSearchButton.tsx',

--- a/packages/website/docs/packages/react/api-reference.mdx
+++ b/packages/website/docs/packages/react/api-reference.mdx
@@ -408,6 +408,7 @@ The root package exports `DocSearch`, `DocSearchAI`, `DocSearchAskAiModal`, `Doc
 | --- | --- |
 | `@docsearch/react/askaiModal` | `DocSearchAskAiModal` |
 | `@docsearch/react/button` | `DocSearchButton` |
+| `@docsearch/react/docsearch` | `DocSearch` - Search only |
 | `@docsearch/react/docsearchAi` | `DocSearchAI` and AI types |
 | `@docsearch/react/modal` | `DocSearchModal` |
 | `@docsearch/react/sidepanel` | `DocSearchSidepanel` and Sidepanel components |


### PR DESCRIPTION
## What

Fixes missing published export for keyword only `<DocSearch />` that was missed in [#2884](https://github.com/algolia/docsearch/pull/2884).