### PR TITLE
fix(askai): Preserve conversation when transitioning to Ask AI

### DIFF
--- a/.changeset/sparkly-kings-wink.md
+++ b/.changeset/sparkly-kings-wink.md
@@ -1,0 +1,5 @@
+---
+"@docsearch/react": patch
+---
+
+fix(askai): preserve the conversation when opening Ask AI from the results row [#3010](https://github.com/algolia/docsearch/issues/3010)

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -487,14 +487,20 @@ export function DocSearchAskAiModal({
   useRefreshOnInitialQuery({ initialQuery, inputRef, refresh });
 
   const hasCurrentMessages = messages.length > 0;
+  const previousIsAskAiActive = React.useRef(isAskAiActive);
 
   // Refresh the autocomplete results when ask ai is toggled off
   // helps return to the previous ac state and start screen
   React.useEffect(() => {
+    const wasAskAiActive = previousIsAskAiActive.current;
+    previousIsAskAiActive.current = isAskAiActive;
+
     if (!isAskAiActive) {
       autocomplete.refresh();
 
-      if (hasCurrentMessages) {
+      // Reset only after leaving Ask AI, not when its first message arrives
+      // before the parent toggle update commits.
+      if (wasAskAiActive && hasCurrentMessages) {
         startNewConversation();
       }
     }

--- a/packages/docsearch-react/src/__tests__/DocSearchAskAiModal.test.tsx
+++ b/packages/docsearch-react/src/__tests__/DocSearchAskAiModal.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DocSearchAskAiModal } from '../DocSearchAskAiModal';
+
+const mocks = vi.hoisted(() => ({
+  startNewConversation: vi.fn(),
+  useAskAi: vi.fn(),
+}));
+
+vi.mock('../useAskAi', () => ({
+  useAskAi: mocks.useAskAi,
+}));
+
+describe('DocSearchAskAiModal', () => {
+  let messages: UIMessage[] = [];
+
+  beforeEach(() => {
+    messages = [];
+    mocks.startNewConversation.mockReset();
+    mocks.useAskAi.mockImplementation(() => ({
+      askAiError: undefined,
+      chatId: 'chat-id',
+      conversations: { add: vi.fn(), getAll: () => [] },
+      exchanges: [],
+      isStreaming: false,
+      messages,
+      restoreConversation: vi.fn(),
+      sendFeedback: vi.fn(),
+      sendMessage: vi.fn(),
+      setMessages: vi.fn(),
+      startNewConversation: mocks.startNewConversation,
+      status: 'ready',
+      stopAskAiStreaming: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not reset a conversation when its first message arrives before Ask AI activates', () => {
+    const props = {
+      apiKey: 'api-key',
+      appId: 'app-id',
+      askAi: 'agent-id',
+      indices: ['index-name'],
+      initialScrollY: 0,
+      onAskAiToggle: vi.fn(),
+    };
+    const { rerender } = render(
+      <DocSearchAskAiModal {...props} isAskAiActive={false} />
+    );
+
+    messages = [
+      {
+        id: 'message-id',
+        parts: [{ text: 'Question', type: 'text' }],
+        role: 'user',
+      },
+    ];
+    rerender(<DocSearchAskAiModal {...props} isAskAiActive={false} />);
+
+    expect(mocks.startNewConversation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/docsearch-react/src/__tests__/api.test.tsx
+++ b/packages/docsearch-react/src/__tests__/api.test.tsx
@@ -500,6 +500,7 @@ describe('api', () => {
       expect(
         document.querySelector('.DocSearch-AskAiScreen')
       ).toBeInTheDocument();
+      expect(await screen.findByText('hello')).toBeInTheDocument();
 
       // could be "Answering..." or "Ask another question..."
       // where "Ask another question..." is actually an input's placeholder text


### PR DESCRIPTION
Fixes #3010 

## Why

Clicking the "Ask AI Assistant" row is the main entry point into Ask AI, but it opened an empty conversation every time. The question was sent and the answer streamed back in full, yet both were thrown away because the chat instance that handled the send was torn down during the search to Ask AI transition. Users had to retype their question to get a visible answer, which made the feature look broken on first use.

The reset logic tied to leaving Ask AI was firing on the initial screen transition too, before the toggle had committed. So the very first message of a fresh conversation triggered a conversation reset. This change gates that reset behind an actual active to inactive transition, so the conversation is only cleared when the user genuinely leaves Ask AI, not while they are entering it.

## Testing scenarios

1. Mount `@docsearch/js` v5 with an `askAi` config (agent ID and API key).
2. Open the modal, type a question, and click the "Ask AI Assistant" row (or press Enter on it). The Ask AI screen should show your question and stream the answer, matching what happens when you type directly into the Ask AI input.
3. Ask a follow up in the same conversation and confirm history is preserved.
4. Leave Ask AI and return to search, then open Ask AI again. The previous conversation should be cleared and you should start fresh.
5. Repeat with the hybrid sidepanel setup to confirm the sidepanel flow is unaffected.