### PR TITLE
fix(askai): Request error for incomplete tool call

### DIFF
--- a/.changeset/six-tigers-fetch.md
+++ b/.changeset/six-tigers-fetch.md
@@ -1,0 +1,5 @@
+---
+"@docsearch/react": patch
+---
+
+Fix Ask AI conversations breaking after stopping a stream mid-tool-call. Incomplete tool parts (`input-streaming`/`input-available`) are now pruned before resending, so the dangling `tool_use` no longer causes the provider to reject every subsequent question.

--- a/packages/docsearch-react/src/useAskAi.ts
+++ b/packages/docsearch-react/src/useAskAi.ts
@@ -104,7 +104,6 @@ const getAgentStudioTransport = ({
       algolia: algoliaParams,
     },
     prepareSendMessagesRequest({ id, messages, body, ...rest }) {
-      // Filter out `data-*` part types since Agent Studio does not currently support them on the request
       const sanitizedMessages = sanitizeMessagesForRequest(messages);
 
       return {

--- a/packages/docsearch-react/src/utils/__tests__/ai.test.ts
+++ b/packages/docsearch-react/src/utils/__tests__/ai.test.ts
@@ -286,6 +286,82 @@ describe('sanitizeMessagesForRequest', () => {
     expect(result[1]).not.toBe(sanitizedMessage);
     expect(result[1].parts).toEqual([{ type: 'text', text: 'Hi' }]);
   });
+
+  it('removes an aborted tool call from the assistant message', () => {
+    const initialQuestion: AIMessage = {
+      id: 'message-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Find installation instructions' }],
+    };
+    const assistantMessage = message('message-2', [
+      { type: 'step-start' },
+      {
+        type: 'tool-algolia_search_index',
+        toolCallId: 'tool-1',
+        state: 'input-streaming',
+        input: undefined,
+      },
+    ]);
+    const followUpQuestion: AIMessage = {
+      id: 'message-3',
+      role: 'user',
+      parts: [{ type: 'text', text: 'What are the prerequisites?' }],
+    };
+
+    expect(
+      sanitizeMessagesForRequest([
+        initialQuestion,
+        assistantMessage,
+        followUpQuestion,
+      ])
+    ).toEqual([
+      initialQuestion,
+      message('message-2', [{ type: 'step-start' }]),
+      followUpQuestion,
+    ]);
+  });
+
+  it('keeps streamed text while removing an incomplete tool call', () => {
+    const result = sanitizeMessagesForRequest([
+      message('message-1', [
+        { type: 'text', text: 'Let me look that up.' },
+        {
+          type: 'tool-searchIndex',
+          toolCallId: 'tool-1',
+          state: 'input-available',
+          input: { query: 'installation' },
+        },
+      ]),
+    ]);
+
+    expect(result).toEqual([
+      message('message-1', [{ type: 'text', text: 'Let me look that up.' }]),
+    ]);
+  });
+
+  it.each([
+    {
+      state: 'output-available' as const,
+      output: { hits: [] },
+    },
+    {
+      state: 'output-error' as const,
+      errorText: 'Search failed',
+    },
+  ])('keeps a $state tool call', (toolPart) => {
+    const messages = [
+      message('message-1', [
+        {
+          type: 'tool-searchIndex',
+          toolCallId: 'tool-1',
+          input: { query: 'installation' },
+          ...toolPart,
+        },
+      ]),
+    ];
+
+    expect(sanitizeMessagesForRequest(messages)).toBe(messages);
+  });
 });
 
 describe('getAgentPromptSuggestions', () => {

--- a/packages/docsearch-react/src/utils/ai.ts
+++ b/packages/docsearch-react/src/utils/ai.ts
@@ -1,4 +1,4 @@
-import type { TextUIPart } from 'ai';
+import { isDataUIPart, isToolOrDynamicToolUIPart, type TextUIPart } from 'ai';
 
 import type { StoredAskAiState } from '../types';
 import type {
@@ -281,10 +281,18 @@ export function sanitizeMessagesForRequest(messages: AIMessage[]): AIMessage[] {
   let sanitizedMessages: AIMessage[] | undefined;
 
   messages.forEach((message, index) => {
-    // Filter out `data-*` part types since Agent Studio does not currently support them on the request
-    const parts = message.parts.filter(
-      (part) => !part.type.startsWith('data-')
-    );
+    // Remove parts that Agent Studio does not support during a request, including incomplete tool calls
+    const parts = message.parts.filter((part) => {
+      if (isDataUIPart(part)) {
+        return false;
+      }
+
+      if (isToolOrDynamicToolUIPart(part) && part.state.startsWith('input-')) {
+        return false;
+      }
+
+      return true;
+    });
 
     if (parts.length === message.parts.length) {
       sanitizedMessages?.push(message);


### PR DESCRIPTION
Fixes #3011 

## Why

Stopping an Ask AI stream while a retrieval tool call is still in flight left an incomplete tool part in the conversation state. Because that part never reached a terminal state, every following question in the same conversation resent a dangling `tool_use` with no matching `tool_result`, and the provider rejected each one with "Bad request to provider." The conversation became permanently unusable, and the only escape was starting over, with nothing telling the user that.

Stopping a stream is a one-click action any user can reach, so this was easy to trigger by anyone who reconsidered a question mid-answer.

## What changed

`sanitizeMessagesForRequest` now prunes tool parts that are still in an `input-streaming` or `input-available` state before a request is sent. Completed tool calls (`output-available` / `output-error`) are kept so answered turns still carry their context.

## Testing

1. Mount `@docsearch/react` (or `@docsearch/js`) with an `askAi` config pointing at Agent Studio.
2. Ask a question that triggers a search.
3. Click the stop button while the tool call row is visible, before its output arrives.
4. Ask another question in the same conversation and confirm it answers normally instead of erroring.
5. As a regression check, ask a question, let it finish fully, then ask a follow-up and confirm retrieval context from the earlier turn still works.