### PR TITLE
fix: JS packages dependencies

### DIFF
--- a/.changeset/blue-cats-send.md
+++ b/.changeset/blue-cats-send.md
@@ -1,0 +1,6 @@
+---
+"@docsearch/sidepanel-js": patch
+"@docsearch/js": patch
+---
+
+Move bundled DocSearch packages to development dependencies to reduce consumers' install footprint.

--- a/bun.lock
+++ b/bun.lock
@@ -147,11 +147,9 @@
     "packages/docsearch-js": {
       "name": "@docsearch/js",
       "version": "5.0.1",
-      "dependencies": {
-        "@docsearch/core": "4.6.0",
-        "@docsearch/react": "4.6.0",
-      },
       "devDependencies": {
+        "@docsearch/core": "5.0.1",
+        "@docsearch/react": "5.0.1",
         "htm": "3.1.1",
         "preact": "11.0.0-beta.0",
         "tsdown": "0.22.7",
@@ -249,11 +247,9 @@
     "packages/docsearch-sidepanel-js": {
       "name": "@docsearch/sidepanel-js",
       "version": "5.0.1",
-      "dependencies": {
-        "@docsearch/core": "4.6.0",
-        "@docsearch/react": "4.6.0",
-      },
       "devDependencies": {
+        "@docsearch/core": "5.0.1",
+        "@docsearch/react": "5.0.1",
         "preact": "11.0.0-beta.0",
         "tsdown": "0.22.7",
         "typescript": "5.7.3",

--- a/packages/docsearch-js/package.json
+++ b/packages/docsearch-js/package.json
@@ -32,11 +32,9 @@
     "build": "tsdown",
     "watch": "tsdown --watch"
   },
-  "dependencies": {
-    "@docsearch/core": "5.0.1",
-    "@docsearch/react": "5.0.1"
-  },
   "devDependencies": {
+    "@docsearch/core": "5.0.1",
+    "@docsearch/react": "5.0.1",
     "htm": "3.1.1",
     "preact": "11.0.0-beta.0",
     "tsdown": "0.22.7",

--- a/packages/docsearch-sidepanel-js/package.json
+++ b/packages/docsearch-sidepanel-js/package.json
@@ -31,11 +31,9 @@
     "build": "tsdown",
     "watch": "tsdown --watch"
   },
-  "dependencies": {
-    "@docsearch/core": "5.0.1",
-    "@docsearch/react": "5.0.1"
-  },
   "devDependencies": {
+    "@docsearch/core": "5.0.1",
+    "@docsearch/react": "5.0.1",
     "preact": "11.0.0-beta.0",
     "tsdown": "0.22.7",
     "typescript": "5.7.3"


### PR DESCRIPTION
As reported in this [comment](https://github.com/algolia/docsearch/issues/2942#issuecomment-5272095079) when installing `@docsearch/js`/`@docsearch/sidepanel-js`, there are packages being installed that are not included in the runtime. This PR moves them to `devDependencies` to reduce package install size.