### PR TITLE
feat(website): consent-gated anonymous_id identity wrapper

### DIFF
--- a/.changeset/lucky-pumas-listen.md
+++ b/.changeset/lucky-pumas-listen.md
@@ -1,0 +1,5 @@
+---
+'@docsearch/docusaurus-adapter': patch
+---
+
+Respect a caller-supplied `transformSearchClient` instead of discarding it.

--- a/adapters/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
+++ b/adapters/docusaurus-theme-search-algolia/src/theme/SearchBar/index.tsx
@@ -148,16 +148,23 @@ function useNavigator({
   return navigator;
 }
 
-function useTransformSearchClient(): DocSearchModalProps['transformSearchClient'] {
+function useTransformSearchClient({
+  transformSearchClient,
+}: Pick<
+  AdapterDocSearchProps,
+  'transformSearchClient'
+>): DocSearchModalProps['transformSearchClient'] {
   const {
     siteMetadata: { docusaurusVersion },
   } = useDocusaurusContext();
   return useCallback(
     (searchClient: DocSearchTransformClient) => {
       searchClient.addAlgoliaAgent('docusaurus', docusaurusVersion);
-      return searchClient;
+      return transformSearchClient
+        ? transformSearchClient(searchClient)
+        : searchClient;
     },
-    [docusaurusVersion]
+    [docusaurusVersion, transformSearchClient]
   );
 }
 
@@ -312,7 +319,7 @@ function DocSearch({
     indices: props.indices,
   });
   const transformItems = useTransformItems(props);
-  const transformSearchClient = useTransformSearchClient();
+  const transformSearchClient = useTransformSearchClient(props);
   const { closeModal, isModalActive } = useDocSearch();
   const [modalLoaded, setModalLoaded] = useState(
     Boolean(DocSearchModal && DocSearchAskAiModal)

--- a/packages/website/plugins/analytics-loader.mjs
+++ b/packages/website/plugins/analytics-loader.mjs
@@ -77,8 +77,7 @@ export default function analyticsLoader(_, options) {
   function loadSegment() {
     if (loaded || pending || !hasConsent()) return;
     pending = true;
-    var settled = fetch('https://dashboard.algolia.com/static/anonymous_id_cookie', { credentials: 'include' })
-      .catch(function () {});     // response unreadable (no CORS), only the Set-Cookie matters
+    var settled = fetch('https://dashboard.algolia.com/static/anonymous_id_cookie', { credentials: 'include', mode: 'no-cors' }).catch(function () {});
     var timeout = new Promise(function (resolve) { setTimeout(resolve, TIMEOUT_MS); });
     Promise.race([settled, timeout]).then(function () {
       pending = false;

--- a/packages/website/plugins/analytics-loader.mjs
+++ b/packages/website/plugins/analytics-loader.mjs
@@ -50,9 +50,53 @@ export default function analyticsLoader(_, options) {
               type: 'text/javascript',
             },
             innerHTML: `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${options.apiKey}";;analytics.SNIPPET_VERSION="4.15.3";
-analytics.load("${options.apiKey}");
-analytics.page();
   }}();`,
+          },
+          {
+            tagName: 'script',
+            attributes: {
+              type: 'text/javascript',
+            },
+            innerHTML: `(function () {
+  var GROUP = 'C0002';
+  var TIMEOUT_MS = 2000;
+  var loaded = false;
+  var pending = false;
+
+  function hasConsent() {
+    return typeof window.OnetrustActiveGroups === 'string'
+        && window.OnetrustActiveGroups.split(',').indexOf(GROUP) !== -1;
+  }
+
+  function cookieId() {
+    var m = document.cookie.match(/(?:^| )anonymous_id=([^;]+)/);
+    if (!m) return null;
+    try { return decodeURIComponent(m[1]); } catch (e) { return m[1]; }
+  }
+
+  function loadSegment() {
+    if (loaded || pending || !hasConsent()) return;
+    pending = true;
+    var settled = fetch('https://dashboard.algolia.com/static/anonymous_id_cookie', { credentials: 'include' })
+      .catch(function () {});     // response unreadable (no CORS), only the Set-Cookie matters
+    var timeout = new Promise(function (resolve) { setTimeout(resolve, TIMEOUT_MS); });
+    Promise.race([settled, timeout]).then(function () {
+      pending = false;
+      var id = cookieId();
+      if (id) analytics.setAnonymousId(id);
+      analytics.page();
+      analytics.load('${options.apiKey}');
+      loaded = true;
+    });
+  }
+
+  loadSegment();
+  var prev = window.OptanonWrapper;
+  window.OptanonWrapper = function () {
+    if (typeof prev === 'function') prev();
+    loadSegment();
+  };
+})();`,
           },
         ],
       };

--- a/packages/website/plugins/client-modules/track.mjs
+++ b/packages/website/plugins/client-modules/track.mjs
@@ -1,8 +1,11 @@
+import { hasConsent } from '@site/src/lib/segment.js';
+
 /** @type import('@docusaurus/types').ClientModule */
 export default {
   onRouteDidUpdate({ location, previousLocation }) {
     if (
       window.analytics &&
+      hasConsent() &&
       previousLocation &&
       location.pathname !== previousLocation.pathname
     ) {

--- a/packages/website/src/lib/searchTracking.js
+++ b/packages/website/src/lib/searchTracking.js
@@ -14,8 +14,9 @@ export function createSearchTracker(trackedIndexNames) {
     timer = null;
     if (!pendingObservation) return;
 
-    const { query, results_count, no_results } = pendingObservation;
+    const { query, results_count } = pendingObservation;
     pendingObservation = null;
+    lastObservedSignature = null;
     track('Search Performed', {
       query,
       results_count,
@@ -64,7 +65,6 @@ export function createSearchTracker(trackedIndexNames) {
     pendingObservation = {
       query,
       results_count: resultsCount,
-      no_results: resultsCount === 0,
     };
     clearTimeout(timer);
     timer = setTimeout(flush, DEBOUNCE_MS);

--- a/packages/website/src/lib/searchTracking.js
+++ b/packages/website/src/lib/searchTracking.js
@@ -8,6 +8,7 @@ export function createSearchTracker(trackedIndexNames) {
   let timer = null;
   let sequenceCounter = 0;
   let highestObservedSequence = 0;
+  let lastObservedSignature = null;
 
   function flush() {
     timer = null;
@@ -15,11 +16,10 @@ export function createSearchTracker(trackedIndexNames) {
 
     const { query, results_count, no_results } = pendingObservation;
     pendingObservation = null;
-    track('search_performed', {
+    track('Search Performed', {
       query,
       results_count,
       surface: 'docsearch',
-      no_results,
     });
   }
 
@@ -43,8 +43,17 @@ export function createSearchTracker(trackedIndexNames) {
     const query = matches[0].request.query;
     if (typeof query !== 'string' || query.trim() === '') return;
 
-    // DocSearch shows a single result list across its indices, so the count the
-    // user sees is the sum of their nbHits.
+    const signature = JSON.stringify(
+      matches.map(({ request }) => [
+        request.indexName,
+        request.query,
+        request.facetFilters ?? null,
+        request.filters ?? null,
+      ])
+    );
+    if (signature === lastObservedSignature) return;
+    lastObservedSignature = signature;
+
     const resultsCount = matches.reduce(
       (total, { result }) =>
         total + (typeof result.nbHits === 'number' ? result.nbHits : 0),
@@ -72,9 +81,7 @@ export function createSearchTracker(trackedIndexNames) {
         (response) => {
           try {
             observe(args, response, sequence);
-          } catch {
-            // tracking must never surface as a search failure
-          }
+          } catch {}
         },
         () => {}
       );

--- a/packages/website/src/lib/searchTracking.js
+++ b/packages/website/src/lib/searchTracking.js
@@ -1,0 +1,86 @@
+import { track } from './segment.js';
+
+const DEBOUNCE_MS = 1000;
+
+export function createSearchTracker(trackedIndexNames) {
+  const trackedIndices = new Set(trackedIndexNames);
+  let pendingObservation = null;
+  let timer = null;
+  let sequenceCounter = 0;
+  let highestObservedSequence = 0;
+
+  function flush() {
+    timer = null;
+    if (!pendingObservation) return;
+
+    const { query, results_count, no_results } = pendingObservation;
+    pendingObservation = null;
+    track('search_performed', {
+      query,
+      results_count,
+      surface: 'docsearch',
+      no_results,
+    });
+  }
+
+  function observe(args, response, sequence) {
+    // Overlapping searches resolve out of order, so a straggler from an earlier
+    // keystroke must not replace what a later one already recorded.
+    if (sequence <= highestObservedSequence) return;
+
+    const requests = args[0] && (args[0].requests || args[0]);
+    const results = response && response.results;
+    if (!Array.isArray(requests) || !Array.isArray(results)) return;
+
+    const matches = requests
+      .map((request, index) => ({ request, result: results[index] }))
+      .filter(
+        ({ request, result }) =>
+          request && result && trackedIndices.has(request.indexName)
+      );
+    if (matches.length === 0) return;
+
+    const query = matches[0].request.query;
+    if (typeof query !== 'string' || query.trim() === '') return;
+
+    // DocSearch shows a single result list across its indices, so the count the
+    // user sees is the sum of their nbHits.
+    const resultsCount = matches.reduce(
+      (total, { result }) =>
+        total + (typeof result.nbHits === 'number' ? result.nbHits : 0),
+      0
+    );
+
+    highestObservedSequence = sequence;
+    pendingObservation = {
+      query,
+      results_count: resultsCount,
+      no_results: resultsCount === 0,
+    };
+    clearTimeout(timer);
+    timer = setTimeout(flush, DEBOUNCE_MS);
+  }
+
+  return function transformSearchClient(client) {
+    if (!client || typeof client.search !== 'function') return client;
+
+    const search = client.search.bind(client);
+    client.search = (...args) => {
+      const sequence = ++sequenceCounter;
+      const result = search(...args);
+      Promise.resolve(result).then(
+        (response) => {
+          try {
+            observe(args, response, sequence);
+          } catch {
+            // tracking must never surface as a search failure
+          }
+        },
+        () => {}
+      );
+      return result;
+    };
+
+    return client;
+  };
+}

--- a/packages/website/src/lib/segment.js
+++ b/packages/website/src/lib/segment.js
@@ -6,6 +6,15 @@ function getAnalytics() {
   return window.analytics;
 }
 
+export function hasConsent() {
+  if (typeof window === 'undefined') return false;
+  if (typeof window.OnetrustActiveGroups !== 'string') return false;
+
+  return window.OnetrustActiveGroups.split(',').includes('C0002');
+}
+
 export function track(event, properties) {
+  if (!hasConsent()) return;
+
   getAnalytics()?.track(event, properties);
 }

--- a/packages/website/src/theme/SearchBar/index.jsx
+++ b/packages/website/src/theme/SearchBar/index.jsx
@@ -1,0 +1,24 @@
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { createSearchTracker } from '@site/src/lib/searchTracking';
+import SearchBar from '@theme-original/SearchBar';
+import React, { useState } from 'react';
+
+function getTrackedIndexNames(docsearch) {
+  const indices = Array.isArray(docsearch?.indices) ? docsearch.indices : [];
+  return indices
+    .map((index) => (typeof index === 'string' ? index : index?.name))
+    .filter(Boolean);
+}
+
+export default function SearchBarWrapper(props) {
+  const { siteConfig } = useDocusaurusContext();
+  // DocSearch memoizes its search client on this function, so the tracker has
+  // to keep the same identity across renders.
+  const [transformSearchClient] = useState(() =>
+    createSearchTracker(
+      getTrackedIndexNames(siteConfig?.themeConfig?.docsearch)
+    )
+  );
+
+  return <SearchBar {...props} transformSearchClient={transformSearchClient} />;
+}


### PR DESCRIPTION
## 🤔 What

- Load Segment only once OneTrust grants C0002, and seed its anonymous id from the shared `anonymous_id` cookie.
- Drop `page` and `track` calls made before consent instead of queueing them on the Segment stub.
- Emit one debounced `search_performed` per settled query on the site searchbox.
- Respect a caller-supplied `transformSearchClient` in the Docusaurus adapter.

## 🤷 Why

[GROUT-503]

## 📷  Previews

<table>
<tr>
 <td> Before accepting cookies
 <td> After accepting cookies
<tr>
 <td>
<img width="932" height="581" alt="Screenshot 2026-08-18 at 15 25 25" src="https://github.com/user-attachments/assets/de8bab3f-8ffb-47db-bb20-cefd2478c381" />
 <td>
<img width="1015" height="346" alt="Screenshot 2026-08-18 at 15 25 40" src="https://github.com/user-attachments/assets/62ef2bf1-6011-4c92-bcda-3c36c6c3359e" />
</table>

<table>
<tr>
 <td> Search request
 <td> Tracking event
<tr>
 <td>
<img width="882" height="467" alt="Screenshot 2026-08-18 at 15 26 10" src="https://github.com/user-attachments/assets/7202fb96-ab5d-43fc-a9d8-7dbfd3333fe6" />
 <td>
<img width="389" height="267" alt="Screenshot 2026-08-18 at 15 26 06" src="https://github.com/user-attachments/assets/0d7387c9-1804-4def-b0c8-27d93803c2d4" />
</table>

[GROUT-503]: https://algolia.atlassian.net/browse/GROUT-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ