### PR TITLE
fix(askai): Fixes interceptAskAiEvent not being called when selecting an Ask AI item with keyboard

### DIFF
--- a/.changeset/itchy-cycles-reply.md
+++ b/.changeset/itchy-cycles-reply.md
@@ -1,0 +1,5 @@
+---
+"@docsearch/react": patch
+---
+
+fix(askai): Fixes `interceptAskAiEvent` not being called when selecting an Ask AI item with keyboard (`Enter`)

--- a/packages/docsearch-react/src/DocSearchAskAiModal.tsx
+++ b/packages/docsearch-react/src/DocSearchAskAiModal.tsx
@@ -27,7 +27,6 @@ import type {
   DocSearchState,
   InternalDocSearchHit,
   OnAskAiFeedback,
-  StoredAskAiMessage,
   StoredAskAiState,
   SuggestedQuestionHit,
 } from './types';
@@ -213,7 +212,6 @@ export function DocSearchAskAiModal({
     chatId,
     messages,
     status,
-    setMessages,
     sendMessage,
     stopAskAiStreaming,
     askAiError,
@@ -385,6 +383,39 @@ export function DocSearchAskAiModal({
     [askAiConfigurationId, appId, sendFeedback]
   );
 
+  const handleSelectStoredConversation = React.useCallback(
+    (item: StoredAskAiState, event: KeyboardEvent | MouseEvent) => {
+      if (
+        isQueryEmpty(item.query) ||
+        !item.messages ||
+        item.messages.length < 1
+      ) {
+        return;
+      }
+
+      const hitMessages = item.messages;
+
+      const initialMessage: InitialAskAiMessage = {
+        // Using `!` here for types, but `item.query` existence is checked above
+        query: item.query!,
+        messageId: hitMessages[0].id,
+      };
+
+      restoreConversation(hitMessages, item.chatId);
+
+      if (interceptAskAiEvent?.(initialMessage)) {
+        if (autocompleteRef.current) {
+          autocompleteRef.current.setQuery('');
+        }
+        event.preventDefault();
+        return;
+      }
+
+      onAskAiToggle(true, initialMessage);
+    },
+    [interceptAskAiEvent, restoreConversation, onAskAiToggle]
+  );
+
   if (!autocompleteRef.current) {
     autocompleteRef.current = createAutocomplete({
       id: 'docsearch',
@@ -415,8 +446,7 @@ export function DocSearchAskAiModal({
             ? buildRecentConversationSources({
                 conversations,
                 disableUserPersonalization,
-                setMessages,
-                onAskAiToggle,
+                handleSelectStoredConversation,
               })
             : [];
           return [...recentConversationSource, ...noQuerySources];
@@ -632,26 +662,8 @@ export function DocSearchAskAiModal({
           onNewConversation={handleNewConversation}
           onItemClick={(item, event) => {
             if (item.type === 'askAI' && item.query) {
-              if (item.anchor === 'stored' && 'messages' in item) {
-                const hitMessages = item.messages as StoredAskAiMessage[];
-                restoreConversation(
-                  hitMessages,
-                  (item as StoredAskAiState).chatId
-                );
-                const initialMessage: InitialAskAiMessage = {
-                  query: item.query,
-                  messageId: hitMessages[0].id,
-                };
-
-                if (interceptAskAiEvent?.(initialMessage)) {
-                  if (autocompleteRef.current) {
-                    autocompleteRef.current.setQuery('');
-                  }
-                  event.preventDefault();
-                  return;
-                }
-
-                onAskAiToggle(true, initialMessage);
+              if (item.anchor === 'stored') {
+                handleSelectStoredConversation(item, event);
               } else {
                 handleSelectAskAiQuestion(true, item.query);
               }

--- a/packages/docsearch-react/src/__tests__/DocSearchAskAiModal.test.tsx
+++ b/packages/docsearch-react/src/__tests__/DocSearchAskAiModal.test.tsx
@@ -1,11 +1,20 @@
-import { render } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import type { UIMessage } from 'ai';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
 
 import { DocSearchAskAiModal } from '../DocSearchAskAiModal';
+import type { StoredAskAiState } from '../types';
 
 const mocks = vi.hoisted(() => ({
+  restoreConversation: vi.fn(),
   startNewConversation: vi.fn(),
   useAskAi: vi.fn(),
 }));
@@ -16,18 +25,21 @@ vi.mock('../useAskAi', () => ({
 
 describe('DocSearchAskAiModal', () => {
   let messages: UIMessage[] = [];
+  let storedConversations: StoredAskAiState[] = [];
 
   beforeEach(() => {
     messages = [];
+    storedConversations = [];
+    mocks.restoreConversation.mockReset();
     mocks.startNewConversation.mockReset();
     mocks.useAskAi.mockImplementation(() => ({
       askAiError: undefined,
       chatId: 'chat-id',
-      conversations: { add: vi.fn(), getAll: () => [] },
+      conversations: { add: vi.fn(), getAll: () => storedConversations },
       exchanges: [],
       isStreaming: false,
       messages,
-      restoreConversation: vi.fn(),
+      restoreConversation: mocks.restoreConversation,
       sendFeedback: vi.fn(),
       sendMessage: vi.fn(),
       setMessages: vi.fn(),
@@ -38,11 +50,41 @@ describe('DocSearchAskAiModal', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.clearAllMocks();
   });
 
-  it('does not reset a conversation when its first message arrives before Ask AI activates', () => {
-    const props = {
+  function createStoredConversation(): StoredAskAiState {
+    return {
+      anchor: 'stored',
+      chatId: 'stored-chat-id',
+      content: null,
+      hierarchy: {
+        lvl0: 'askAI',
+        lvl1: 'What is DocSearch?',
+        lvl2: '2026-08-19T00:00:00.000Z',
+        lvl3: null,
+        lvl4: null,
+        lvl5: null,
+        lvl6: null,
+      },
+      messages: [
+        {
+          id: 'stored-message-id',
+          parts: [{ text: 'What is DocSearch?', type: 'text' }],
+          role: 'user',
+        },
+      ],
+      objectID: 'stored-conversation',
+      query: 'What is DocSearch?',
+      type: 'askAI',
+      url: '',
+      url_without_anchor: '',
+    };
+  }
+
+  function createProps() {
+    return {
       apiKey: 'api-key',
       appId: 'app-id',
       askAi: 'agent-id',
@@ -50,6 +92,10 @@ describe('DocSearchAskAiModal', () => {
       initialScrollY: 0,
       onAskAiToggle: vi.fn(),
     };
+  }
+
+  it('does not reset a conversation when its first message arrives before Ask AI activates', () => {
+    const props = createProps();
     const { rerender } = render(
       <DocSearchAskAiModal {...props} isAskAiActive={false} />
     );
@@ -64,5 +110,80 @@ describe('DocSearchAskAiModal', () => {
     rerender(<DocSearchAskAiModal {...props} isAskAiActive={false} />);
 
     expect(mocks.startNewConversation).not.toHaveBeenCalled();
+  });
+
+  it('restores a stored conversation with its persisted chat ID on click', async () => {
+    const conversation = createStoredConversation();
+    storedConversations = [conversation];
+    const props = createProps();
+
+    render(<DocSearchAskAiModal {...props} isAskAiActive={false} />);
+
+    fireEvent.click(await screen.findByText('What is DocSearch?'));
+
+    expect(mocks.restoreConversation).toHaveBeenCalledTimes(1);
+    expect(mocks.restoreConversation).toHaveBeenCalledWith(
+      conversation.messages,
+      'stored-chat-id'
+    );
+    await waitFor(() => {
+      expect(props.onAskAiToggle).toHaveBeenCalledWith(true, {
+        messageId: 'stored-message-id',
+        query: 'What is DocSearch?',
+      });
+    });
+  });
+
+  it('restores a stored conversation with its persisted chat ID on Enter', async () => {
+    const conversation = createStoredConversation();
+    storedConversations = [conversation];
+    const props = createProps();
+
+    render(<DocSearchAskAiModal {...props} isAskAiActive={false} />);
+
+    const input = await screen.findByPlaceholderText(
+      'Search docs or ask AI a question'
+    );
+    await screen.findByText('What is DocSearch?');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mocks.restoreConversation).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.restoreConversation).toHaveBeenCalledWith(
+      conversation.messages,
+      'stored-chat-id'
+    );
+    expect(props.onAskAiToggle).toHaveBeenCalledWith(true, {
+      messageId: 'stored-message-id',
+      query: 'What is DocSearch?',
+    });
+  });
+
+  it('does not open Ask AI when stored conversation selection is intercepted', async () => {
+    const conversation = createStoredConversation();
+    storedConversations = [conversation];
+    const interceptAskAiEvent = vi.fn(() => true);
+    const props = createProps();
+
+    render(
+      <DocSearchAskAiModal
+        {...props}
+        interceptAskAiEvent={interceptAskAiEvent}
+        isAskAiActive={false}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('What is DocSearch?'));
+
+    expect(mocks.restoreConversation).toHaveBeenCalledWith(
+      conversation.messages,
+      'stored-chat-id'
+    );
+    expect(interceptAskAiEvent).toHaveBeenCalledWith({
+      messageId: 'stored-message-id',
+      query: 'What is DocSearch?',
+    });
+    expect(props.onAskAiToggle).not.toHaveBeenCalled();
   });
 });

--- a/packages/docsearch-react/src/utils/createAskAiSources.ts
+++ b/packages/docsearch-react/src/utils/createAskAiSources.ts
@@ -3,8 +3,12 @@ import type { SearchResponse } from 'algoliasearch/lite';
 
 import type { DocSearchTransformClient } from '../DocSearch';
 import type { PromptSuggestions } from '../DocSearchAI';
-import type { InternalDocSearchHit } from '../types';
-import type { AIMessage, PromptSuggestion } from '../types/AskiAi';
+import type {
+  InternalDocSearchHit,
+  StoredAskAiMessage,
+  StoredAskAiState,
+} from '../types';
+import type { PromptSuggestion } from '../types/AskiAi';
 
 import { SOURCE_IDS } from './collections';
 
@@ -38,15 +42,16 @@ const EMPTY_SNIPPET_RESULT: InternalDocSearchHit['_snippetResult'] = {
 export function buildRecentConversationSources({
   conversations,
   disableUserPersonalization,
-  setMessages,
-  onAskAiToggle,
+  handleSelectStoredConversation,
 }: {
-  conversations: { getAll: () => unknown[] };
+  conversations: { getAll: () => StoredAskAiState[] };
   disableUserPersonalization: boolean;
-  setMessages: (messages: AIMessage[]) => void;
-  onAskAiToggle: (toggle: boolean) => void;
+  handleSelectStoredConversation: (
+    item: StoredAskAiState,
+    event: KeyboardEvent | MouseEvent
+  ) => void;
 }): Array<
-  AutocompleteSource<InternalDocSearchHit & { messages?: AIMessage[] }>
+  AutocompleteSource<InternalDocSearchHit & { messages?: StoredAskAiMessage[] }>
 > {
   return [
     {
@@ -59,11 +64,12 @@ export function buildRecentConversationSources({
           conversations.getAll() as unknown as InternalDocSearchHit[]
         ).slice(0, MAX_RECENT_CONVERSATIONS_DISPLAYED);
       },
-      onSelect({ item }): void {
-        if (item.messages) {
-          setMessages(item.messages);
-          onAskAiToggle(true);
+      onSelect({ item, event }): void {
+        if (item.type !== 'askAI') {
+          return;
         }
+
+        handleSelectStoredConversation(item, event);
       },
     },
   ];


### PR DESCRIPTION
## Why

When selecting a stored Ask AI conversation from the start screen, the behavior was inconsistent between input methods. Clicking an item went through the modal's per-render click handler, but selecting the same item with the keyboard (arrow keys plus Enter) went through the Autocomplete source's `onSelect`, which held onto the callback captured when the Autocomplete instance was first created.

Because that instance is only created once and kept in a ref, the keyboard path could call a stale handler. The practical effect was that `interceptAskAiEvent` was skipped on keyboard selection, so integrations relying on it to intercept and handle conversation restore never fired, and the conversation would open in the modal instead of deferring to the host app.

This change routes stored conversation selection through a single handler that always reads the latest props, so keyboard and pointer selection behave identically and `interceptAskAiEvent` is honored in both cases.

## Testing scenarios

1. Configure DocSearch with Ask AI and an `interceptAskAiEvent` callback that returns `true`.
2. Start a conversation so it gets saved, then reopen the modal to the start screen where recent conversations are listed.
3. Use the arrow keys to highlight a recent conversation and press Enter. Confirm `interceptAskAiEvent` is called and the app handles the restore rather than the modal opening the conversation itself.
4. Click the same recent conversation with the mouse and confirm the behavior matches the keyboard path.
5. Repeat steps 3 and 4 without an `interceptAskAiEvent` callback and confirm the conversation restores and opens in the modal as expected.
6. Trigger a rerender of the modal (for example by changing props on the host) and confirm keyboard selection still uses the current `interceptAskAiEvent` and `onAskAiToggle`, not a stale one.