### PR TITLE
chore: automate GitHub releases

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,9 +8,11 @@
         "@axe-core/playwright": "^4.12.1",
         "@changesets/cli": "^2.29.7",
         "@eslint-community/eslint-plugin-eslint-comments": "4.4.1",
+        "@octokit/rest": "22.0.1",
         "@playwright/test": "1.49.1",
         "@stylistic/eslint-plugin": "2.13.0",
         "@testing-library/dom": "10.4.0",
+        "@types/bun": "1.3.10",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "bundlesize2": "0.0.32",
@@ -938,6 +940,30 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.7", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.4", "@octokit/request": "^10.0.13", "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.4", "", { "dependencies": { "@octokit/types": "^17.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.4", "", { "dependencies": { "@octokit/request": "^10.0.13", "@octokit/types": "^17.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@28.0.0", "", {}, "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.15", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "content-type": "^3.0.0", "json-with-bigint": "^3.5.12", "universal-user-agent": "^7.0.2" } }, "sha512-3CBg9aJ0hO9Pjyij8LbK/xYtEaPws9SW7xKz67daPNxQB1q5Y9OMA7DDOG0A6Hwf9ygGu3tvzusg0LXQ8/wAjA=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.1", "", { "dependencies": { "@octokit/types": "^17.0.0" } }, "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@17.0.0", "", { "dependencies": { "@octokit/openapi-types": "^28.0.0" } }, "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
@@ -1358,6 +1384,8 @@
 
     "@types/bonjour": ["@types/bonjour@3.5.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ=="],
 
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/connect-history-api-fallback": ["@types/connect-history-api-fallback@1.5.4", "", { "dependencies": { "@types/express-serve-static-core": "*", "@types/node": "*" } }, "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw=="],
@@ -1658,6 +1686,8 @@
 
     "batch": ["batch@0.6.1", "", {}, "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="],
 
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "big.js": ["big.js@5.2.2", "", {}, "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="],
@@ -1701,6 +1731,8 @@
     "buffer-fill": ["buffer-fill@1.0.0", "", {}, "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -2539,6 +2571,8 @@
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.12", "", {}, "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -3666,6 +3700,8 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
@@ -3995,6 +4031,12 @@
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@manypkg/get-packages/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/request/content-type": ["content-type@3.0.0", "", {}, "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
@@ -4673,6 +4715,10 @@
     "@manypkg/get-packages/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "@manypkg/get-packages/globby/slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
     "@svgr/core/cosmiconfig/import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "version": "changeset version && bun run sync:docsearch-version && bun install",
     "release": "changeset publish && bun run gh:release",
     "sync:docsearch-version": "bun scripts/updateDocsearchVersion.ts",
-    "gh:relase": "bun scripts/generate-github-releases.ts"
+    "gh:release": "bun scripts/generate-github-releases.ts"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -56,16 +56,19 @@
     "website:test": "bun --filter @docsearch/website start -- --no-open",
     "changeset": "changeset",
     "version": "changeset version && bun run sync:docsearch-version && bun install",
-    "release": "changeset publish",
-    "sync:docsearch-version": "bun scripts/updateDocsearchVersion.ts"
+    "release": "changeset publish && bun run gh:release",
+    "sync:docsearch-version": "bun scripts/updateDocsearchVersion.ts",
+    "gh:relase": "bun scripts/generate-github-releases.ts"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@changesets/cli": "^2.29.7",
     "@eslint-community/eslint-plugin-eslint-comments": "4.4.1",
+    "@octokit/rest": "22.0.1",
     "@playwright/test": "1.49.1",
     "@stylistic/eslint-plugin": "2.13.0",
     "@testing-library/dom": "10.4.0",
+    "@types/bun": "1.3.10",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "bundlesize2": "0.0.32",

--- a/scripts/generate-github-releases.ts
+++ b/scripts/generate-github-releases.ts
@@ -1,0 +1,323 @@
+// oxlint-disable no-console
+import { resolve } from 'node:path';
+import { exit } from 'node:process';
+import { parseArgs } from 'util';
+
+import { Octokit } from '@octokit/rest';
+import { $, Glob } from 'bun';
+
+const CHANGELOG_NAME = 'CHANGELOG.md';
+
+const log = {
+  colors: {
+    reset: '\x1b[0m',
+    info: Bun.color('oklch(86.5% 0.127 207.078)', 'ansi'),
+    success: Bun.color('oklch(76.5% 0.177 163.223)', 'ansi'),
+    warn: Bun.color('oklch(87.9% 0.169 91.605)', 'ansi'),
+    error: Bun.color('oklch(71.2% 0.194 13.428)', 'ansi'),
+    border: Bun.color('oklch(70.7% 0.022 261.325)', 'ansi'),
+  },
+  log(message: string) {
+    process.stdout.write(`${message}\n`);
+  },
+  line() {
+    this.log('');
+  },
+  info(message: string) {
+    this.log(`${this.colors.info}• ${message}${this.colors.reset}`);
+  },
+  success(message: string) {
+    this.log(`${this.colors.success} ${message}${this.colors.reset}`);
+  },
+  warn(message: string) {
+    this.log(`${this.colors.warn}! ${message} !${this.colors.reset}`);
+  },
+  error(message: string) {
+    this.log(`${this.colors.error} ${message}${this.colors.reset}`);
+  },
+  section(title: string) {
+    this.log(
+      `${log.colors.border}--------- ${title} -----------${log.colors.reset}`
+    );
+  },
+};
+
+async function getPublishVersion(wantedVersion: string | undefined) {
+  if (wantedVersion && wantedVersion.trim().length > 0) {
+    return wantedVersion;
+  }
+
+  const { version } = await import('../packages/docsearch-react/src/version');
+
+  return version;
+}
+
+function getChangelogEntry(changelog: string, version: string) {
+  let headingStartInfo: { index: number; depth: number } | undefined;
+  let endIndex: number | undefined;
+
+  // Iterate through each headings and code blocks (for skipping its contents)
+  const regex = /^(#{1,6})\s(.*)$|^(`{3,})/gm;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(changelog)) !== null) {
+    // Skip over code blocks so we don't match any headings inside of them
+    if (match[3]) {
+      const endOfCodeBlockRegex = new RegExp(`^${match[3]}`, 'gm');
+      endOfCodeBlockRegex.lastIndex = regex.lastIndex;
+      const endMatch = endOfCodeBlockRegex.exec(changelog);
+      if (endMatch) {
+        // Start next search for headings after the end of the code block
+        regex.lastIndex = endOfCodeBlockRegex.lastIndex;
+        continue;
+      } else {
+        // Can't find end of code block, probably malformed
+        break;
+      }
+    }
+
+    const headingDepth = match[1].length;
+    const headingText = match[2].trim();
+
+    // Search for heading of the entry
+    if (headingText === version) {
+      headingStartInfo = { index: regex.lastIndex, depth: headingDepth };
+      continue;
+    }
+
+    // If we've found the entry heading, search for the closing heading with the same depth
+    if (headingStartInfo && headingDepth === headingStartInfo.depth) {
+      endIndex = match.index;
+      break;
+    }
+  }
+
+  return changelog.slice(headingStartInfo?.index, endIndex).trim();
+}
+
+interface Pkg {
+  tagName: string;
+  path: string;
+  packageJson: { version: string } & Record<string, any>;
+}
+
+async function getPkg(tag: string): Promise<Pkg | null> {
+  const pkgJsonFiles = new Glob('{packages,adapters}/**/package.json');
+  let pkg: Pkg | null = null;
+
+  for await (const file of pkgJsonFiles.scan('.')) {
+    const pkgJson = await Bun.file(file).json();
+
+    if (tag.startsWith(`${pkgJson.name}@`)) {
+      pkg = {
+        tagName: tag,
+        path: file.replace(/\package\.json$/, ''),
+        packageJson: pkgJson,
+      };
+
+      break;
+    }
+  }
+
+  return pkg;
+}
+
+// Push git tag
+async function pushTag({
+  tagName,
+  dryRun,
+}: {
+  dryRun?: boolean;
+  tagName: string;
+}) {
+  if (dryRun) {
+    log.log(`[DRY_RUN] - Pushing tag ${tagName}`);
+    return;
+  }
+
+  try {
+    await $`git push origin ${tagName}`.quiet();
+  } catch (e) {
+    throw new Error(`Error pushing tag ${tagName}: ${e}`);
+  }
+}
+
+// Create GH release
+async function createRelease({
+  dryRun,
+  token,
+  tagName,
+  changelog,
+  prerelease = false,
+  latest,
+}: {
+  dryRun?: boolean;
+  token?: string;
+  tagName: string;
+  changelog: string;
+  prerelease?: boolean;
+  latest: boolean;
+}): Promise<void> {
+  let makeLatest: 'true' | 'false' = 'false';
+
+  if (latest && !prerelease) {
+    makeLatest = 'true';
+  }
+
+  if (dryRun) {
+    log.log(`[DRY_RUN] - Creating release for ${tagName}:`);
+    log.log(`[DRY_RUN] - Latest: ${makeLatest}`);
+    log.log(`[DRY_RUN] - Prerelease: ${prerelease}`);
+    log.line();
+    return;
+  }
+
+  try {
+    const octokit = new Octokit({ auth: token });
+
+    await octokit.rest.repos.createRelease({
+      owner: 'algolia',
+      repo: 'docsearch',
+      name: tagName,
+      tag_name: tagName,
+      body: changelog,
+      prerelease,
+      make_latest: makeLatest,
+    });
+  } catch (e) {
+    throw new Error(`Error creating release for ${tagName}: ${e}`);
+  }
+}
+
+async function getTagsForVersion(version: string) {
+  const { stdout } = await $`git tag --list '*${version}'`.quiet();
+  const tags = stdout.toString().trim().split('\n').filter(Boolean);
+
+  return tags;
+}
+
+async function getPackages(tags: string[]) {
+  const pkgs: Pkg[] = [];
+
+  for (const t of tags) {
+    const pkg = await getPkg(t);
+
+    if (!pkg) {
+      continue;
+    }
+
+    pkgs.push(pkg);
+  }
+
+  return pkgs;
+}
+
+async function runFlow({
+  dryRun,
+  version: wantedVersion,
+}: {
+  dryRun?: boolean;
+  version?: string;
+}) {
+  const githubToken = process.env.GITHUB_TOKEN;
+
+  if (!dryRun && (!githubToken || githubToken.trim() === '')) {
+    log.error('A `GITHUB_TOKEN` is required');
+    exit(1);
+  }
+
+  const publishVersion = await getPublishVersion(wantedVersion);
+  const tags = await getTagsForVersion(publishVersion);
+
+  if (tags.length === 0) {
+    log.info(
+      `No tags found to publish version v${wantedVersion} with, exiting`
+    );
+    exit(0);
+  }
+
+  const pkgs = await getPackages(tags);
+
+  if (pkgs.length === 0) {
+    log.info(`No packages found to create releases for, exiting`);
+    exit(0);
+  }
+
+  log.line();
+  log.log(`🚀 Generating package releases for v${publishVersion}`);
+  log.line();
+
+  const publishedPackages: string[] = [];
+
+  for (const pkg of pkgs) {
+    log.section(pkg.packageJson.name);
+    log.info(`Creating release for: ${pkg.packageJson.name}`);
+
+    if (dryRun) {
+      log.warn('DRY_RUN enabled - no actual changes will be published');
+    }
+
+    if (!pkg.path) {
+      log.error(`No path found for ${pkg.tagName}`);
+      continue;
+    }
+
+    try {
+      const changelog = await Bun.file(
+        resolve(pkg.path, CHANGELOG_NAME)
+      ).text();
+
+      const changelogEntry = getChangelogEntry(
+        changelog,
+        publishVersion ? publishVersion : pkg.packageJson.version
+      );
+
+      await pushTag({ tagName: pkg.tagName, dryRun });
+
+      await createRelease({
+        dryRun,
+        token: githubToken,
+        tagName: pkg.tagName,
+        changelog: changelogEntry,
+        prerelease: pkg.packageJson.version.includes('-'),
+        latest: pkg.tagName.includes('@docsearch/react'),
+      });
+
+      publishedPackages.push(pkg.packageJson.name);
+    } catch (e) {
+      log.error(Error.isError(e) ? e.message : String(e));
+    }
+    log.line();
+  }
+
+  if (!dryRun) {
+    log.line();
+  }
+
+  if (publishedPackages.length === 0) {
+    log.error('Failed to generate releases on GitHub');
+    exit(1);
+  }
+
+  log.success('GitHub releases generated for the following packages:');
+  publishedPackages.forEach((pkg) => {
+    log.log(`   -  ${pkg}`);
+  });
+}
+
+const { values } = parseArgs({
+  args: Bun.argv,
+  options: {
+    dryRun: {
+      type: 'boolean',
+      short: 'd',
+    },
+    version: {
+      type: 'string',
+      short: 'v',
+    },
+  },
+  strict: true,
+  allowPositionals: true,
+});
+
+runFlow(values);

--- a/scripts/generate-github-releases.ts
+++ b/scripts/generate-github-releases.ts
@@ -1,5 +1,5 @@
 // oxlint-disable no-console
-import { resolve } from 'node:path';
+import path, { resolve } from 'node:path';
 import { exit } from 'node:process';
 import { parseArgs } from 'util';
 
@@ -91,6 +91,10 @@ function getChangelogEntry(changelog: string, version: string) {
     }
   }
 
+  if (headingStartInfo === undefined) {
+    throw new Error(`Cannot find CHANGELOG heading for version: ${version}`);
+  }
+
   return changelog.slice(headingStartInfo?.index, endIndex).trim();
 }
 
@@ -110,7 +114,7 @@ async function getPkg(tag: string): Promise<Pkg | null> {
     if (tag.startsWith(`${pkgJson.name}@`)) {
       pkg = {
         tagName: tag,
-        path: file.replace(/\package\.json$/, ''),
+        path: path.dirname(file),
         packageJson: pkgJson,
       };
 
@@ -173,6 +177,29 @@ async function createRelease({
 
   try {
     const octokit = new Octokit({ auth: token });
+    let existingRelease = false;
+
+    try {
+      await octokit.rest.repos.getReleaseByTag({
+        owner: 'algolia',
+        repo: 'docsearch',
+        tag: tagName,
+      });
+
+      existingRelease = true;
+    } catch (e) {
+      const err = e as unknown as { status?: number };
+
+      // 404 means the release does not exist yet, and we need to create it
+      if (err.status !== 404) {
+        throw e;
+      }
+    }
+
+    if (existingRelease) {
+      log.warn(`GitHub release already exists for ${tagName}, skipping...`);
+      return;
+    }
 
     await octokit.rest.repos.createRelease({
       owner: 'algolia',
@@ -189,7 +216,7 @@ async function createRelease({
 }
 
 async function getTagsForVersion(version: string) {
-  const { stdout } = await $`git tag --list '*${version}'`.quiet();
+  const { stdout } = await $`git tag --list '*@${version}'`.quiet();
   const tags = stdout.toString().trim().split('\n').filter(Boolean);
 
   return tags;
@@ -213,10 +240,10 @@ async function getPackages(tags: string[]) {
 
 async function runFlow({
   dryRun,
-  version: wantedVersion,
+  wantedVersion,
 }: {
   dryRun?: boolean;
-  version?: string;
+  wantedVersion?: string;
 }) {
   const githubToken = process.env.GITHUB_TOKEN;
 
@@ -230,7 +257,7 @@ async function runFlow({
 
   if (tags.length === 0) {
     log.info(
-      `No tags found to publish version v${wantedVersion} with, exiting`
+      `No tags found to publish version v${publishVersion} with, exiting`
     );
     exit(0);
   }
@@ -247,6 +274,7 @@ async function runFlow({
   log.line();
 
   const publishedPackages: string[] = [];
+  const failedPackages: string[] = [];
 
   for (const pkg of pkgs) {
     log.section(pkg.packageJson.name);
@@ -279,12 +307,13 @@ async function runFlow({
         tagName: pkg.tagName,
         changelog: changelogEntry,
         prerelease: pkg.packageJson.version.includes('-'),
-        latest: pkg.tagName.includes('@docsearch/react'),
+        latest: pkg.tagName.startsWith('@docsearch/react@'),
       });
 
       publishedPackages.push(pkg.packageJson.name);
     } catch (e) {
       log.error(Error.isError(e) ? e.message : String(e));
+      failedPackages.push(pkg.packageJson.name);
     }
     log.line();
   }
@@ -302,12 +331,20 @@ async function runFlow({
   publishedPackages.forEach((pkg) => {
     log.log(`   -  ${pkg}`);
   });
+
+  if (failedPackages.length > 0) {
+    log.error('Some packages failed to be released on GitHub:');
+    failedPackages.forEach((pkg) => {
+      log.log(`   -  ${pkg}`);
+    });
+    exit(1);
+  }
 }
 
 const { values } = parseArgs({
-  args: Bun.argv,
+  args: Bun.argv.slice(2),
   options: {
-    dryRun: {
+    'dry-run': {
       type: 'boolean',
       short: 'd',
     },
@@ -317,7 +354,11 @@ const { values } = parseArgs({
     },
   },
   strict: true,
-  allowPositionals: true,
 });
 
-runFlow(values);
+runFlow({ dryRun: values['dry-run'], wantedVersion: values.version }).catch(
+  (e) => {
+    log.error(String(e));
+    exit(1);
+  }
+);


### PR DESCRIPTION
## What

Adds a script that will:

1. Push the created tags to the remote origin
2. Parse each package's `CHANGELOG.md` for release notes, then create a GitHub release.

`--dry-run/-d` Enables dry run (nothing is pushed)
`--version/-v` Set a version you are trying to create a release for

A `GITHUB_TOKEN` environment variable is required if trying to run locally:

`GITHUB_TOKEN=xyz... bun scripts/generate-github-releases.ts`

## Examples

`bun scripts/generate-github-releases.ts` -> Uses the currently set version from `@docsearch/react`

`bun scripts/generate-github-releases.ts -v 5.0.3` -> Attempts  to  publish releases for `5.0.3`