### PR TITLE
fix(ci): gate releases on releases/* merges and create tags via GitHub releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,27 @@ jobs:
     docker:
       - image: cimg/node:24.16
     steps:
+      - run:
+          name: Only release when a releases/* branch was merged
+          command: |
+            set -euo pipefail
+            head_ref="$(curl -sSf \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/algolia/docsearch/commits/${CIRCLE_SHA1}/pulls" \
+              | jq -r --arg sha "$CIRCLE_SHA1" --arg base "$CIRCLE_BRANCH" '
+                  [ .[]
+                    | select(.merged_at != null)
+                    | select(.base.ref == $base)
+                    | select(.merge_commit_sha == $sha)
+                    | .head.ref
+                  ] | first // empty')"
+            echo "Merged from: ${head_ref:-<no merged PR found>}"
+            case "$head_ref" in
+              releases/*) echo "Release branch detected, continuing" ;;
+              *) echo "Not a release merge, skipping"; circleci-agent step halt ;;
+            esac
       - checkout
       - *attach_workspace
       - run: *install_bun

--- a/scripts/generate-github-releases.ts
+++ b/scripts/generate-github-releases.ts
@@ -24,16 +24,16 @@ const log = {
     this.log('');
   },
   info(message: string) {
-    this.log(`${this.colors.info}• ${message}${this.colors.reset}`);
+    this.log(`${this.colors.info}\u2022 ${message}${this.colors.reset}`);
   },
   success(message: string) {
-    this.log(`${this.colors.success} ${message}${this.colors.reset}`);
+    this.log(`${this.colors.success}\u2713 ${message}${this.colors.reset}`);
   },
   warn(message: string) {
     this.log(`${this.colors.warn}! ${message} !${this.colors.reset}`);
   },
   error(message: string) {
-    this.log(`${this.colors.error} ${message}${this.colors.reset}`);
+    this.log(`${this.colors.error}\u2717 ${message}${this.colors.reset}`);
   },
   section(title: string) {
     this.log(
@@ -125,26 +125,6 @@ async function getPkg(tag: string): Promise<Pkg | null> {
   return pkg;
 }
 
-// Push git tag
-async function pushTag({
-  tagName,
-  dryRun,
-}: {
-  dryRun?: boolean;
-  tagName: string;
-}) {
-  if (dryRun) {
-    log.log(`[DRY_RUN] - Pushing tag ${tagName}`);
-    return;
-  }
-
-  try {
-    await $`git push origin ${tagName}`.quiet();
-  } catch (e) {
-    throw new Error(`Error pushing tag ${tagName}: ${e}`);
-  }
-}
-
 // Create GH release
 async function createRelease({
   dryRun,
@@ -153,6 +133,7 @@ async function createRelease({
   changelog,
   prerelease = false,
   latest,
+  commitSha,
 }: {
   dryRun?: boolean;
   token?: string;
@@ -160,6 +141,7 @@ async function createRelease({
   changelog: string;
   prerelease?: boolean;
   latest: boolean;
+  commitSha: string;
 }): Promise<void> {
   let makeLatest: 'true' | 'false' = 'false';
 
@@ -171,6 +153,7 @@ async function createRelease({
     log.log(`[DRY_RUN] - Creating release for ${tagName}:`);
     log.log(`[DRY_RUN] - Latest: ${makeLatest}`);
     log.log(`[DRY_RUN] - Prerelease: ${prerelease}`);
+    log.log(`[DRY_RUN] - Commit: ${commitSha}`);
     log.line();
     return;
   }
@@ -209,6 +192,7 @@ async function createRelease({
       body: changelog,
       prerelease,
       make_latest: makeLatest,
+      target_commitish: commitSha,
     });
   } catch (e) {
     throw new Error(`Error creating release for ${tagName}: ${e}`);
@@ -216,10 +200,17 @@ async function createRelease({
 }
 
 async function getTagsForVersion(version: string) {
-  const { stdout } = await $`git tag --list '*@${version}'`.quiet();
-  const tags = stdout.toString().trim().split('\n').filter(Boolean);
+  const { stdout, stderr, exitCode } = await $`git tag --list '*@${version}'`
+    .quiet()
+    .nothrow();
 
-  return tags;
+  if (exitCode !== 0) {
+    throw new Error(
+      `Failed to list git tags for version ${version} (exit ${exitCode}): ${stderr.toString().trim()}`
+    );
+  }
+
+  return stdout.toString().trim().split('\n').filter(Boolean);
 }
 
 async function getPackages(tags: string[]) {
@@ -269,8 +260,15 @@ async function runFlow({
     exit(0);
   }
 
+  const commitSha = await $`git rev-parse HEAD`
+    .quiet()
+    .text()
+    .then((sha) => sha.trim());
+
   log.line();
-  log.log(`🚀 Generating package releases for v${publishVersion}`);
+  log.log(
+    `🚀 Generating package releases for v${publishVersion} and commit ${commitSha}`
+  );
   log.line();
 
   const publishedPackages: string[] = [];
@@ -299,8 +297,6 @@ async function runFlow({
         publishVersion ? publishVersion : pkg.packageJson.version
       );
 
-      await pushTag({ tagName: pkg.tagName, dryRun });
-
       await createRelease({
         dryRun,
         token: githubToken,
@@ -308,6 +304,7 @@ async function runFlow({
         changelog: changelogEntry,
         prerelease: pkg.packageJson.version.includes('-'),
         latest: pkg.tagName.startsWith('@docsearch/react@'),
+        commitSha,
       });
 
       publishedPackages.push(pkg.packageJson.name);


### PR DESCRIPTION
## Why

The release CI job runs on every merge to `main`, but it's only meant to actually publish packages when a `releases/*` branch is merged. There was no explicit check for this, so any merge to `main` could trigger `bun run release`, risking accidental publishes for unrelated changes.

Tagging also relied on pushing git tags directly from CI before creating the GitHub release. This meant tag creation and release creation were two separate steps that could get out of sync, and it required CI to have push access to the repo just for tagging. Passing the commit SHA to GitHub's release API via `target_commitish` lets GitHub create the tag as part of the release itself, tying it directly to the commit being released and removing the extra push step entirely.

`getTagsForVersion` also swallowed errors from the underlying `git tag` command, so a failed lookup would silently return an empty array instead of surfacing what went wrong.