### PR TITLE
feat(facets): support selecting multiple values per facet

### DIFF
--- a/.changeset/happy-spiders-stop.md
+++ b/.changeset/happy-spiders-stop.md
@@ -1,0 +1,13 @@
+---
+"@docsearch/react": minor
+"@docsearch/css": minor
+---
+
+feat(facets): Support selecting multiple values per facet
+
+`FacetBar` now renders checkbox items instead of a radio group, so users can
+select more than one value per facet. Selected values for the same facet are
+combined into an Algolia `facetFilters` OR group; different facets are still
+combined with AND. Configured `facetFilters` OR groups that share a single
+facet key (for example `['lang:en', 'lang:fr']`) are now recognized as the
+default selection for that facet, in addition to single `key:value` entries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ bun run lint:css
 ## E2E Testing (Playwright)
 
 ```bash
-# Run Cypress tests
+# Run all Playwright tests
 bun run pw:run
 
 # Run with specific browser
@@ -75,6 +75,38 @@ bun run pw:run:chromium
 bun run pw:run:firefox
 bun run pw:run:webkit
 ```
+
+Only the `chromium` project is currently enabled in `playwright.config.ts`; `firefox` and `webkit` will not run until those projects are uncommented, even though their `pw:run:*` scripts exist.
+
+Playwright auto-starts the Docusaurus site (`bun run website:test`) on `http://localhost:3000` and reuses an already-running server locally (not in CI). Tests hit the live Algolia index for the docs site, so outbound network access is required.
+
+### Accessibility Tests (axe + Playwright)
+
+- **When to run:** For changes to widget markup, styles, keyboard handling, focus management, or ARIA attributes. Add or extend coverage when introducing new interactive behavior.
+- **Where tests live:**
+  - `e2e/a11y.test.ts` - dedicated axe scans (modal smoke test, modal search results, sidepanel smoke test)
+  - `e2e/fixtures.ts` - shared fixtures, page-ready helpers, and the `gatherA11yViolations` / `axe()` helper (WCAG 2.0/2.1/2.2 A & AA tags)
+  - `e2e/search.spec.ts` - keyboard, focus, and ARIA state assertions (shortcuts, arrow navigation, `aria-activedescendant`, `aria-selected`)
+
+```bash
+# Install the Chromium browser binary (first run only)
+bunx playwright install chromium
+
+# Build workspace packages before running e2e
+bun run build
+
+# Run the dedicated accessibility scans
+bun run pw:run e2e/a11y.test.ts --project=chromium
+
+# Run accessibility scans plus keyboard/focus/ARIA regression tests
+bun run pw:run e2e/a11y.test.ts e2e/search.spec.ts --project=chromium
+
+# Run a single accessibility test by name
+bun run pw:run e2e/a11y.test.ts --project=chromium --grep 'Modal Search results'
+```
+
+- **Test-authoring pattern:** Reuse the shared `axe()` fixture instead of instantiating `AxeBuilder` directly, wait for the target UI state (modal focused, sidepanel open, results rendered) before scanning, scope `.include()` to the relevant container, and attach `scanResults.violations` via `testInfo.attach` for debugging.
+- **Interpreting results:** Existing tests assert a maximum violation-node count per scan (currently 6/24/4), not zero violations. `gatherA11yViolations` flattens `violations[].nodes`, so the count reflects affected elements, not unique rules. Passing means staying within the existing budget — it is not a full accessibility certification, and automated axe checks don't replace manual keyboard traversal and screen-reader verification. Don't raise a threshold or add `.exclude()`/`disableRules()` just to make a failing test pass; investigate the regression, fix it, and only adjust the budget with an explicit justification.
 
 ## Code Style Guidelines
 

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/docsearch-react/dist/umd/index.js",
-      "maxSize": "160 kB"
+      "maxSize": "161 kB"
     },
     {
       "path": "packages/docsearch-js/dist/umd/index.js",

--- a/packages/docsearch-css/src/modal.css
+++ b/packages/docsearch-css/src/modal.css
@@ -288,16 +288,29 @@
     background: var(--docsearch-dropdown-menu-item-hover-background);
   }
 
+  /* Keyboard focus needs a cue distinct from the shared hover/highlight background. */
+  &:focus-visible {
+    outline: 2px solid var(--docsearch-focus-color);
+    outline-offset: -2px;
+  }
+
   svg {
     flex-shrink: 0;
   }
 }
 
-.DocSearch-Menu-RadioItem[data-checked] {
+.DocSearch-Menu-RadioItem[data-checked],
+.DocSearch-Menu-CheckboxItem[data-checked] {
   color: var(--docsearch-highlight-color);
 }
 
-.DocSearch-Menu-RadioItem-Indicator {
+/* Aligns the reset item's label with sibling items that render an indicator. */
+.DocSearch-Menu-ResetItem {
+  padding-inline-start: calc(1.14em + 1rem + 0.25rem);
+}
+
+.DocSearch-Menu-RadioItem-Indicator,
+.DocSearch-Menu-CheckboxItem-Indicator {
   --indicator-size: 1rem;
 
   pointer-events: none;

--- a/packages/docsearch-react/src/__tests__/utils.test.ts
+++ b/packages/docsearch-react/src/__tests__/utils.test.ts
@@ -95,7 +95,46 @@ describe('utils', () => {
             searchParameters: { facetFilters: 'format:guide' as never },
           },
         ])
-      ).toEqual({ language: 'fr', version: 'v2', format: 'guide' });
+      ).toEqual({ language: ['fr'], version: ['v2'], format: ['guide'] });
+    });
+
+    it('derives multiple selections from a single-key OR group', () => {
+      expect(
+        deriveDefaultSelectedFacetsFromIndex([
+          {
+            name: 'docs',
+            searchParameters: {
+              facetFilters: [
+                'language:en',
+                [
+                  'docusaurus_tag:default',
+                  'docusaurus_tag:docs-default-current',
+                ],
+              ],
+            },
+          },
+        ])
+      ).toEqual({
+        language: ['en'],
+        docusaurus_tag: ['default', 'docs-default-current'],
+      });
+    });
+
+    it('ignores OR groups that mix facet keys or contain invalid entries', () => {
+      expect(
+        deriveDefaultSelectedFacetsFromIndex([
+          {
+            name: 'docs',
+            searchParameters: {
+              facetFilters: [
+                ['language:en', 'type:guide'],
+                ['version:v1', 'invalid'],
+                [],
+              ],
+            },
+          },
+        ])
+      ).toEqual({});
     });
 
     it('returns configured facetFilters when no dynamic facets are selected', () => {
@@ -105,16 +144,25 @@ describe('utils', () => {
     it('merges configured and dynamic facetFilters', () => {
       expect(
         createFacetFilters(['docusaurus_tag:default'], {
-          language: 'en',
-          version: 'v2',
+          language: ['en'],
+          version: ['v2'],
         })
       ).toEqual(['docusaurus_tag:default', 'language:en', 'version:v2']);
+    });
+
+    it('combines multiple values of the same facet into an OR group', () => {
+      expect(
+        createFacetFilters(undefined, {
+          language: ['en', 'fr'],
+          version: ['v2'],
+        })
+      ).toEqual([['language:en', 'language:fr'], 'version:v2']);
     });
 
     it('overrides configured filters with dynamic selections for the same facet', () => {
       expect(
         createFacetFilters(['language:en', 'version:v2'], {
-          language: 'fr',
+          language: ['fr'],
         })
       ).toEqual(['version:v2', 'language:fr']);
     });
@@ -122,10 +170,30 @@ describe('utils', () => {
     it('removes configured filters for cleared facet selections', () => {
       expect(
         createFacetFilters(['language:en', 'version:v2'], {
-          language: '',
-          type: 'guide',
+          language: [],
+          type: ['guide'],
         })
       ).toEqual(['version:v2', 'type:guide']);
+    });
+
+    it('replaces a configured OR group when every key in it is selected', () => {
+      expect(
+        createFacetFilters(
+          [
+            'language:en',
+            ['docusaurus_tag:default', 'docusaurus_tag:docs-default-current'],
+          ],
+          { docusaurus_tag: ['docs-default-next'] }
+        )
+      ).toEqual(['language:en', 'docusaurus_tag:docs-default-next']);
+    });
+
+    it('keeps a configured OR group when only some of its keys are selected', () => {
+      expect(
+        createFacetFilters([['language:en', 'type:guide']], {
+          language: ['fr'],
+        })
+      ).toEqual([['language:en', 'type:guide'], 'language:fr']);
     });
   });
 

--- a/packages/docsearch-react/src/components/FacetBar.tsx
+++ b/packages/docsearch-react/src/components/FacetBar.tsx
@@ -3,7 +3,10 @@ import React, { type JSX } from 'react';
 import type { DocSearchFacet } from '../DocSearch';
 import { ChevronIcon } from '../icons';
 import { capitalize } from '../utils';
-import type { FacetSelections } from '../utils/createDocSearchSources';
+import type {
+  FacetSelections,
+  FacetSelectionUpdate,
+} from '../utils/createDocSearchSources';
 import { getFacetLabel } from '../utils/facets';
 
 import { Chip } from './ui/Chip';
@@ -17,7 +20,8 @@ export type FacetBarTranslations = Partial<{
    */
   defaultValueLabel: string;
   /**
-   * Facet menu trigger aria label when a facet is selected.
+   * Facet menu trigger aria label suffix when one or more values are selected,
+   * for example `Language, en, fr selected`.
    *
    * @default 'selected'
    */
@@ -52,30 +56,83 @@ export interface FacetBarFacet extends DocSearchFacet {
   values: string[];
 }
 
+const EMPTY_SELECTION: string[] = [];
+
+interface FacetValueItemProps {
+  facetKey: string;
+  value: string;
+  checked: boolean;
+  onToggle: (facetKey: string, value: string) => void;
+}
+
+const FacetValueItem = React.memo(function FacetValueItem({
+  facetKey,
+  value,
+  checked,
+  onToggle,
+}: FacetValueItemProps): JSX.Element {
+  const handleCheckedChange = React.useCallback(() => {
+    onToggle(facetKey, value);
+  }, [facetKey, onToggle, value]);
+
+  return (
+    <Menu.CheckboxItem
+      checked={checked}
+      label={value}
+      onCheckedChange={handleCheckedChange}
+    >
+      {capitalize(value)}
+    </Menu.CheckboxItem>
+  );
+});
+
+function toggleValue(value: string) {
+  return (currentValues: string[]): string[] =>
+    currentValues.includes(value)
+      ? currentValues.filter((selected) => selected !== value)
+      : [...currentValues, value];
+}
+
+function removeValue(value: string) {
+  return (currentValues: string[]): string[] =>
+    currentValues.filter((selected) => selected !== value);
+}
+
 interface FacetMenuProps {
   facet: FacetBarFacet;
-  selectedValue: string;
+  selectedValues: string[];
   defaultValueLabel: string;
   menuTriggerSelectedAriaLabel: string;
-  onSelectionChange: (facet: string, value: string) => void;
+  onSelectionChange: (facet: string, update: FacetSelectionUpdate) => void;
   registerTrigger: (facetKey: string, el: HTMLButtonElement | null) => void;
 }
 
 const FacetMenu = React.memo(function FacetMenu({
   facet,
-  selectedValue,
+  selectedValues,
   defaultValueLabel,
   onSelectionChange,
   registerTrigger,
   menuTriggerSelectedAriaLabel,
 }: FacetMenuProps): JSX.Element {
   const label = getFacetLabel(facet);
-  const handleValueChange = React.useCallback(
-    (value: string) => {
-      onSelectionChange(facet.key, value);
-    },
-    [facet.key, onSelectionChange]
+  const hasSelection = selectedValues.length > 0;
+  const selectedSet = React.useMemo(
+    () => new Set(selectedValues),
+    [selectedValues]
   );
+
+  const handleToggleValue = React.useCallback(
+    (facetKey: string, value: string) => {
+      onSelectionChange(facetKey, toggleValue(value));
+    },
+    [onSelectionChange]
+  );
+
+  const handleSelectAll = React.useCallback(() => {
+    onSelectionChange(facet.key, EMPTY_SELECTION);
+  }, [facet.key, onSelectionChange]);
+
   const triggerRef = React.useCallback(
     (el: HTMLButtonElement | null) => {
       registerTrigger(facet.key, el);
@@ -87,10 +144,10 @@ const FacetMenu = React.memo(function FacetMenu({
     <Menu>
       <Menu.Trigger
         ref={triggerRef}
-        data-has-selection={Boolean(selectedValue)}
+        data-has-selection={hasSelection}
         aria-label={
-          selectedValue
-            ? `${label}, ${selectedValue} ${menuTriggerSelectedAriaLabel}`
+          hasSelection
+            ? `${label}, ${selectedValues.join(', ')} ${menuTriggerSelectedAriaLabel}`
             : label
         }
       >
@@ -98,19 +155,22 @@ const FacetMenu = React.memo(function FacetMenu({
         <ChevronIcon />
       </Menu.Trigger>
       <Menu.Popup>
-        <Menu.RadioGroup
-          value={selectedValue}
-          onValueChange={handleValueChange}
+        <Menu.Item
+          className="DocSearch-Menu-ResetItem"
+          label={`${defaultValueLabel} ${label}`}
+          onClick={handleSelectAll}
         >
-          <Menu.RadioItem value="" label={`${defaultValueLabel} ${label}`}>
-            {defaultValueLabel}
-          </Menu.RadioItem>
-          {facet.values.map((value) => (
-            <Menu.RadioItem key={value} value={value} label={value}>
-              {capitalize(value)}
-            </Menu.RadioItem>
-          ))}
-        </Menu.RadioGroup>
+          {defaultValueLabel}
+        </Menu.Item>
+        {facet.values.map((value) => (
+          <FacetValueItem
+            key={value}
+            facetKey={facet.key}
+            value={value}
+            checked={selectedSet.has(value)}
+            onToggle={handleToggleValue}
+          />
+        ))}
       </Menu.Popup>
     </Menu>
   );
@@ -123,6 +183,7 @@ interface SelectedFacetChipProps {
   dismissAriaLabel: string;
   onDismiss: (
     facetKey: string,
+    value: string,
     event: React.MouseEvent<HTMLButtonElement>
   ) => void;
 }
@@ -136,9 +197,9 @@ const SelectedFacetChip = React.memo(function SelectedFacetChip({
 }: SelectedFacetChipProps): JSX.Element | null {
   const handleDismissFacet = React.useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
-      onDismiss(facetKey, e);
+      onDismiss(facetKey, value, e);
     },
-    [facetKey, onDismiss]
+    [facetKey, onDismiss, value]
   );
 
   return (
@@ -155,7 +216,7 @@ const SelectedFacetChip = React.memo(function SelectedFacetChip({
 interface FacetBarProps {
   facets: FacetBarFacet[];
   selections: FacetSelections;
-  onSelectionChange: (facet: string, value: string) => void;
+  onSelectionChange: (facet: string, update: FacetSelectionUpdate) => void;
   clearSelections: () => void;
   translations?: FacetBarTranslations;
 }
@@ -180,9 +241,17 @@ export const FacetBar = React.memo(function FacetBar({
     [facets]
   );
   const selectionsToDisplay = React.useMemo(() => {
-    return Object.entries(selections).filter(
-      ([key, value]) => Boolean(value) && visibleFacetKeys.has(key)
-    );
+    const entries: Array<[key: string, value: string]> = [];
+
+    for (const [key, values] of Object.entries(selections)) {
+      if (!visibleFacetKeys.has(key)) continue;
+
+      for (const value of values) {
+        entries.push([key, value]);
+      }
+    }
+
+    return entries;
   }, [selections, visibleFacetKeys]);
 
   const triggerRefs = React.useRef(new Map<string, HTMLButtonElement>());
@@ -199,7 +268,11 @@ export const FacetBar = React.memo(function FacetBar({
   );
 
   const handleDismissFacet = React.useCallback(
-    (facetKey: string, ev: React.MouseEvent<HTMLButtonElement>) => {
+    (
+      facetKey: string,
+      value: string,
+      ev: React.MouseEvent<HTMLButtonElement>
+    ) => {
       const dismissButton = ev.currentTarget;
       const selectionBar = dismissButton.closest(
         '.DocSearch-FacetSelectionBar'
@@ -220,7 +293,7 @@ export const FacetBar = React.memo(function FacetBar({
         target?.focus();
       }
 
-      onSelectionChange(facetKey, '');
+      onSelectionChange(facetKey, removeValue(value));
     },
     [onSelectionChange]
   );
@@ -246,21 +319,17 @@ export const FacetBar = React.memo(function FacetBar({
         role="group"
         aria-label={facetsAriaLabel}
       >
-        {facets.map((facet) => {
-          const selectedValue = selections[facet.key] ?? '';
-
-          return (
-            <FacetMenu
-              key={facet.key}
-              facet={facet}
-              selectedValue={selectedValue}
-              defaultValueLabel={defaultValueLabel}
-              registerTrigger={registerTrigger}
-              menuTriggerSelectedAriaLabel={facetMenuTriggerAriaLabel}
-              onSelectionChange={onSelectionChange}
-            />
-          );
-        })}
+        {facets.map((facet) => (
+          <FacetMenu
+            key={facet.key}
+            facet={facet}
+            selectedValues={selections[facet.key] ?? EMPTY_SELECTION}
+            defaultValueLabel={defaultValueLabel}
+            registerTrigger={registerTrigger}
+            menuTriggerSelectedAriaLabel={facetMenuTriggerAriaLabel}
+            onSelectionChange={onSelectionChange}
+          />
+        ))}
       </div>
       {selectionsToDisplay.length > 0 && (
         <div
@@ -270,7 +339,7 @@ export const FacetBar = React.memo(function FacetBar({
         >
           {selectionsToDisplay.map(([key, value]) => (
             <SelectedFacetChip
-              key={key}
+              key={`${key}:${value}`}
               facetKey={key}
               facetLabel={facetLabels.get(key) ?? key}
               value={value}

--- a/packages/docsearch-react/src/components/__tests__/FacetBar.test.tsx
+++ b/packages/docsearch-react/src/components/__tests__/FacetBar.test.tsx
@@ -9,6 +9,7 @@ import '@testing-library/jest-dom/vitest';
 import React, { type JSX } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+import type { FacetSelectionUpdate } from '../../utils/createDocSearchSources';
 import { FacetBar } from '../FacetBar';
 
 const FACETS = [
@@ -16,21 +17,38 @@ const FACETS = [
   { key: 'docs_version', label: 'Version', values: ['v1.0', 'v2.0'] },
 ];
 
+function resolveUpdate(
+  update: FacetSelectionUpdate,
+  currentValues: string[]
+): string[] {
+  return typeof update === 'function' ? update(currentValues) : update;
+}
+
+/**
+ * Renders the bar with a spy that records the resolved values for each change,
+ * mirroring how useDocSearchFacets resolves functional updates.
+ */
 function renderFacetBar(
   overrides: Partial<React.ComponentProps<typeof FacetBar>> = {}
 ): {
   onSelectionChange: ReturnType<typeof vi.fn>;
   clearSelections: ReturnType<typeof vi.fn>;
 } {
+  const selections = overrides.selections ?? {};
   const onSelectionChange = vi.fn();
   const clearSelections = vi.fn();
   render(
     <FacetBar
       facets={FACETS}
-      selections={{}}
       clearSelections={clearSelections}
-      onSelectionChange={onSelectionChange}
       {...overrides}
+      selections={selections}
+      onSelectionChange={(facet: string, update: FacetSelectionUpdate) => {
+        onSelectionChange(
+          facet,
+          resolveUpdate(update, selections[facet] ?? [])
+        );
+      }}
     />
   );
   return { onSelectionChange, clearSelections };
@@ -43,18 +61,16 @@ function renderFacetBar(
 function StatefulFacetBar({
   initialSelections,
 }: {
-  initialSelections: Record<string, string>;
+  initialSelections: Record<string, string[]>;
 }): JSX.Element {
   const [selections, setSelections] = React.useState(initialSelections);
 
   const handleSelectionChange = React.useCallback(
-    (facet: string, value: string) => {
-      setSelections((prev) => {
-        const next = { ...prev };
-        if (value === '') delete next[facet];
-        else next[facet] = value;
-        return next;
-      });
+    (facet: string, update: FacetSelectionUpdate) => {
+      setSelections((prev) => ({
+        ...prev,
+        [facet]: resolveUpdate(update, prev[facet] ?? []),
+      }));
     },
     []
   );
@@ -105,7 +121,7 @@ describe('FacetBar', () => {
   });
 
   it('marks triggers with a selection via data-has-selection', () => {
-    renderFacetBar({ selections: { language: 'en' } });
+    renderFacetBar({ selections: { language: ['en'] } });
 
     expect(
       screen.getByRole('button', { name: 'Language, en selected' })
@@ -116,40 +132,141 @@ describe('FacetBar', () => {
     );
   });
 
-  it('calls onSelectionChange when selecting a facet value', async () => {
+  it('announces every selected value in the trigger aria label', () => {
+    renderFacetBar({ selections: { language: ['en', 'fr'] } });
+
+    expect(
+      screen.getByRole('button', { name: 'Language, en, fr selected' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders facet values as checkbox menu items', async () => {
+    renderFacetBar({ selections: { language: ['en'] } });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Language, en selected' })
+    );
+
+    expect(
+      await screen.findByRole('menuitemcheckbox', { name: 'En' })
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('menuitemcheckbox', { name: 'Fr' })
+    ).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('renders the default option as a plain action item', async () => {
+    renderFacetBar();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Language' }));
+
+    const defaultOption = await screen.findByRole('menuitem', {
+      name: 'All',
+    });
+    expect(defaultOption).not.toHaveAttribute('aria-checked');
+  });
+
+  it('calls onSelectionChange with the added value when selecting a facet value', async () => {
     const { onSelectionChange } = renderFacetBar();
 
     fireEvent.click(screen.getByRole('button', { name: 'Language' }));
 
-    const option = await screen.findByRole('menuitemradio', { name: 'Fr' });
+    const option = await screen.findByRole('menuitemcheckbox', { name: 'Fr' });
     fireEvent.click(option);
 
     await waitFor(() => {
-      expect(onSelectionChange).toHaveBeenCalledWith('language', 'fr');
+      expect(onSelectionChange).toHaveBeenCalledWith('language', ['fr']);
     });
   });
 
-  it('offers a default option that clears the facet selection', async () => {
+  it('appends to existing selections when selecting another value', async () => {
     const { onSelectionChange } = renderFacetBar({
-      selections: { language: 'en' },
+      selections: { language: ['en'] },
     });
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Language, en selected' })
     );
 
-    const defaultOption = await screen.findByRole('menuitemradio', {
+    const option = await screen.findByRole('menuitemcheckbox', { name: 'Fr' });
+    fireEvent.click(option);
+
+    await waitFor(() => {
+      expect(onSelectionChange).toHaveBeenCalledWith('language', ['en', 'fr']);
+    });
+  });
+
+  it('removes a value when unselecting a checked facet value', async () => {
+    const { onSelectionChange } = renderFacetBar({
+      selections: { language: ['en', 'fr'] },
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Language, en, fr selected' })
+    );
+
+    const option = await screen.findByRole('menuitemcheckbox', { name: 'En' });
+    fireEvent.click(option);
+
+    await waitFor(() => {
+      expect(onSelectionChange).toHaveBeenCalledWith('language', ['fr']);
+    });
+  });
+
+  it('accumulates rapid toggles without losing earlier selections', async () => {
+    render(<StatefulFacetBar initialSelections={{}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Language' }));
+
+    const en = await screen.findByRole('menuitemcheckbox', { name: 'En' });
+    const fr = screen.getByRole('menuitemcheckbox', { name: 'Fr' });
+    fireEvent.click(en);
+    fireEvent.click(fr);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Language, en, fr selected' })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the menu open after toggling a value', async () => {
+    render(<StatefulFacetBar initialSelections={{}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Language' }));
+
+    const option = await screen.findByRole('menuitemcheckbox', { name: 'Fr' });
+    fireEvent.click(option);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menuitemcheckbox', { name: 'Fr' })
+      ).toHaveAttribute('aria-checked', 'true');
+    });
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('offers a default option that clears the facet selection', async () => {
+    const { onSelectionChange } = renderFacetBar({
+      selections: { language: ['en', 'fr'] },
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Language, en, fr selected' })
+    );
+
+    const defaultOption = await screen.findByRole('menuitem', {
       name: 'All',
     });
     fireEvent.click(defaultOption);
 
     await waitFor(() => {
-      expect(onSelectionChange).toHaveBeenCalledWith('language', '');
+      expect(onSelectionChange).toHaveBeenCalledWith('language', []);
     });
   });
 
   it('does not render the selection bar when nothing is selected', () => {
-    renderFacetBar({ selections: { language: '' } });
+    renderFacetBar({ selections: { language: [] } });
 
     expect(
       screen.queryByRole('group', { name: 'Selected search filters' })
@@ -157,32 +274,38 @@ describe('FacetBar', () => {
   });
 
   it('renders a chip per selected facet value', () => {
-    renderFacetBar({ selections: { language: 'en', docs_version: 'v2.0' } });
+    renderFacetBar({
+      selections: { language: ['en', 'fr'], docs_version: ['v2.0'] },
+    });
 
     const selectionBar = screen.getByRole('group', {
       name: 'Selected search filters',
     });
     expect(selectionBar).toHaveTextContent('En');
+    expect(selectionBar).toHaveTextContent('Fr');
     expect(selectionBar).toHaveTextContent('V2.0');
+    expect(
+      screen.getAllByRole('button', { name: /^Clear filter:/ })
+    ).toHaveLength(3);
   });
 
-  it('clears a single selection when dismissing its chip', () => {
+  it('clears only the dismissed value when dismissing its chip', () => {
     const { onSelectionChange } = renderFacetBar({
-      selections: { language: 'en', docs_version: 'v2.0' },
+      selections: { language: ['en', 'fr'], docs_version: ['v2.0'] },
     });
 
-    const dismissLanguage = screen.getByRole('button', {
+    const dismissEnglish = screen.getByRole('button', {
       name: 'Clear filter: En (Language)',
     });
-    fireEvent.click(dismissLanguage);
+    fireEvent.click(dismissEnglish);
 
     expect(onSelectionChange).toHaveBeenCalledTimes(1);
-    expect(onSelectionChange).toHaveBeenCalledWith('language', '');
+    expect(onSelectionChange).toHaveBeenCalledWith('language', ['fr']);
   });
 
   it('clears every selection when clicking "Clear all"', () => {
     const { clearSelections } = renderFacetBar({
-      selections: { language: 'en', docs_version: 'v2.0' },
+      selections: { language: ['en'], docs_version: ['v2.0'] },
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear all' }));
@@ -192,7 +315,7 @@ describe('FacetBar', () => {
 
   it('uses custom translations', () => {
     renderFacetBar({
-      selections: { language: 'en' },
+      selections: { language: ['en'] },
       translations: {
         clearAllLabel: 'Tout effacer',
         facetsAriaLabel: 'Filtres',
@@ -213,7 +336,7 @@ describe('FacetBar', () => {
     it('moves focus to the next chip when dismissing a chip with siblings', () => {
       render(
         <StatefulFacetBar
-          initialSelections={{ language: 'en', docs_version: 'v2.0' }}
+          initialSelections={{ language: ['en'], docs_version: ['v2.0'] }}
         />
       );
 
@@ -233,10 +356,29 @@ describe('FacetBar', () => {
       ).toHaveFocus();
     });
 
+    it('moves focus to the next chip of the same facet when dismissing one of its values', () => {
+      render(
+        <StatefulFacetBar initialSelections={{ language: ['en', 'fr'] }} />
+      );
+
+      const dismissEnglish = screen.getByRole('button', {
+        name: 'Clear filter: En (Language)',
+      });
+      dismissEnglish.focus();
+      fireEvent.click(dismissEnglish);
+
+      expect(
+        screen.queryByRole('button', { name: 'Clear filter: En (Language)' })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Clear filter: Fr (Language)' })
+      ).toHaveFocus();
+    });
+
     it('moves focus to the previous chip when dismissing the last chip in the row', () => {
       render(
         <StatefulFacetBar
-          initialSelections={{ language: 'en', docs_version: 'v2.0' }}
+          initialSelections={{ language: ['en'], docs_version: ['v2.0'] }}
         />
       );
 
@@ -252,7 +394,7 @@ describe('FacetBar', () => {
     });
 
     it("moves focus to the facet's menu trigger when dismissing the only chip", () => {
-      render(<StatefulFacetBar initialSelections={{ language: 'en' }} />);
+      render(<StatefulFacetBar initialSelections={{ language: ['en'] }} />);
 
       const dismiss = screen.getByRole('button', {
         name: 'Clear filter: En (Language)',
@@ -271,7 +413,7 @@ describe('FacetBar', () => {
     it('moves focus to the first facet trigger when clicking "Clear all"', () => {
       render(
         <StatefulFacetBar
-          initialSelections={{ language: 'en', docs_version: 'v2.0' }}
+          initialSelections={{ language: ['en'], docs_version: ['v2.0'] }}
         />
       );
 

--- a/packages/docsearch-react/src/components/ui/Menu.tsx
+++ b/packages/docsearch-react/src/components/ui/Menu.tsx
@@ -51,6 +51,16 @@ function MenuPopup({
 
 Menu.Popup = MenuPopup;
 
+function MenuItem({
+  className,
+  ...props
+}: MenuPrimitive.Item.Props): JSX.Element {
+  const cn = `DocSearch-Menu-Item${className ? ` ${className}` : ''}`;
+  return <MenuPrimitive.Item className={cn} {...props} />;
+}
+
+Menu.Item = MenuItem;
+
 function MenuRadioGroup({
   ...props
 }: MenuPrimitive.RadioGroup.Props): JSX.Element {
@@ -78,6 +88,26 @@ function MenuRadioItem({
 }
 
 Menu.RadioItem = MenuRadioItem;
+
+function MenuCheckboxItem({
+  className,
+  children,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props): JSX.Element {
+  const cn = `DocSearch-Menu-Item DocSearch-Menu-CheckboxItem${className ? ` ${className}` : ''}`;
+  return (
+    <MenuPrimitive.CheckboxItem className={cn} {...props}>
+      <span className="DocSearch-Menu-CheckboxItem-Indicator">
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  );
+}
+
+Menu.CheckboxItem = MenuCheckboxItem;
 
 function MenuGroupLabel({
   className,

--- a/packages/docsearch-react/src/hooks/__tests__/useDocSearchFacets.test.tsx
+++ b/packages/docsearch-react/src/hooks/__tests__/useDocSearchFacets.test.tsx
@@ -57,14 +57,119 @@ describe('useDocSearchFacets', () => {
     );
 
     act(() => {
-      result.current.handleFacetSelectionChange('language', 'en');
+      result.current.handleFacetSelectionChange('language', ['en']);
     });
 
-    expect(result.current.facetSelections).toEqual({ language: 'en' });
+    expect(result.current.facetSelections).toEqual({ language: ['en'] });
     expect(result.current.facetSelectionsRef.current).toEqual({
-      language: 'en',
+      language: ['en'],
     });
     expect(onSelectionsChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports multiple selected values per facet', () => {
+    const onSelectionsChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDocSearchFacets({
+        facets: [{ key: 'language' }],
+        indexes,
+        searchClient,
+        onSelectionsChange,
+      })
+    );
+
+    act(() => {
+      result.current.handleFacetSelectionChange('language', ['en', 'fr']);
+    });
+
+    expect(result.current.facetSelections).toEqual({ language: ['en', 'fr'] });
+    expect(onSelectionsChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves functional updates against the current selections', () => {
+    const { result } = renderHook(() =>
+      useDocSearchFacets({
+        facets: [{ key: 'language' }],
+        indexes,
+        searchClient,
+      })
+    );
+
+    // Two toggles in the same act: the second must see the first's result.
+    act(() => {
+      result.current.handleFacetSelectionChange('language', (current) => [
+        ...current,
+        'en',
+      ]);
+      result.current.handleFacetSelectionChange('language', (current) => [
+        ...current,
+        'fr',
+      ]);
+    });
+
+    expect(result.current.facetSelections).toEqual({ language: ['en', 'fr'] });
+  });
+
+  it('does not notify when the selected values are unchanged', () => {
+    const onSelectionsChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDocSearchFacets({
+        facets: [{ key: 'language' }],
+        indexes,
+        searchClient,
+        onSelectionsChange,
+      })
+    );
+
+    act(() => {
+      result.current.handleFacetSelectionChange('language', ['en', 'fr']);
+    });
+    act(() => {
+      result.current.handleFacetSelectionChange('language', ['en', 'fr']);
+    });
+
+    expect(onSelectionsChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when clearing a facet that has no selection', () => {
+    const onSelectionsChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDocSearchFacets({
+        facets: [{ key: 'language' }],
+        indexes,
+        searchClient,
+        onSelectionsChange,
+      })
+    );
+
+    act(() => {
+      result.current.handleFacetSelectionChange('language', []);
+    });
+
+    expect(result.current.facetSelections).toEqual({});
+    expect(onSelectionsChange).not.toHaveBeenCalled();
+  });
+
+  it('derives initial selections from configured facetFilters', () => {
+    const { result } = renderHook(() =>
+      useDocSearchFacets({
+        facets: [{ key: 'language' }],
+        indexes: [
+          {
+            name: 'docs',
+            searchParameters: {
+              facetFilters: ['language:en', ['version:v1', 'version:v2']],
+            },
+          },
+        ],
+        searchClient,
+      })
+    );
+
+    expect(result.current.facetSelections).toEqual({
+      language: ['en'],
+      version: ['v1', 'v2'],
+    });
   });
 
   it('updates the ref synchronously so getSources closures read fresh selections', () => {
@@ -76,13 +181,13 @@ describe('useDocSearchFacets', () => {
       })
     );
 
-    let refValueDuringChange: Record<string, string> | undefined;
+    let refValueDuringChange: Record<string, string[]> | undefined;
     act(() => {
-      result.current.handleFacetSelectionChange('language', 'fr');
+      result.current.handleFacetSelectionChange('language', ['fr']);
       refValueDuringChange = { ...result.current.facetSelectionsRef.current };
     });
 
-    expect(refValueDuringChange).toEqual({ language: 'fr' });
+    expect(refValueDuringChange).toEqual({ language: ['fr'] });
   });
 
   it('clears all selections and notifies', () => {
@@ -97,14 +202,72 @@ describe('useDocSearchFacets', () => {
     );
 
     act(() => {
-      result.current.handleFacetSelectionChange('language', 'en');
+      result.current.handleFacetSelectionChange('language', ['en', 'fr']);
     });
     act(() => {
       result.current.clearFacetSelections();
     });
 
-    expect(result.current.facetSelections).toEqual({ language: '' });
-    expect(result.current.facetSelectionsRef.current).toEqual({ language: '' });
+    expect(result.current.facetSelections).toEqual({ language: [] });
+    expect(result.current.facetSelectionsRef.current).toEqual({ language: [] });
+    expect(onSelectionsChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps individually cleared facets cleared when clearing all', () => {
+    const onSelectionsChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDocSearchFacets({
+        facets: [{ key: 'language' }, { key: 'version' }],
+        indexes: [
+          {
+            name: 'docs',
+            searchParameters: { facetFilters: ['language:en', 'version:v1'] },
+          },
+        ],
+        searchClient,
+        onSelectionsChange,
+      })
+    );
+
+    // Clear one facet, then clear all while the other still has a value.
+    act(() => {
+      result.current.handleFacetSelectionChange('language', []);
+    });
+    act(() => {
+      result.current.clearFacetSelections();
+    });
+
+    // `language` must stay overridden, otherwise its configured
+    // `language:en` filter would silently come back.
+    expect(result.current.facetSelections).toEqual({
+      language: [],
+      version: [],
+    });
+    expect(onSelectionsChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not notify when clearing all with no selected values', () => {
+    const onSelectionsChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDocSearchFacets({
+        facets: [{ key: 'language' }],
+        indexes,
+        searchClient,
+        onSelectionsChange,
+      })
+    );
+
+    act(() => {
+      result.current.handleFacetSelectionChange('language', ['en']);
+    });
+    act(() => {
+      result.current.handleFacetSelectionChange('language', []);
+    });
+    act(() => {
+      result.current.clearFacetSelections();
+    });
+
+    expect(result.current.facetSelections).toEqual({ language: [] });
     expect(onSelectionsChange).toHaveBeenCalledTimes(2);
   });
 
@@ -131,7 +294,7 @@ describe('useDocSearchFacets', () => {
 
     // the latest callback is invoked, not the one from the first render
     act(() => {
-      result.current.handleFacetSelectionChange('language', 'en');
+      result.current.handleFacetSelectionChange('language', ['en']);
     });
     expect(latestOnSelectionsChange).toHaveBeenCalledTimes(1);
   });

--- a/packages/docsearch-react/src/hooks/useDocSearchFacets.ts
+++ b/packages/docsearch-react/src/hooks/useDocSearchFacets.ts
@@ -4,11 +4,16 @@ import type { FacetBarFacet } from '../components/FacetBar';
 import type { DocSearchFacet, DocSearchIndex } from '../DocSearch';
 import { useFacetValues } from '../useFacetValues';
 import type { useSearchClient } from '../useSearchClient';
-import type { FacetSelections } from '../utils/createDocSearchSources';
+import type {
+  FacetSelections,
+  FacetSelectionUpdate,
+} from '../utils/createDocSearchSources';
 import {
   deriveDefaultSelectedFacetsFromIndex,
   normalizeFacets,
 } from '../utils/facets';
+
+const EMPTY_SELECTION: string[] = [];
 
 export interface UseDocSearchFacetsProps {
   facets?: DocSearchFacet[];
@@ -27,8 +32,33 @@ export interface UseDocSearchFacetsResult {
   facetSelections: FacetSelections;
   /** Always-current selections, for consumption inside `getSources` closures. */
   facetSelectionsRef: React.MutableRefObject<FacetSelections>;
-  handleFacetSelectionChange: (facet: string, value: string) => void;
+  /**
+   * Replaces the selected values of a facet. An empty array clears the facet,
+   * which also drops any configured `facetFilters` entry for that key.
+   */
+  handleFacetSelectionChange: (
+    facet: string,
+    update: FacetSelectionUpdate
+  ) => void;
   clearFacetSelections: () => void;
+}
+
+/**
+ * Compares two selections for a facet. A missing entry and an empty array are
+ * both "nothing selected" so clearing an untouched facet doesn't trigger a
+ * refresh.
+ */
+function areSelectionsEqual(
+  a: string[] | undefined,
+  b: string[] | undefined
+): boolean {
+  const left = a ?? EMPTY_SELECTION;
+  const right = b ?? EMPTY_SELECTION;
+
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+
+  return left.every((value, index) => value === right[index]);
 }
 
 export function useDocSearchFacets({
@@ -74,29 +104,41 @@ export function useDocSearchFacets({
   }, []);
 
   const handleFacetSelectionChange = React.useCallback(
-    (facet: string, value: string): void => {
+    (facet: string, update: FacetSelectionUpdate): void => {
       const existing = facetSelectionsRef.current[facet];
+      const values =
+        typeof update === 'function'
+          ? update(existing ?? EMPTY_SELECTION)
+          : update;
 
-      if (existing === value) return;
+      if (areSelectionsEqual(existing, values)) return;
 
-      const next = { ...facetSelectionsRef.current };
-
-      next[facet] = value;
-
-      applySelections(next);
+      applySelections({ ...facetSelectionsRef.current, [facet]: values });
     },
     [applySelections]
   );
 
   const clearFacetSelections = React.useCallback(() => {
-    if (Object.keys(facetSelectionsRef.current).length === 0) return;
-    const next = {};
+    const current = facetSelectionsRef.current;
+    const next: FacetSelections = {};
+    let hasSelectedValues = false;
 
+    // Keep an explicit empty override for every exposed facet that already
+    // has an entry, including facets the user cleared individually. Dropping
+    // those entries would silently re-apply their configured `facetFilters`.
     for (const facet of normalizedFacetsRef.current) {
-      if (facetSelectionsRef.current[facet.key]) {
-        next[facet.key] = '';
+      const values = current[facet.key];
+
+      if (values === undefined) continue;
+
+      if (values.length > 0) {
+        hasSelectedValues = true;
       }
+
+      next[facet.key] = EMPTY_SELECTION;
     }
+
+    if (!hasSelectedValues) return;
 
     applySelections(next);
   }, [applySelections]);

--- a/packages/docsearch-react/src/utils/__tests__/createDocSearchSources.test.ts
+++ b/packages/docsearch-react/src/utils/__tests__/createDocSearchSources.test.ts
@@ -1,3 +1,4 @@
+import type { SearchClient } from 'algoliasearch';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { DocSearchHit, InternalDocSearchHit } from '../../types';
@@ -102,9 +103,7 @@ describe('buildQuerySources', () => {
       state: { context: { searchSuggestions: [] } },
       setContext: vi.fn(),
       setStatus: vi.fn(),
-      searchClient: {
-        search,
-      } as any,
+      searchClient: { search } as unknown as SearchClient,
       indexes: [{ name: 'docs' }],
       insights: false,
       saveRecentSearch: vi.fn(),
@@ -153,5 +152,62 @@ describe('buildQuerySources', () => {
     expect(referenceItems[1].__docsearch_parent?.objectID).toBe(
       'reference-install'
     );
+  });
+
+  it('applies facet selections as facetFilters on every index request', async () => {
+    const search = vi.fn().mockResolvedValue({
+      results: [
+        { index: 'docs', nbHits: 0, hits: [] },
+        { index: 'blog', nbHits: 0, hits: [] },
+      ],
+    });
+
+    await buildQuerySources({
+      query: 'install',
+      state: { context: { searchSuggestions: [] } },
+      setContext: vi.fn(),
+      setStatus: vi.fn(),
+      searchClient: { search } as unknown as SearchClient,
+      indexes: [
+        {
+          name: 'docs',
+          searchParameters: {
+            facetFilters: [
+              'language:en',
+              ['docusaurus_tag:default', 'docusaurus_tag:docs-default-current'],
+              'type:guide',
+            ],
+          },
+        },
+        { name: 'blog' },
+      ],
+      insights: false,
+      saveRecentSearch: vi.fn(),
+      onClose: vi.fn(),
+      facetSelections: {
+        current: {
+          language: ['fr', 'de'],
+          docusaurus_tag: ['docs-default-next'],
+        },
+      },
+    });
+
+    expect(search).toHaveBeenCalledTimes(1);
+
+    const { requests } = search.mock.calls[0][0];
+
+    // Configured filters for selected keys (including the fully-covered OR
+    // group) are replaced; unrelated configured filters are kept. Multiple
+    // values for one facet become an OR group.
+    expect(requests[0].facetFilters).toEqual([
+      'type:guide',
+      ['language:fr', 'language:de'],
+      'docusaurus_tag:docs-default-next',
+    ]);
+    // Indices without configured filters receive only the selections.
+    expect(requests[1].facetFilters).toEqual([
+      ['language:fr', 'language:de'],
+      'docusaurus_tag:docs-default-next',
+    ]);
   });
 });

--- a/packages/docsearch-react/src/utils/createDocSearchSources.ts
+++ b/packages/docsearch-react/src/utils/createDocSearchSources.ts
@@ -19,6 +19,7 @@ import type {
 import type { useSearchClient } from '../useSearchClient';
 
 import { SOURCE_IDS } from './collections';
+import { getFacetFilterKey } from './facets';
 import { groupBy } from './groupBy';
 import { identity } from './identity';
 import { isModifierEvent } from './isModifierEvent';
@@ -33,24 +34,66 @@ export type StoredSearchesLike<TItem> = {
   getAll: () => TItem[];
 };
 
-export type FacetSelections = Record<string, string>;
+/**
+ * Selected values per facet key. An empty array means the facet was explicitly
+ * cleared: any configured `facetFilters` entry for that key is dropped from the
+ * request and no dynamic filter is added.
+ */
+export type FacetSelections = Record<string, string[]>;
 
+/**
+ * Next selected values for a facet, or an updater that receives the current
+ * values. Updaters are resolved against the always-current selections so
+ * toggles can't lose selections to stale props.
+ */
+export type FacetSelectionUpdate =
+  | string[]
+  | ((currentValues: string[]) => string[]);
+
+function isFacetFilterOverridden(
+  facetFilter: FacetFilters,
+  selectedFacets: Set<string>
+): boolean {
+  if (typeof facetFilter === 'string') {
+    const key = getFacetFilterKey(facetFilter);
+
+    return key !== null && selectedFacets.has(key);
+  }
+
+  // A nested array is an OR group. Only drop it when the user's selections
+  // cover every key in the group; otherwise keep the configured filter as-is.
+  return (
+    facetFilter.length > 0 &&
+    facetFilter.every((entry) => isFacetFilterOverridden(entry, selectedFacets))
+  );
+}
+
+/**
+ * Merges configured `facetFilters` with the user's facet selections.
+ *
+ * Multiple values selected for the same facet are combined into an OR group
+ * (nested array). Different facets are combined with AND (top-level entries),
+ * following Algolia `facetFilters` semantics.
+ */
 export function createFacetFilters(
   searchParametersFacetFilters: SearchParamsObject['facetFilters'],
   facetSelections: FacetSelections
 ): SearchParamsObject['facetFilters'] {
   const selections = Object.entries(facetSelections);
-  const selectedFacets = new Set(selections.map(([facet]) => facet));
-  const dynamicFacetFilters: string[] = [];
 
-  for (const [facet, selection] of selections) {
-    if (selection !== '') {
-      dynamicFacetFilters.push(`${facet}:${selection}`);
-    }
+  if (selections.length === 0) {
+    return searchParametersFacetFilters;
   }
 
-  if (selectedFacets.size === 0) {
-    return searchParametersFacetFilters;
+  const selectedFacets = new Set(selections.map(([facet]) => facet));
+  const dynamicFacetFilters: FacetFilters = [];
+
+  for (const [facet, values] of selections) {
+    if (values.length === 1) {
+      dynamicFacetFilters.push(`${facet}:${values[0]}`);
+    } else if (values.length > 1) {
+      dynamicFacetFilters.push(values.map((value) => `${facet}:${value}`));
+    }
   }
 
   let configuredFacetFilters: FacetFilters = [];
@@ -64,16 +107,9 @@ export function createFacetFilters(
     configuredFacetFilters = [searchParametersFacetFilters];
   }
 
-  const remainingFacetFilters = configuredFacetFilters.filter((facetFilter) => {
-    if (typeof facetFilter !== 'string') {
-      return true;
-    }
-
-    const separatorIndex = facetFilter.indexOf(':');
-    const facet = facetFilter.slice(0, separatorIndex);
-
-    return separatorIndex <= 0 || !selectedFacets.has(facet);
-  });
+  const remainingFacetFilters = configuredFacetFilters.filter(
+    (facetFilter) => !isFacetFilterOverridden(facetFilter, selectedFacets)
+  );
 
   return [...remainingFacetFilters, ...dynamicFacetFilters];
 }

--- a/packages/docsearch-react/src/utils/facets.ts
+++ b/packages/docsearch-react/src/utils/facets.ts
@@ -43,6 +43,41 @@ export function getFacetLabel(facet: DocSearchFacet): string {
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
+/**
+ * Extracts the facet key from an Algolia `facetFilters` string entry such as
+ * `language:en`. Returns `null` when the entry doesn't have a `key:value`
+ * shape.
+ */
+export function getFacetFilterKey(facetFilter: string): string | null {
+  const separatorIndex = facetFilter.indexOf(':');
+
+  return separatorIndex <= 0 ? null : facetFilter.slice(0, separatorIndex);
+}
+
+function parseFacetFilter(
+  facetFilter: string
+): { key: string; value: string } | null {
+  const key = getFacetFilterKey(facetFilter);
+
+  if (key === null) {
+    return null;
+  }
+
+  const value = facetFilter.slice(key.length + 1);
+
+  return value ? { key, value } : null;
+}
+
+/**
+ * Reads the initial facet selections from the configured `facetFilters` of each
+ * index. Later indices override earlier ones for the same facet key.
+ *
+ * - A `key:value` string selects a single value.
+ * - A nested OR group whose entries all share the same key (for example
+ *   `['docusaurus_tag:default', 'docusaurus_tag:docs-default-current']`)
+ *   selects every value in the group.
+ * - OR groups that mix facet keys can't map to a single facet and are ignored.
+ */
 export function deriveDefaultSelectedFacetsFromIndex(
   indices: DocSearchIndex[]
 ): FacetSelections {
@@ -54,21 +89,38 @@ export function deriveDefaultSelectedFacetsFromIndex(
     for (const facetFilter of Array.isArray(facetFilters)
       ? facetFilters
       : [facetFilters]) {
-      if (typeof facetFilter !== 'string') {
+      if (typeof facetFilter === 'string') {
+        const parsed = parseFacetFilter(facetFilter);
+
+        if (parsed) {
+          defaultFacets[parsed.key] = [parsed.value];
+        }
+
         continue;
       }
 
-      const separatorIndex = facetFilter.indexOf(':');
-
-      if (separatorIndex <= 0) {
+      if (!Array.isArray(facetFilter) || facetFilter.length === 0) {
         continue;
       }
 
-      const key = facetFilter.slice(0, separatorIndex);
-      const value = facetFilter.slice(separatorIndex + 1);
+      let groupKey: string | null = null;
+      const groupValues: string[] = [];
 
-      if (key && value) {
-        defaultFacets[key] = value;
+      for (const entry of facetFilter) {
+        const parsed =
+          typeof entry === 'string' ? parseFacetFilter(entry) : null;
+
+        if (!parsed || (groupKey !== null && parsed.key !== groupKey)) {
+          groupKey = null;
+          break;
+        }
+
+        groupKey = parsed.key;
+        groupValues.push(parsed.value);
+      }
+
+      if (groupKey !== null) {
+        defaultFacets[groupKey] = groupValues;
       }
     }
   }

--- a/packages/website/docs/packages/docusaurus-adapter/configuration-reference.mdx
+++ b/packages/website/docs/packages/docusaurus-adapter/configuration-reference.mdx
@@ -223,6 +223,8 @@ docsearch: {
 
 Configure each attribute as an Algolia facet. The modal supports up to five unique, nonempty facet keys. It merges facet values from every keyword index and hides facets with no values.
 
+Users can select multiple values per facet. The modal combines values of the same facet with OR and different facets with AND. When `contextualSearch` is on, the modal uses the contextual filters as initial selections. Expose `language` to let users change the current locale filter, or `docusaurus_tag` to let users change the default and docs version tags.
+
 These controls don't configure the search page sidebar. Use `searchPage.facets` for that page.
 
 ## Result badges

--- a/packages/website/docs/packages/js/api-reference.mdx
+++ b/packages/website/docs/packages/js/api-reference.mdx
@@ -133,7 +133,9 @@ interface DocSearchFacet {
 }
 ```
 
-DocSearch supports up to five facets. It compares trimmed, lowercase keys to ignore duplicates and empty keys, fetches values from all configured indices, and displays only facets that have values. Selecting a value adds a `facetFilters` entry to every index query while retaining that index's configured filters.
+DocSearch supports up to five facets. It compares trimmed, lowercase keys to ignore duplicates and empty keys, fetches values from all configured indices, and displays only facets that have values.
+
+Users can select multiple values per facet. DocSearch combines values of the same facet with OR and different facets with AND when it builds `facetFilters` for each index. A selection replaces the index's configured `facetFilters` entries for that facet key and keeps entries for other keys. DocSearch also replaces a configured OR group when the user has a selection for every key in the group.
 
 ```js title="docsearch-options.js"
 facets: [

--- a/packages/website/docs/packages/react/api-reference.mdx
+++ b/packages/website/docs/packages/react/api-reference.mdx
@@ -69,6 +69,8 @@ Facet controls populated from the configured indices. Defaults to `[]`.
 
 DocSearch supports up to five facets. It ignores empty and duplicate keys, merges sorted values from all configured indices, and hides facets with no values. Configure each attribute for faceting in the Algolia index.
 
+Users can select multiple values per facet. DocSearch combines values of the same facet with OR and different facets with AND when it builds `facetFilters` for each index. A selection replaces the index's configured `facetFilters` entries for that facet key and keeps entries for other keys. DocSearch also replaces a configured OR group, such as `['docusaurus_tag:default', 'docusaurus_tag:docs-default-current']`, when the user has a selection for every key in the group.
+
 ### `theme`
 
 > `type: 'light' | 'dark'` | **optional**

--- a/packages/website/docs/packages/react/examples.mdx
+++ b/packages/website/docs/packages/react/examples.mdx
@@ -41,7 +41,7 @@ Configure the attributes for faceting in Algolia, then expose up to five control
 />
 ```
 
-DocSearch loads available values from all configured indices and appends selected values to each index's `facetFilters`.
+DocSearch loads available values from all configured indices. When a user selects values, DocSearch replaces each index's configured `facetFilters` entries for that facet key with the selection and keeps entries for other keys. Users can select multiple values per facet. DocSearch combines them with OR, for example `[['language:en', 'language:fr'], 'version:v2']`.
 
 ## Show a result badge
 


### PR DESCRIPTION
## Summary

- `FacetBar` now renders checkbox items instead of a radio group, so users can select more than one value per facet.
- Selected values for the same facet are combined into an Algolia `facetFilters` OR group; different facets are still combined with AND.
- Configured `facetFilters` OR groups that share a single facet key (e.g. `['lang:en', 'lang:fr']`) are now recognized as the default selection for that facet, in addition to single `key:value` entries.
- Adds an Accessibility Tests section to `AGENTS.md` documenting the existing axe + Playwright suite (commands, conventions, and how to interpret violation budgets).

## Changeset

Includes a `minor` changeset for `@docsearch/react` and `@docsearch/css`. This is additive: the public `facets` config prop and existing single-value `facetFilters` configs continue to work unchanged; the internal `FacetSelections` type is not part of the public API surface.

## Test plan

- [x] Reviewed diff for standards, performance, code quality, and accessibility (static review)
- [ ] `bun run test --run`
- [ ] `bun run test:types`
- [ ] `bun run pw:run e2e/a11y.test.ts e2e/search.spec.ts --project=chromium`