### PR TITLE
feat(askai): Bump to ai-sdk v6

### DIFF
--- a/.changeset/wet-chicken-say.md
+++ b/.changeset/wet-chicken-say.md
@@ -1,0 +1,5 @@
+---
+"@docsearch/react": minor
+---
+
+Upgrade `ai` to v6 and `@ai-sdk/react` to v3

--- a/bun.lock
+++ b/bun.lock
@@ -187,12 +187,12 @@
       "name": "@docsearch/react",
       "version": "5.0.5",
       "dependencies": {
-        "@ai-sdk/react": "^2.0.30",
+        "@ai-sdk/react": "^3.0.259",
         "@algolia/autocomplete-core": "1.19.2",
         "@base-ui/react": "^1.5.0",
         "@docsearch/core": "5.0.5",
         "@docsearch/css": "5.0.5",
-        "ai": "^5.0.30",
+        "ai": "^6.0.256",
         "algoliasearch": "^5.28.0",
         "marked": "^16.3.0",
         "zod": "^4.1.8",
@@ -304,13 +304,13 @@
 
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.112", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.29", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-M58LfWXTTmwDqYJNDxGfzlAyXDAg8iV2gPq2ZvIGlIZzJ9oTA7yX85lVFEZ0Owc/Gm+j/sVUczu0tnvc575jpg=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.189", "", { "dependencies": { "@ai-sdk/provider": "3.0.15", "@ai-sdk/provider-utils": "4.0.50", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-roPKojHenQm7U77kNNE0w586jP2vnjxaNx/+KFSQkJRLLAxrg7yUwZQfyOEizoTxdaltu+ZIlLRTw09X3XbGvQ=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.15", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.29", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4oNFrqBcy24KNclF1tWp/7ks+kSkDF6VZ1ccIfQoFVIgAAaoNH8bOTbOadVa4Dk70ghsh32caSHYWlzBI8F10g=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.50", "", { "dependencies": { "@ai-sdk/provider": "3.0.15", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8", "undici": "^6.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-YAcB+7M1JhAYsHorTrWyldCyZihjCKr/QRXH2vFrara/+lwqNE7q5KzoucKLZ7ktFiUonhnhFhRoiymsq/2K2Q=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@2.0.215", "", { "dependencies": { "@ai-sdk/provider-utils": "3.0.29", "ai": "5.0.213", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1", "zod": "^3.25.76 || ^4.1.8" }, "optionalPeers": ["zod"] }, "sha512-tZlREeRyWHMO970fnmmLkaDdK3CkNXAvcMOKt4vevAqe3y7ewRw3/e92MziUFlOltjTMutiMlxi1lnJsX55Vcw=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.280", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.50", "ai": "6.0.277", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-A00dgsOo3Xq4b8je0DM8dBFHZX/8iTIKupOhWcvXcYdKo9nxOKwC+fh9SFGbFbvQhDn8awEPiTm5a25GD8aCsA=="],
 
     "@algolia/abtesting": ["@algolia/abtesting@1.21.2", "", { "dependencies": { "@algolia/client-common": "5.55.2", "@algolia/requester-browser-xhr": "5.55.2", "@algolia/requester-fetch": "5.55.2", "@algolia/requester-node-http": "5.55.2" } }, "sha512-uXj0rgk30EpsKvOpuS+R+1XFDrnm56hED1Lz56e8uBkZdKCxw99LS2U8eXBqAHYU8kpkbsnV1GC8velBG070Hg=="],
 
@@ -1490,7 +1490,7 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
-    "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -1604,7 +1604,7 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
-    "ai": ["ai@5.0.213", "", { "dependencies": { "@ai-sdk/gateway": "2.0.112", "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.29", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QCPMxXxV/I+nXVYyQru62Izx8cU5UmPDkooJmYy1+kBvhT/hDH/n33th/SAE73A2kRXIUO1cFdvhZ0XCRPdWaw=="],
+    "ai": ["ai@6.0.277", "", { "dependencies": { "@ai-sdk/gateway": "3.0.189", "@ai-sdk/provider": "3.0.15", "@ai-sdk/provider-utils": "4.0.50", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-fYlPj2QsisCH66SsEfWM8gV0ZR+6NLuRYSnVw3GKUKlvP+iIAUQR1bUJn1Y6lcAKeoEWQeZaann2ahXZY2HXtQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -3669,6 +3669,8 @@
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
     "undefsafe": ["undefsafe@2.0.5", "", {}, "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="],
+
+    "undici": ["undici@6.28.1", "", {}, "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -48,12 +48,12 @@
     "watch": "tsdown --watch"
   },
   "dependencies": {
-    "@ai-sdk/react": "^2.0.30",
+    "@ai-sdk/react": "^3.0.259",
     "@algolia/autocomplete-core": "1.19.2",
     "@base-ui/react": "^1.5.0",
     "@docsearch/core": "5.0.5",
     "@docsearch/css": "5.0.5",
-    "ai": "^5.0.30",
+    "ai": "^6.0.256",
     "algoliasearch": "^5.28.0",
     "marked": "^16.3.0",
     "zod": "^4.1.8"

--- a/packages/docsearch-react/src/utils/ai.ts
+++ b/packages/docsearch-react/src/utils/ai.ts
@@ -1,4 +1,4 @@
-import { isDataUIPart, isToolOrDynamicToolUIPart, type TextUIPart } from 'ai';
+import { isDataUIPart, isToolUIPart, type TextUIPart } from 'ai';
 
 import type { StoredAskAiState } from '../types';
 import type {
@@ -287,7 +287,7 @@ export function sanitizeMessagesForRequest(messages: AIMessage[]): AIMessage[] {
         return false;
       }
 
-      if (isToolOrDynamicToolUIPart(part) && part.state.startsWith('input-')) {
+      if (isToolUIPart(part) && part.state.startsWith('input-')) {
         return false;
       }
 


### PR DESCRIPTION
## Why

`@docsearch/react` currently depends on `ai@^5` and `@ai-sdk/react@^2`, which resolve `@ai-sdk/provider-utils@3.x`. Every release in that line pins `undici@^5.29.0`, the last 5.x release, which carries 12 open advisories plus an unpatched advisory in `@ai-sdk/provider-utils` itself. Since `ai` and `@ai-sdk/react` are regular dependencies (not optional peers), every consumer of DocSearch picks these up in `npm audit` or Dependabot, whether or not Ask AI is enabled.

The AI SDK moved off `undici@5` starting with `@ai-sdk/provider-utils@4.0.46`, which only ships in the v6 line. There's no way to clear these advisories while staying on v5.

Fixes #3042.

## What changed

- Bumped `ai` to `^6.0.256` and `@ai-sdk/react` to `^3.0.259`
- Updated `isToolOrDynamicToolUIPart` to `isToolUIPart` in `src/utils/ai.ts`, since the old name was renamed in v6 (old export was removed, not just deprecated)

All symbols DocSearch imports from these packages (`DefaultChatTransport`, `generateId`, `isDataUIPart`, `Chat`, `useChat`, etc.) are still exported in v6, so no other code changes were needed.

## Testing

Ask AI has not been verified at runtime against v6 yet, so this needs manual testing before merge:

- Open the Ask AI modal and send a message, confirm streaming responses render correctly
- Trigger a tool call (search) and confirm results render as expected
- Send a message, then send a follow up, confirm conversation history and context work
- Check the browser console for any warnings from the AI SDK during a full conversation
- Run `npm audit` against the built package to confirm the undici advisories are gone