### PR TITLE
fix(sidepanel): make closed panel inert

### DIFF
--- a/.changeset/quiet-panels-rest.md
+++ b/.changeset/quiet-panels-rest.md
@@ -1,0 +1,5 @@
+---
+'@docsearch/react': patch
+---
+
+Make closed Sidepanels inert so their content is excluded from keyboard navigation and the accessibility tree while preserving conversation state.

--- a/e2e/a11y.test.ts
+++ b/e2e/a11y.test.ts
@@ -68,4 +68,89 @@ test.describe('a11y > Sidepanel', () => {
       gatherA11yViolations(scanResults.violations).length
     ).toBeLessThanOrEqual(4);
   });
+
+  for (const closeMethod of ['Escape', 'close button'] as const) {
+    test(`Closed panel is inaccessible and preserves conversation after ${closeMethod}`, async ({
+      sidepanel,
+      page,
+    }) => {
+      await page.route('**/agents/*/completions?*', (route) =>
+        route.fulfill({
+          contentType: 'text/event-stream',
+          body: [
+            { type: 'text-start', id: 'answer' },
+            { type: 'text-delta', id: 'answer', delta: 'Saved answer' },
+            { type: 'text-end', id: 'answer' },
+            { type: 'finish' },
+          ]
+            .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+            .join(''),
+        })
+      );
+
+      // Place focus sentinels next to the mounted panel to test both Tab directions.
+      await sidepanel.sidepanel.evaluate((panel) => {
+        for (const position of ['beforebegin', 'afterend'] as const) {
+          const button = document.createElement('button');
+          button.id = `panel-${position}`;
+          button.textContent = position;
+          panel.insertAdjacentElement(position, button);
+        }
+      });
+      const before = page.locator('#panel-beforebegin');
+      const after = page.locator('#panel-afterend');
+      const prompt = sidepanel.sidepanel.locator('textarea');
+      const panelHandle = await sidepanel.sidepanel.elementHandle();
+
+      const expectClosed = async (): Promise<void> => {
+        await expect(sidepanel.sidepanel).toBeAttached();
+        await expect(sidepanel.sidepanel).not.toHaveClass(/is-open/);
+        await expect(sidepanel.sidepanel).toHaveAttribute('inert', '');
+        // Read Chromium's accessibility tree; Playwright 1.49's DOM-based
+        // ariaSnapshot doesn't account for inert.
+        expect(
+          await page.accessibility.snapshot({
+            root: panelHandle!,
+            interestingOnly: false,
+          })
+        ).toBeNull();
+        await before.focus();
+        await page.keyboard.press('Tab');
+        await expect(after).toBeFocused();
+        await page.keyboard.press('Shift+Tab');
+        await expect(before).toBeFocused();
+        await prompt.evaluate((element) => element.focus());
+        await expect(before).toBeFocused();
+      };
+
+      await expectClosed();
+      await sidepanel.openSidepanel();
+      await expect(prompt).toBeFocused();
+      await prompt.fill('My question');
+      await prompt.press('Enter');
+      await expect(sidepanel.sidepanel.getByText('Saved answer')).toBeVisible();
+      await prompt.fill('A follow-up question');
+
+      if (closeMethod === 'Escape') {
+        await page.keyboard.press('Escape');
+      } else {
+        await sidepanel.sidepanel.getByTitle('Close Sidepanel').click();
+      }
+
+      await expectClosed();
+      await sidepanel.openSidepanel();
+      await expect(prompt).toBeFocused();
+      await expect(prompt).toHaveValue('A follow-up question');
+      await expect(sidepanel.sidepanel.getByText('My question')).toBeVisible();
+      await expect(sidepanel.sidepanel.getByText('Saved answer')).toBeVisible();
+      expect(
+        JSON.stringify(
+          await page.accessibility.snapshot({
+            root: panelHandle!,
+            interestingOnly: false,
+          })
+        )
+      ).toContain('Saved answer');
+    });
+  }
 });

--- a/packages/docsearch-react/src/Sidepanel/Sidepanel.tsx
+++ b/packages/docsearch-react/src/Sidepanel/Sidepanel.tsx
@@ -130,6 +130,10 @@ type Props = Omit<
 > &
   SidepanelProps &
   SidepanelSearchParameters & {
+    /**
+     * Keep mounted when closed to preserve the conversation. Closed content is
+     * inert.
+     */
     isOpen?: boolean;
     onOpen: () => void;
     onClose: () => void;
@@ -167,6 +171,15 @@ function SidepanelInner(
   const sidepanelContainerRef = React.useRef<HTMLDivElement>(null);
   const promptInputRef = React.useRef<HTMLTextAreaElement>(null);
   const isMobile = useIsMobile();
+
+  const setSidepanelContainer = React.useCallback(
+    (node: HTMLDivElement | null): void => {
+      sidepanelContainerRef.current = node;
+      // React versions before 19 don't support the boolean inert prop.
+      node?.toggleAttribute('inert', !isOpen);
+    },
+    [isOpen]
+  );
 
   const expectedWidth = useSidepanelWidth({
     isExpanded,
@@ -396,7 +409,7 @@ function SidepanelInner(
       }
       role="dialog"
       tabIndex={-1}
-      ref={sidepanelContainerRef}
+      ref={setSidepanelContainer}
     >
       <aside
         id="docsearch-sidepanel"

--- a/packages/docsearch-react/src/__tests__/sidepanel.test.tsx
+++ b/packages/docsearch-react/src/__tests__/sidepanel.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+import { Sidepanel } from '../Sidepanel/Sidepanel';
+
+vi.mock('../useIsMobile', () => ({ useIsMobile: () => false }));
+
+const props = {
+  appId: 'test-app',
+  apiKey: 'test-key',
+  agentId: 'test-agent',
+  onOpen: vi.fn(),
+  onClose: vi.fn(),
+};
+
+describe('Sidepanel closed state', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(Element.prototype, 'scrollIntoView');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it.each(['floating', 'inline'] as const)(
+    'makes the mounted %s panel inert by default',
+    (variant) => {
+      render(<Sidepanel {...props} variant={variant} />);
+
+      // JSDOM doesn't implement inert focus or accessibility-tree behavior.
+      // Browser regressions cover those; here we check the native attribute.
+      expect(screen.getByRole('dialog')).toHaveAttribute('inert');
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    }
+  );
+
+  it('restores interaction without remounting or clearing panel and draft state', () => {
+    const { rerender } = render(<Sidepanel {...props} isOpen={true} />);
+    const panel = screen.getByRole('dialog');
+    const prompt = screen.getByRole('textbox');
+
+    expect(panel).not.toHaveAttribute('inert');
+    fireEvent.change(prompt, { target: { value: 'A follow-up question' } });
+    fireEvent.click(screen.getByTitle('Expand or collapse Sidepanel'));
+    fireEvent.click(screen.getByTitle('Conversation history'));
+
+    rerender(<Sidepanel {...props} isOpen={false} />);
+
+    expect(panel).toHaveAttribute('inert');
+    expect(prompt).toBeInTheDocument();
+
+    rerender(<Sidepanel {...props} isOpen={true} />);
+
+    expect(screen.getByRole('dialog')).toBe(panel);
+    expect(panel).not.toHaveAttribute('inert');
+    expect(panel).toHaveClass('is-expanded');
+    expect(screen.getByRole('textbox')).toBe(prompt);
+    expect(prompt).toHaveValue('A follow-up question');
+    expect(screen.getByText('My conversation history')).toBeInTheDocument();
+  });
+
+  it('preserves conversation messages across close and reopen', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        [
+          { type: 'text-start', id: 'answer' },
+          { type: 'text-delta', id: 'answer', delta: 'Saved answer' },
+          { type: 'text-end', id: 'answer' },
+          { type: 'finish' },
+        ]
+          .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+          .join(''),
+        { headers: { 'content-type': 'text/event-stream' } }
+      )
+    );
+    const { rerender } = render(<Sidepanel {...props} isOpen={true} />);
+    const prompt = screen.getByRole('textbox');
+    fireEvent.change(prompt, { target: { value: 'My question' } });
+    fireEvent.submit(prompt.closest('form')!);
+
+    await screen.findByText('Saved answer');
+    rerender(<Sidepanel {...props} isOpen={false} />);
+    expect(screen.getByRole('dialog')).toHaveAttribute('inert');
+    rerender(<Sidepanel {...props} isOpen={true} />);
+
+    expect(screen.getByText('My question')).toBeInTheDocument();
+    expect(screen.getByText('Saved answer')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveFocus();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/website/docs/packages/sidepanel/advanced-use-cases.mdx
+++ b/packages/website/docs/packages/sidepanel/advanced-use-cases.mdx
@@ -79,6 +79,47 @@ export function Support() {
 
 Call the method after the Sidepanel has mounted and registered its view. Check `isSidepanelOpen` to read its open state. See [Hybrid Mode](/docs/hybrid-mode) for cross-view ref behavior.
 
+## Keep a controlled panel mounted
+
+The low-level `Sidepanel` from `@docsearch/react/sidepanel` accepts `isOpen`, `onOpen`, and `onClose`. Unlike `Sidepanel` from `@docsearch/sidepanel`, it doesn't require a `DocSearch` provider. Render it on the client and keep it mounted when closed to preserve the current conversation, draft prompt, and panel state. Unmounting discards that in-memory state; saved conversation history is separate.
+
+The component owns closed-state visibility and interaction: its stylesheet hides the panel, and the closed root is `inert`, excluding its descendants from keyboard navigation and the accessibility tree. Reopening restores interaction without resetting the conversation. Closing doesn't stop an active response.
+
+The panel focuses its prompt when opened on desktop and blurs the prompt when closed. It doesn't autofocus on mobile or restore focus to your trigger. Your integration owns `isOpen` and focus restoration. Route close actions through a handler that returns focus to the trigger, or another appropriate element if the trigger no longer exists.
+
+```tsx title="ControlledAssistant.tsx"
+import { Sidepanel } from '@docsearch/react/sidepanel';
+import { useCallback, useRef, useState, type JSX } from 'react';
+import '@docsearch/react/style';
+import '@docsearch/react/style/sidepanel';
+
+export function ControlledAssistant(): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => {
+    triggerRef.current?.focus();
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <>
+      <button type="button" ref={triggerRef} aria-expanded={isOpen} onClick={open}>
+        Ask AI
+      </button>
+      <Sidepanel
+        appId="YOUR_APPLICATION_ID"
+        apiKey="YOUR_SEARCH_API_KEY"
+        agentId="YOUR_AGENT_ID"
+        isOpen={isOpen}
+        onOpen={open}
+        onClose={close}
+      />
+    </>
+  );
+}
+```
+
 ## Handle Agent Studio tools
 
 Key each client tool by the name emitted by your agent. Always return tool output through `addToolOutput` when you provide `onToolCall`.


### PR DESCRIPTION
## Why

The Sidepanel component only hides closed state visually with CSS (opacity and transform). Consumers are meant to keep it mounted so conversation state survives closing and reopening, but that mounted-but-hidden panel stayed reachable via Tab and screen readers. A user tabbing through the page could land inside a panel they can't see, and screen reader users would hear content that isn't actually on screen.

Closes #3047.

Toggling the native `inert` attribute based on `isOpen` removes the closed panel from keyboard navigation and the accessibility tree without unmounting it, so conversation history, the draft prompt, and panel state (like expanded view) are all preserved when reopened.

The `inert` attribute is set through a callback ref rather than the boolean JSX prop, since the package supports React versions before 19, which don't recognize `inert` as a native prop.

Also documents the low-level Sidepanel's lifecycle contract, since consumers integrating it directly need to know that closed-state visibility and focus exclusion are handled internally, but focus restoration to their own trigger element is their responsibility.

## Testing

- Open the Sidepanel, close it with Escape or the close button, then press Tab repeatedly from outside the panel. Focus should skip over anything inside the closed panel entirely.
- With a screen reader running, close the Sidepanel and browse the page. The closed panel's content shouldn't be announced.
- Start a conversation in the Sidepanel, close it, then reopen it. The conversation and any unsent draft text in the prompt box should still be there.
- Confirm the prompt input still autofocuses when reopening on desktop, and that mobile behavior (no autofocus) is unchanged.