### PR TITLE
feat(react): split sidepanelButton/sidepanelPanel entry points

### DIFF
--- a/.changeset/blue-clubs-relax.md
+++ b/.changeset/blue-clubs-relax.md
@@ -1,0 +1,6 @@
+---
+"@docsearch/sidepanel": minor
+"@docsearch/react": minor
+---
+
+Add `@docsearch/react/sidepanelButton` and `@docsearch/react/sidepanelPanel` entry points so consumers can statically import the Sidepanel trigger while dynamically importing the panel (and its Ask AI/Markdown dependencies) only when needed. `@docsearch/sidepanel` now uses these split entries internally.

--- a/packages/docsearch-react/README.md
+++ b/packages/docsearch-react/README.md
@@ -38,4 +38,6 @@ export default App;
 
 ## Documentation
 
+[Lazy-load the Sidepanel](https://docsearch.algolia.com/docs/packages/react/examples#lazy-load-the-sidepanel) with a static `SidepanelButton` import from `@docsearch/react/sidepanelButton` and a dynamic panel import from `@docsearch/react/sidepanelPanel`.
+
 [Read documentation →](https://docsearch.algolia.com/docs/packages/react/getting-started)

--- a/packages/docsearch-react/package.json
+++ b/packages/docsearch-react/package.json
@@ -26,6 +26,8 @@
     "./docsearchAi": "./dist/esm/docsearchAi.js",
     "./modal": "./dist/esm/modal.js",
     "./sidepanel": "./dist/esm/sidepanel.js",
+    "./sidepanelButton": "./dist/esm/sidepanelButton.js",
+    "./sidepanelPanel": "./dist/esm/sidepanelPanel.js",
     "./useDocSearchKeyboardEvents": "./dist/esm/useDocSearchKeyboardEvents.js",
     "./useTheme": "./dist/esm/useTheme.js",
     "./version": "./dist/esm/version.js",

--- a/packages/docsearch-react/src/Sidepanel/__tests__/sidepanelButton.test.tsx
+++ b/packages/docsearch-react/src/Sidepanel/__tests__/sidepanelButton.test.tsx
@@ -1,0 +1,59 @@
+import { SidepanelButton } from '@docsearch/react/sidepanelButton';
+import type { SidepanelButtonProps } from '@docsearch/react/sidepanelButton';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+// Importing the public button entry must not evaluate the panel dependencies.
+vi.mock('ai', () => {
+  throw new Error('The button loaded the AI SDK');
+});
+vi.mock('@ai-sdk/react', () => {
+  throw new Error('The button loaded the chat hooks');
+});
+vi.mock('marked', () => {
+  throw new Error('The button loaded the Markdown renderer');
+});
+
+afterEach(cleanup);
+
+describe('sidepanelButton entry point', () => {
+  it('renders independently and forwards preload and activation handlers', () => {
+    const onMouseEnter = vi.fn();
+    const onFocus = vi.fn();
+    const onTouchStart = vi.fn();
+    const onClick = vi.fn();
+    render(
+      <SidepanelButton
+        variant="inline"
+        onMouseEnter={onMouseEnter}
+        onFocus={onFocus}
+        onTouchStart={onTouchStart}
+        onClick={onClick}
+      />
+    );
+    const button = screen.getByRole('button', { name: /^Ask AI/ });
+    expect(button).toHaveAttribute('type', 'button');
+    expect(button.tabIndex).toBe(0);
+    fireEvent.mouseEnter(button);
+    fireEvent.focus(button);
+    fireEvent.touchStart(button);
+    fireEvent.click(button);
+    for (const handler of [onMouseEnter, onFocus, onTouchStart, onClick]) {
+      expect(handler).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('preserves translations and allows disabling the shortcut hint', () => {
+    const props: SidepanelButtonProps = {
+      variant: 'inline',
+      translations: { buttonText: 'Ask docs', buttonAriaLabel: 'Ask docs' },
+      keyboardShortcuts: { 'Ctrl/Cmd+I': false },
+    };
+    render(<SidepanelButton {...props} />);
+    const button = screen.getByRole('button', { name: 'Ask docs' });
+    expect(button).toHaveTextContent('Ask docs');
+    expect(button).not.toHaveAttribute('aria-keyshortcuts');
+  });
+});

--- a/packages/docsearch-react/tsdown.config.mts
+++ b/packages/docsearch-react/tsdown.config.mts
@@ -34,6 +34,8 @@ export default defineConfig([
       useTheme: 'src/useTheme.tsx',
       version: 'src/version.ts',
       sidepanel: 'src/Sidepanel.tsx',
+      sidepanelPanel: 'src/Sidepanel/Sidepanel.tsx',
+      sidepanelButton: 'src/Sidepanel/SidepanelButton.tsx',
     },
     ...sharedConfig,
     dts: true,

--- a/packages/docsearch-sidepanel/src/Sidepanel.tsx
+++ b/packages/docsearch-sidepanel/src/Sidepanel.tsx
@@ -1,9 +1,9 @@
 import { useDocSearch } from '@docsearch/core';
-import {
-  Sidepanel as SidepanelComp,
-  type DocSearchSidepanelProps,
-  type SidepanelSearchParameters,
+import type {
+  DocSearchSidepanelProps,
+  SidepanelSearchParameters,
 } from '@docsearch/react/sidepanel';
+import { Sidepanel as SidepanelComp } from '@docsearch/react/sidepanelPanel';
 import React from 'react';
 import type { JSX } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/docsearch-sidepanel/src/SidepanelButton.tsx
+++ b/packages/docsearch-sidepanel/src/SidepanelButton.tsx
@@ -1,6 +1,6 @@
 import { useDocSearch } from '@docsearch/core';
-import type { SidepanelButtonProps as ButtonProps } from '@docsearch/react/sidepanel';
-import { SidepanelButton as Button } from '@docsearch/react/sidepanel';
+import type { SidepanelButtonProps as ButtonProps } from '@docsearch/react/sidepanelButton';
+import { SidepanelButton as Button } from '@docsearch/react/sidepanelButton';
 import React from 'react';
 import type { JSX } from 'react';
 import { createPortal } from 'react-dom';

--- a/packages/docsearch-sidepanel/tsdown.config.mts
+++ b/packages/docsearch-sidepanel/tsdown.config.mts
@@ -56,6 +56,8 @@ export default defineConfig([
         'react-dom': 'ReactDOM',
         '@docsearch/core': 'DocSearchCore',
         '@docsearch/react/sidepanel': 'DocSearchReact',
+        '@docsearch/react/sidepanelPanel': 'DocSearchReact',
+        '@docsearch/react/sidepanelButton': 'DocSearchReact',
       },
     },
     format: 'umd',

--- a/packages/website/docs/packages/react/api-reference.mdx
+++ b/packages/website/docs/packages/react/api-reference.mdx
@@ -414,6 +414,8 @@ The root package exports `DocSearch`, `DocSearchAI`, `DocSearchAskAiModal`, `Doc
 | `@docsearch/react/docsearchAi` | `DocSearchAI` and AI types |
 | `@docsearch/react/modal` | `DocSearchModal` |
 | `@docsearch/react/sidepanel` | `DocSearchSidepanel` and Sidepanel components |
+| `@docsearch/react/sidepanelButton` | `SidepanelButton`, `SidepanelButtonProps`, `SidepanelButtonTranslations`, and `ButtonVariant` |
+| `@docsearch/react/sidepanelPanel` | `Sidepanel`, `SidepanelProps`, `SidepanelRef`, and `SidepanelTranslations` - panel only, without the button |
 | `@docsearch/react/useDocSearchKeyboardEvents` | `useDocSearchKeyboardEvents` |
 | `@docsearch/react/useTheme` | `useTheme` |
 | `@docsearch/react/version` | `version` |

--- a/packages/website/docs/packages/react/examples.mdx
+++ b/packages/website/docs/packages/react/examples.mdx
@@ -258,3 +258,69 @@ Return `true` from `interceptAskAiEvent` after handling the message:
 ```
 
 For the supported modal and Sidepanel integration, use [hybrid mode](/docs/hybrid-mode).
+
+## Lazy-load the Sidepanel
+
+Import the trigger from `@docsearch/react/sidepanelButton`, then dynamically import `Sidepanel` from `@docsearch/react/sidepanelPanel`. The button entry excludes the panel and its Ask AI dependencies. Dynamically importing the panel entry defers those dependencies until needed.
+
+Don't statically import the button from `@docsearch/react/sidepanel` when you need this boundary. Tree shaking depends on the bundler: a production Bun build with both a static button import and a dynamic panel import from the shared `@docsearch/react/sidepanel` entry includes the AI SDK and Markdown renderer in the initial chunks. Using the dedicated `sidepanelButton`/`sidepanelPanel` entries keeps those dependencies deferred and avoids bundling the button twice.
+
+```tsx title="LazyAssistant.tsx"
+import { lazy, Suspense, useRef, useState } from 'react';
+import type { JSX } from 'react';
+import { SidepanelButton } from '@docsearch/react/sidepanelButton';
+import '@docsearch/css/dist/sidepanel.css';
+
+const loadSidepanel = () => import('@docsearch/react/sidepanelPanel');
+const LazySidepanel = lazy(() =>
+  loadSidepanel().then(({ Sidepanel }) => ({ default: Sidepanel }))
+);
+const keyboardShortcuts = { 'Ctrl/Cmd+I': false };
+
+function preloadSidepanel() {
+  // Let activation retry if this speculative preload fails.
+  loadSidepanel().catch(() => {});
+}
+
+export function LazyAssistant(): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const trigger = useRef<HTMLButtonElement | null>(null);
+
+  return (
+    <>
+      <SidepanelButton
+        variant="inline"
+        keyboardShortcuts={keyboardShortcuts}
+        aria-expanded={isOpen}
+        onMouseEnter={preloadSidepanel}
+        onFocus={preloadSidepanel}
+        onTouchStart={preloadSidepanel}
+        onClick={(event) => {
+          trigger.current = event.currentTarget;
+          setIsOpen(true);
+        }}
+      />
+      {isOpen && (
+        <Suspense fallback={<output>Loading assistant…</output>}>
+          <LazySidepanel
+            appId="YOUR_APP_ID"
+            apiKey="YOUR_SEARCH_API_KEY"
+            agentId="YOUR_AGENT_ID"
+            isOpen={isOpen}
+            onOpen={() => setIsOpen(true)}
+            onClose={() => {
+              setIsOpen(false);
+              trigger.current?.focus();
+            }}
+            keyboardShortcuts={keyboardShortcuts}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}
+```
+
+Hover, focus, and touch start preload the module without opening the panel. Activation also loads it if preloading hasn't finished. This example disables the global shortcut because the panel's keyboard listener isn't mounted before activation, and unmounts the panel on close. To preserve an in-progress conversation, keep it mounted after the first activation and control visibility with `isOpen`.
+
+For provider-based composition, `@docsearch/sidepanel/button` also uses the lightweight trigger entry. Keep the panel mounted when you need provider refs, keyboard shortcuts, or [hybrid handoff](/docs/hybrid-mode) before a user activates the trigger.

--- a/packages/website/docs/packages/sidepanel/api.mdx
+++ b/packages/website/docs/packages/sidepanel/api.mdx
@@ -207,3 +207,5 @@ Whether the provider is mounted.
 | `@docsearch/sidepanel` | `Sidepanel`, `SidepanelButton` | `SidepanelProps`, `SidepanelButtonProps` |
 | `@docsearch/sidepanel/sidepanel` | `Sidepanel` | `SidepanelProps` |
 | `@docsearch/sidepanel/button` | `SidepanelButton` | `SidepanelButtonProps` |
+
+Import `@docsearch/sidepanel/button` and dynamically import `@docsearch/sidepanel/sidepanel` to defer the panel and its Ask AI dependencies, the same way as the [React lazy-load example](/docs/packages/react/examples#lazy-load-the-sidepanel). Internally, these entries build on the equivalent `@docsearch/react/sidepanelButton` and `@docsearch/react/sidepanelPanel` entries, so no further split is needed.


### PR DESCRIPTION
## Why

Consumers who wanted to statically import `SidepanelButton` while dynamically importing `Sidepanel` (for lazy-loading) still ended up with the panel's Ask AI SDK and Markdown renderer in their initial bundle. Both components shared the same `@docsearch/react/sidepanel` entry point, so bundlers couldn't tree-shake the panel's dependencies out of a build that also statically imported the button from that entry.

This splits the shared entry into two dedicated ones, `sidepanelButton` and `sidepanelPanel`, so each ships only what it needs. `@docsearch/sidepanel` now builds on these split entries internally, and the docs cover the pattern for both packages.

Closes #3048 

## Testing

- Import `SidepanelButton` from `@docsearch/react/sidepanelButton` and dynamically `import()` `Sidepanel` from `@docsearch/react/sidepanelPanel` in a bundler build (Vite/Rollup/webpack). Confirm the initial chunk excludes `ai`, `@ai-sdk/react`, and `marked`.
- Run the new `sidepanelButton.test.tsx` suite to confirm the button entry point renders and forwards preload/activation handlers without pulling in panel dependencies.
- Verify `@docsearch/sidepanel`'s existing button and panel exports still work unchanged for consumers not using the split entries directly.
- Check the updated docs examples (`packages/website/docs/packages/react/examples.mdx` and `packages/website/docs/packages/sidepanel/api.mdx`) render correctly and the lazy-load example works as written.
